### PR TITLE
(chore)link troubleshooting guide instead of github issue or r2r thread

### DIFF
--- a/jsx/fatal_error.jsx
+++ b/jsx/fatal_error.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { FaGithub, FaGlobe } from 'react-icons/fa'
+import { FaMedkit } from 'react-icons/fa'
 const RefreshTime = 4000
 export default class FatalError extends React.Component {
   constructor (props) {
@@ -47,19 +47,15 @@ export default class FatalError extends React.Component {
                       <h5 className='card-title'>Connection Lost</h5>
                       <p className='card-text'>
                         Something went wrong and the UI cannot contact the server anymore. You may need to restart the
-                        webserver. If the problem still occurs you may ask on Reef2Reef or raise an issue on github.
+                        webserver or do some troubleshooting.
                       </p>
                       <p className='card-text'>
                         <a
                           target='_blank'
-                          href='https://www.reef2reef.com/threads/reef-pi-an-opensource-reef-tank-controller-based-on-raspberry-pi.289256/'
+                          href='http://reef-pi.com/additional-documentation/troubleshooting/'
                           className='btn btn-primary mr-2'
                         >
-                          {FaGlobe()} Ask on R2R
-                        </a>
-
-                        <a target='_blank' href='https://github.com/reef-pi/reef-pi/issues' className='btn btn-primary'>
-                          {FaGithub()} Ask on Github
+                          {FaMedkit()} Troubleshoot
                         </a>
                       </p>
                     </div>


### PR DESCRIPTION
@zekth this changes the alert message when reef-pi ui is not connected to backend server. Instead of directly forwarding users to r2r thread or github issue, it guides them to use the troubleshooting guide. I intend to update the troubleshooting guide to include r2r link and github issue as last resort.

The idea here is to make uses familiar with the troubleshooting process when things go south. And mitigate the most common issue on their end directly, without being hammered by github issue or r2r requests for simple things, and only use those two forums as last option