### PR TITLE
Changing DosingPump.regiment.duration to a float64

### DIFF
--- a/controller/modules/doser/pump.go
+++ b/controller/modules/doser/pump.go
@@ -89,7 +89,7 @@ func (c *Controller) Update(id string, p Pump) error {
 }
 
 func Validate(p Pump) error {
-	if p.Regiment.Duration <= 0 {
+	if p.Regiment.Duration < 0 {
 		return errors.New("Duration must be greater than 0")
 	}
 	return nil

--- a/controller/modules/doser/pump.go
+++ b/controller/modules/doser/pump.go
@@ -2,7 +2,7 @@ package doser
 
 import (
 	"encoding/json"
-	"errors"
+	"fmt"
 	"log"
 
 	cron "gopkg.in/robfig/cron.v2"
@@ -90,7 +90,7 @@ func (c *Controller) Update(id string, p Pump) error {
 
 func Validate(p Pump) error {
 	if p.Regiment.Duration < 0 {
-		return errors.New("Duration must be greater than 0")
+		return fmt.Errorf("Invalid Duration")
 	}
 	return nil
 }

--- a/controller/modules/doser/runner.go
+++ b/controller/modules/doser/runner.go
@@ -14,14 +14,14 @@ type Runner struct {
 	statsMgr telemetry.StatsManager
 }
 
-func (r *Runner) Dose(speed float64, duration time.Duration) error {
+func (r *Runner) Dose(speed float64, duration float64) error {
 	v := make(map[int]float64)
 	v[r.pump.Pin] = speed
 	if err := r.jacks.Control(r.pump.Jack, v); err != nil {
 		return err
 	}
 	select {
-	case <-time.After(duration * time.Second):
+	case <-time.After(time.Duration(int64(duration * float64(time.Second.Nanoseconds())))):
 		v[r.pump.Pin] = 0
 		if err := r.jacks.Control(r.pump.Jack, v); err != nil {
 			return err

--- a/controller/modules/doser/runner.go
+++ b/controller/modules/doser/runner.go
@@ -21,7 +21,7 @@ func (r *Runner) Dose(speed float64, duration float64) error {
 		return err
 	}
 	select {
-	case <-time.After(time.Duration(int64(duration * float64(time.Second.Nanoseconds())))):
+	case <-time.After(time.Duration(duration * float64(time.Second))):
 		v[r.pump.Pin] = 0
 		if err := r.jacks.Control(r.pump.Jack, v); err != nil {
 			return err

--- a/controller/modules/doser/types.go
+++ b/controller/modules/doser/types.go
@@ -7,15 +7,15 @@ import (
 )
 
 type DosingRegiment struct {
-	Enable   bool          `json:"enable"`
-	Schedule Schedule      `json:"schedule"`
-	Duration float64       `json:"duration"`
-	Speed    float64       `json:"speed"`
+	Enable   bool     `json:"enable"`
+	Schedule Schedule `json:"schedule"`
+	Duration float64  `json:"duration"`
+	Speed    float64  `json:"speed"`
 }
 
 type CalibrationDetails struct {
-	Speed    float64       `json:"speed"`
-	Duration float64       `json:"duration"`
+	Speed    float64 `json:"speed"`
+	Duration float64 `json:"duration"`
 }
 
 type Schedule struct {

--- a/controller/modules/doser/types.go
+++ b/controller/modules/doser/types.go
@@ -2,7 +2,6 @@ package doser
 
 import (
 	"strings"
-	"time"
 
 	cron "gopkg.in/robfig/cron.v2"
 )
@@ -10,13 +9,13 @@ import (
 type DosingRegiment struct {
 	Enable   bool          `json:"enable"`
 	Schedule Schedule      `json:"schedule"`
-	Duration time.Duration `json:"duration"`
+	Duration float64       `json:"duration"`
 	Speed    float64       `json:"speed"`
 }
 
 type CalibrationDetails struct {
 	Speed    float64       `json:"speed"`
-	Duration time.Duration `json:"duration"`
+	Duration float64       `json:"duration"`
 }
 
 type Schedule struct {

--- a/jsx/doser/calibrate.jsx
+++ b/jsx/doser/calibrate.jsx
@@ -78,7 +78,7 @@ const CalibrateForm = withFormik({
   },
   validationSchema: CalibrateSchema,
   handleSubmit: (values, {props}) => {
-    props.onSubmit(parseInt(values.duration), parseInt(values.speed))
+    props.onSubmit(parseFloat(values.duration), parseInt(values.speed))
   }
 })(Calibrate)
 

--- a/jsx/doser/calibration_modal.jsx
+++ b/jsx/doser/calibration_modal.jsx
@@ -27,7 +27,7 @@ export default class CalibrationModal extends React.Component {
 
   calibrate (duration, speed) {
     const payload = {
-      duration: parseInt(duration),
+      duration: parseFloat(duration),
       speed: parseInt(speed)
     }
 

--- a/jsx/doser/main.jsx
+++ b/jsx/doser/main.jsx
@@ -79,7 +79,6 @@ class doser extends React.Component {
 
   updateDoser (values) {
     var payload = this.valuesToDoser(values)
-
     this.props.update(values.id, payload)
   }
 

--- a/jsx/doser/main.jsx
+++ b/jsx/doser/main.jsx
@@ -64,7 +64,7 @@ class doser extends React.Component {
       pin: parseInt(values.pin),
       regiment: {
         enable: values.enable,
-        duration: parseInt(values.duration),
+        duration: parseFloat(values.duration),
         speed: parseInt(values.speed),
         schedule: {
           day: values.day,


### PR DESCRIPTION
Referencing the conversation in https://github.com/reef-pi/reef-pi/pull/717

My goal is to be able to allow partial second dosing with a dosing pump (5.25 seconds). Currently the pump.regiment.duration is a "time.Duration". This field isn't really being used as a true time.Duration and as is represents a int64. I want to change it to be a float64 to allow decimal point precision.

Advantages to this way over the previous PR
1. Nanoseconds are not exposed through the API.
2. Not a breaking change (database and ui will work fine if I change it)
3. Much simpler change

A couple other thoughts. When I design an API I prefer to express the unit of a time field in its name rather than leaving it ambiguous. In this case I would change "duration" to "durationSeconds" so that any consumers of the API will know what it is without having to go search the backend code for usage. This would be a breaking change and so I am not suggesting it be changed. But for future versions of the API you might consider it.