### PR TITLE
(bug)don't close gpio upon shutdown

### DIFF
--- a/controller/equipment/controller.go
+++ b/controller/equipment/controller.go
@@ -55,7 +55,6 @@ func (c *Controller) Stop() {
 		log.Println("Equipment subsystem is running in dev mode, skipping GPIO closing")
 		return
 	}
-	embd.CloseGPIO()
 }
 
 func (c *Controller) AddCheck(check Check) {


### PR DESCRIPTION
Currently reef-pi closes all GPIO during shutdown, this causes all equipment controller via power controller features will be stopped/ turned off during reef-pi reload. This is undesirable since a typical reef-pi upgrade process involves reloading reef-pi. This change set alters that behavior leaving the GPIO states as it is during shutdown/reloads. 