### PR TITLE
(bug)start api server even if i2c is disabled

### DIFF
--- a/commands/main.go
+++ b/commands/main.go
@@ -44,11 +44,15 @@ func main() {
 	}
 	c, err := controller.New(Version, config.Database)
 	if err != nil {
-		log.Fatal("Failed to initialize controller. ERROR:", err)
+		log.Fatal("ERROR: Failed to initialize controller. Error:", err)
 	}
 	if err := c.Start(); err != nil {
-		log.Fatal(err)
+		log.Println("ERROR: Failed to start controller. Error:", err)
 	}
+	if err := c.API(); err != nil {
+		log.Println("ERROR: Failed to start controller. Error:", err)
+	}
+
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, os.Interrupt, syscall.SIGUSR2)
 	for {

--- a/controller/api.go
+++ b/controller/api.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 )
 
-func (r *ReefPi) setupAPI() error {
+func (r *ReefPi) API() error {
 	err, router := startAPIServer(r.settings.Address)
 	if err != nil {
 		return err

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -87,7 +87,7 @@ func (r *ReefPi) loadSubsystems() error {
 	if r.settings.Temperature {
 		temp, err := temperature.New(r.settings.DevMode, r.store, r.telemetry)
 		if err != nil {
-			log.Println("Failed to initialize temperature controller")
+			log.Println("ERROR: Failed to initialize temperature subsystem")
 			return err
 		}
 		r.subsystems[temperature.Bucket] = temp
@@ -95,7 +95,7 @@ func (r *ReefPi) loadSubsystems() error {
 	if r.settings.ATO {
 		a, err := ato.New(r.settings.DevMode, r.store, r.telemetry)
 		if err != nil {
-			log.Println("Failed to initialize ato controller")
+			log.Println("ERROR: Failed to initialize ato subsystem")
 			return err
 		}
 		r.subsystems[ato.Bucket] = a
@@ -107,6 +107,7 @@ func (r *ReefPi) loadSubsystems() error {
 		}
 		l, err := lighting.New(conf, r.jacks, r.store, r.telemetry)
 		if err != nil {
+			log.Println("ERROR: Failed to initialize lighting subsystem")
 			return err
 		}
 		r.subsystems[lighting.Bucket] = l
@@ -124,7 +125,7 @@ func (r *ReefPi) loadSubsystems() error {
 	}
 	for sName, sController := range r.subsystems {
 		if err := sController.Setup(); err != nil {
-			log.Println("Failed to setup subsystem:", sName)
+			log.Println("ERROR: Failed to setup subsystem:", sName)
 			return err
 		}
 		sController.Start()
@@ -143,7 +144,6 @@ func (r *ReefPi) Start() error {
 	if err := r.loadSubsystems(); err != nil {
 		return err
 	}
-	r.setupAPI()
 	log.Println("reef-pi is up and running")
 	return nil
 }


### PR DESCRIPTION
reef-pi controller fails to start if lighting is enabled and pwm hardware is not configured or missing. This patch ensures that we start api server irrespective of whether any other subsystem starts or not