### PR TITLE
(bug)create feed when each sensor of probe is started

### DIFF
--- a/controller/ato/ato.go
+++ b/controller/ato/ato.go
@@ -66,7 +66,6 @@ func (c *Controller) Create(a ATO) error {
 		return err
 	}
 	if a.Enable {
-		a.CreateFeed(c.c.Telemetry())
 		quit := make(chan struct{})
 		c.quitters[a.ID] = quit
 		go c.Run(a, quit)
@@ -90,7 +89,6 @@ func (c *Controller) Update(id string, a ATO) error {
 		delete(c.quitters, a.ID)
 	}
 	if a.Enable {
-		a.CreateFeed(c.c.Telemetry())
 		quit := make(chan struct{})
 		c.quitters[a.ID] = quit
 		go c.Run(a, quit)
@@ -160,6 +158,7 @@ func (c *Controller) Run(a ATO, quit chan struct{}) {
 		log.Printf("ERROR: ato sub-system. Invalid period set for sensor:%s. Expected postive, found:%d\n", a.Name, a.Period)
 		return
 	}
+	a.CreateFeed(c.c.Telemetry())
 	ticker := time.NewTicker(a.Period * time.Second)
 	for {
 		select {

--- a/controller/ato/controlller.go
+++ b/controller/ato/controlller.go
@@ -39,21 +39,7 @@ func (c *Controller) Setup() error {
 	if err := c.c.Store().CreateBucket(Bucket); err != nil {
 		return err
 	}
-	if err := c.c.Store().CreateBucket(UsageBucket); err != nil {
-		return err
-	}
-	atos, err := c.List()
-	if err != nil {
-		log.Println("ERROR: ato subsystem: Failed to list sensors. Error:", err)
-		return nil
-	}
-	for _, a := range atos {
-		if !a.Enable {
-			continue
-		}
-		a.CreateFeed(c.c.Telemetry())
-	}
-	return nil
+	return c.c.Store().CreateBucket(UsageBucket)
 }
 
 func (c *Controller) Start() {

--- a/controller/ph/controller.go
+++ b/controller/ph/controller.go
@@ -39,21 +39,7 @@ func (c *Controller) Setup() error {
 	if err := c.controller.Store().CreateBucket(Bucket); err != nil {
 		return err
 	}
-	if err := c.controller.Store().CreateBucket(ReadingsBucket); err != nil {
-		return err
-	}
-	probes, err := c.List()
-	if err != nil {
-		log.Println("ERROR: ph subsystem: Failed to list probes. Error:", err)
-		return err
-	}
-	for _, p := range probes {
-		if !p.Enable {
-			continue
-		}
-		p.CreateFeed(c.controller.Telemetry())
-	}
-	return nil
+	return c.controller.Store().CreateBucket(ReadingsBucket)
 }
 
 func (c *Controller) Start() {

--- a/controller/ph/probe.go
+++ b/controller/ph/probe.go
@@ -102,6 +102,7 @@ func (c *Controller) Run(p Probe, quit chan struct{}) {
 		log.Printf("ERROR:ph sub-system. Invalid period set for probe:%s. Expected postive, found:%d\n", p.Name, p.Period)
 		return
 	}
+	p.CreateFeed(c.controller.Telemetry())
 	d := drivers.NewAtlasEZO(byte(p.Address), c.bus)
 	ticker := time.NewTicker(p.Period * time.Second)
 	for {

--- a/controller/temperature/controller.go
+++ b/controller/temperature/controller.go
@@ -39,18 +39,7 @@ func (c *Controller) Setup() error {
 	if err := c.c.Store().CreateBucket(Bucket); err != nil {
 		return err
 	}
-	if err := c.c.Store().CreateBucket(UsageBucket); err != nil {
-		return err
-	}
-	tcs, err := c.List()
-	if err != nil {
-		log.Println("ERROR: temperature-subsystem: failed to list. Error:", err)
-		return nil
-	}
-	for _, tc := range tcs {
-		tc.CreateFeed(c.c.Telemetry())
-	}
-	return nil
+	return c.c.Store().CreateBucket(UsageBucket)
 }
 
 func (c *Controller) Start() {

--- a/controller/temperature/tc.go
+++ b/controller/temperature/tc.go
@@ -62,7 +62,6 @@ func (c *Controller) Create(tc TC) error {
 	if err := c.c.Store().Create(Bucket, fn); err != nil {
 		return err
 	}
-	tc.CreateFeed(c.c.Telemetry())
 	if tc.Enable {
 		quit := make(chan struct{})
 		c.quitters[tc.ID] = quit
@@ -86,7 +85,6 @@ func (c *Controller) Update(id string, tc TC) error {
 		close(quit)
 		delete(c.quitters, tc.ID)
 	}
-	tc.CreateFeed(c.c.Telemetry())
 	if tc.Enable {
 		quit := make(chan struct{})
 		c.quitters[tc.ID] = quit
@@ -127,6 +125,7 @@ func (c *Controller) IsEquipmentInUse(id string) (bool, error) {
 }
 
 func (c *Controller) Run(t TC, quit chan struct{}) {
+	t.CreateFeed(c.c.Telemetry())
 	if t.Period <= 0 {
 		log.Printf("ERROR: temperature sub-system. Invalid period set for sensor:%s. Expected postive, found:%d\n", t.Name, t.Period)
 		return


### PR DESCRIPTION
Current adafruit telemetry emission causes error when ph probe name or temperature sensor is updated, since the feed is only created during bootup and metric emission assume a feed with same name exist. Moving this logic to probe starting will fix all creation as well as update issues. We have to mention in the doc that users have to delete stale feeds (when sensors are deleted from reef-pi)