### PR TITLE
(chore)add yup based validation instead of onChange parsing

### DIFF
--- a/jsx/configuration/settings.jsx
+++ b/jsx/configuration/settings.jsx
@@ -1,10 +1,12 @@
 import React from 'react'
+import { showError } from 'utils/alert'
 import Capabilities from './capabilities'
 import Display from './display'
 import HealthNotify from './health_notify'
 import { updateSettings, fetchSettings } from 'redux/actions/settings'
 import { connect } from 'react-redux'
 import { isEmptyObject } from 'jquery'
+import SettingsSchema from './settings_schema'
 
 class settings extends React.Component {
   constructor (props) {
@@ -85,21 +87,27 @@ class settings extends React.Component {
   }
 
   update () {
-    this.props.updateSettings(this.state.settings)
-    this.setState({ updated: false })
+    var settings = this.state.settings
+    if (SettingsSchema.isValidSync(settings)) {
+      settings = SettingsSchema.cast(settings)
+      console.log(settings)
+      this.setState({ updated: false, settings: settings })
+      this.props.updateSettings(settings)
+      return
+    }
+    SettingsSchema.validate(settings).catch(err => {
+      showError(err.errors.join(','))
+    })
   }
 
   componentDidMount () {
     this.props.fetchSettings()
   }
 
-  toRow (label, parse = false) {
+  toRow (label) {
     var fn = function (ev) {
       var settings = this.state.settings
       settings[label] = ev.target.value
-      if (parse) {
-        settings[label] = parseInt(settings[label])
-      }
       this.setState({
         settings: settings,
         updated: true
@@ -146,10 +154,10 @@ class settings extends React.Component {
             </div>
             <div className='row'>
               <div className='col-lg-6 col-sm-12'>{this.toRow('address')}</div>
-              <div className='col-lg-6 col-sm-12'>{this.toRow('rpi_pwm_freq', true)}</div>
+              <div className='col-lg-6 col-sm-12'>{this.toRow('rpi_pwm_freq')}</div>
             </div>
             <div className='row'>
-              <div className='col-lg-6 col-sm-12'>{this.toRow('pca9685_pwm_freq', true)}</div>
+              <div className='col-lg-6 col-sm-12'>{this.toRow('pca9685_pwm_freq')}</div>
               <div className='col-lg-6 col-sm-12'>
                 <div className='form-group'>
                   <label htmlFor='updateNotification'>Notification</label>

--- a/jsx/configuration/settings_schema.jsx
+++ b/jsx/configuration/settings_schema.jsx
@@ -1,0 +1,22 @@
+import * as Yup from 'yup'
+
+const SettingsSchema = Yup.object().shape({
+  name: Yup.string().required('Name is required'),
+  interface: Yup.string().required('Network Interface is required'),
+  address: Yup.string().required('Network address is required'),
+  display: Yup.bool(),
+  notification: Yup.bool(),
+  capabilities: Yup.object().required('Capabilities is required'),
+  health_check: Yup.object().shape({
+    enable: Yup.bool(),
+    max_memory: Yup.number().positive().integer(),
+    max_cpu: Yup.number().positive().integer()
+  }),
+  https: Yup.bool(),
+  pca9685: Yup.bool(),
+  pprof: Yup.bool(),
+  rpi_pwm_freq: Yup.number().positive().integer(),
+  pca9685_pwm_freq: Yup.number().positive().integer()
+})
+
+export default SettingsSchema

--- a/jsx/configuration/settings_schema.test.js
+++ b/jsx/configuration/settings_schema.test.js
@@ -1,0 +1,35 @@
+import SettingsSchema from './settings_schema'
+
+describe('Settings schema validation', () => {
+  var settings = { }
+
+  beforeEach(() => {
+    settings = {
+      name: 'Hallroom',
+      interface: 'wlan0',
+      address: '0.0.0.0:443',
+      display: false,
+      notification: false,
+      capabilities: {
+        dev_mode: false,
+        dashboard: true
+      },
+      health_check: {
+        enable: false,
+        max_memory: 500,
+        max_cpu: 2
+      },
+      https: true,
+      pca9685: false,
+      pprof: true,
+      rpi_pwm_freq: '20s0',
+      pca9685_pwm_freq: 1500
+    }
+  })
+  it('works', () => {
+    expect.assertions(1)
+    return SettingsSchema.isValid(settings).then(
+      valid => expect(valid).toBe(true)
+    )
+  })
+})


### PR DESCRIPTION
Users see NaN in rpi_pwm_freq and other fields where we do the parsing (string to int) . This changes the onChange validation to yup schema based validation, right before the update