### PR TITLE
(bug)preseed stats db everytime an entity created

### DIFF
--- a/controller/ato/ato.go
+++ b/controller/ato/ato.go
@@ -65,6 +65,10 @@ func (c *Controller) Create(a ATO) error {
 	if err := c.c.Store().Create(Bucket, fn); err != nil {
 		return err
 	}
+	usage := Usage{
+		Time: utils.TeleTime(time.Now()),
+	}
+	c.statsMgr.Update(a.ID, usage)
 	if a.Enable {
 		quit := make(chan struct{})
 		c.quitters[a.ID] = quit

--- a/controller/doser/pump.go
+++ b/controller/doser/pump.go
@@ -21,7 +21,6 @@ func (c *Controller) Create(p Pump) error {
 	if err := c.c.Store().Create(Bucket, fn); err != nil {
 		return err
 	}
-
 	if p.Regiment.Enable {
 		return c.addToCron(p)
 	}

--- a/controller/health.go
+++ b/controller/health.go
@@ -144,6 +144,11 @@ func (h *HealthChecker) Start() {
 		log.Println("ERROR: health checker. Failed to load usage. Error:", err)
 	}
 	log.Println("Starting health checker")
+	metric := HealthMetric{
+		len:  1,
+		Time: utils.TeleTime(time.Now()),
+	}
+	h.statsMgr.Update(HealthStatsKey, metric)
 	ticker := time.NewTicker(h.interval)
 	for {
 		select {

--- a/controller/macro/subsystem.go
+++ b/controller/macro/subsystem.go
@@ -3,7 +3,6 @@ package macro
 import (
 	"fmt"
 	"github.com/reef-pi/reef-pi/controller/types"
-	"github.com/reef-pi/reef-pi/controller/utils"
 	"sync"
 )
 
@@ -14,7 +13,6 @@ type Subsystem struct {
 	sync.Mutex
 	devMode    bool
 	quitters   map[string]chan struct{}
-	statsMgr   *utils.StatsManager
 	controller types.Controller
 }
 

--- a/controller/ph/probe.go
+++ b/controller/ph/probe.go
@@ -51,6 +51,11 @@ func (c *Controller) Create(p Probe) error {
 	if err := c.controller.Store().Create(Bucket, fn); err != nil {
 		return err
 	}
+	m := Measurement{
+		Time: utils.TeleTime(time.Now()),
+		len:  1,
+	}
+	c.statsMgr.Update(p.ID, m)
 	if p.Enable {
 		p.CreateFeed(c.controller.Telemetry())
 		quit := make(chan struct{})

--- a/controller/temperature/tc.go
+++ b/controller/temperature/tc.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/reef-pi/reef-pi/controller/types"
+	"github.com/reef-pi/reef-pi/controller/utils"
 	"log"
 	"time"
 )
@@ -62,6 +63,10 @@ func (c *Controller) Create(tc TC) error {
 	if err := c.c.Store().Create(Bucket, fn); err != nil {
 		return err
 	}
+	u := Usage{
+		Time: utils.TeleTime(time.Now()),
+	}
+	c.statsMgr.Update(tc.ID, u)
 	if tc.Enable {
 		quit := make(chan struct{})
 		c.quitters[tc.ID] = quit


### PR DESCRIPTION
 To avoid bogus stats no found error before the first check interval. This causes bogus alerts in UI and confuses reef-pi users