### PR TITLE
Fix component-selector to appear over footer

### DIFF
--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -39,6 +39,10 @@ html {
   margin-bottom: 10px;
 }
 
+div.dropdown-menu {
+  z-index: 1031;
+}
+
 input[type=number].no-spinner::-webkit-inner-spin-button,
 input[type=number].no-spinner::-webkit-outer-spin-button {
   -webkit-appearance: none;


### PR DESCRIPTION
Change z-index for div.drop-down menu.  This will set all button based dropdowns to appear above fixed footer.
Fixes #632 
![image](https://user-images.githubusercontent.com/1632746/47966449-70275000-e020-11e8-9b05-a43a972d3f76.png)
