### PR TITLE
Add a Dockerfile which contains a usable dev and build environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+LABEL maintainer="code@reef-pi.com"
+
+# Use debian as it matches a Raspbian environment
+FROM debian:stretch
+
+RUN apt-get update -y && \
+    apt-get install curl build-essential git mercurial -y
+
+RUN curl -sL https://deb.nodesource.com/setup_7.x | bash - && \
+    apt-get install -y nodejs && \
+    ln -sf /usr/bin/nodejs /usr/bin/node && \
+    npm install -g npm
+RUN curl https://dl.google.com/go/go1.10.linux-amd64.tar.gz > /tmp/go1.10.linux-amd64.tar.gz && \
+    tar xvzf /tmp/go1.10.linux-amd64.tar.gz -C /usr/local 
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOPATH=/gopath
+
+RUN mkdir -p /gopath/src/github.com/reef-pi/reef-pi
+WORKDIR /gopath/src/github.com/reef-pi/reef-pi
+
+# Bootstrap dependencies 
+COPY Makefile package.json package-lock.json /gopath/src/github.com/reef-pi/reef-pi/
+RUN make go-get
+RUN npm install
+
+# Copy the rest of the code base for building
+COPY . /gopath/src/github.com/reef-pi/reef-pi/
+
+RUN make ui
+RUN make bin
+


### PR DESCRIPTION
The resultant image can be used to iterate on the code base, especiall
on the front end code. Installs required NPM and Node versions, as
well as installing Go 1.10.

The Dockerfile is not used for Travis CI yet, as it requires a Ruby
install for the actual packaging work. I didn't want to lump over the
entire CI and test process in one shot.

The container doesn't currently "run" the service, though this could
be done. Its expected to be run in a shell environment at this stage.

Signed-off-by: Yann Ramin <atrus@stackworks.net>