### PR TITLE
(bug)Don't register and remove zombie drivers

### DIFF
--- a/controller/drivers/main.go
+++ b/controller/drivers/main.go
@@ -111,6 +111,7 @@ func (d *Drivers) Create(d1 Driver) error {
 		return err
 	}
 	if err := d.register(d1, factory); err != nil {
+	    _ = d.store.Delete(DriverBucket, d1.ID)
 		return err
 	}
 	return nil
@@ -120,9 +121,9 @@ func (d *Drivers) Update(id string, d1 Driver) error {
 	return d.store.Update(DriverBucket, id, d1)
 }
 func (d *Drivers) Delete(id string) error {
-	_, err := d.Get(id)
-	if err != nil {
-		return err
+	dri, err := d.Get(id)
+	if err == nil {
+		_ = dri.Close()
 	}
 	return d.store.Delete(DriverBucket, id)
 }

--- a/controller/drivers/main.go
+++ b/controller/drivers/main.go
@@ -107,13 +107,12 @@ func (d *Drivers) Create(d1 Driver) error {
 	if err != nil {
 		return err
 	}
-	if err := d.store.Create(DriverBucket, fn); err != nil {
-		return err
-	}
 	if err := d.register(d1, factory); err != nil {
-		_ = d.store.Delete(DriverBucket, d1.ID)
 		return err
 	}
+    if err := d.store.Create(DriverBucket, fn); err != nil {
+        return err
+    }
 	return nil
 }
 func (d *Drivers) Update(id string, d1 Driver) error {

--- a/controller/drivers/main.go
+++ b/controller/drivers/main.go
@@ -107,12 +107,14 @@ func (d *Drivers) Create(d1 Driver) error {
 	if err != nil {
 		return err
 	}
-	if err := d.register(d1, factory); err != nil {
-		return err
-	}
     if err := d.store.Create(DriverBucket, fn); err != nil {
         return err
     }
+	if err := d.register(d1, factory); err != nil {
+	    // Registration has failed, we need to de-allocate the DB entry
+	    _ = d.store.Delete(DriverBucket, d1.ID)
+		return err
+	}
 	return nil
 }
 

--- a/controller/drivers/main.go
+++ b/controller/drivers/main.go
@@ -115,10 +115,12 @@ func (d *Drivers) Create(d1 Driver) error {
     }
 	return nil
 }
+
 func (d *Drivers) Update(id string, d1 Driver) error {
 	d1.ID = id
 	return d.store.Update(DriverBucket, id, d1)
 }
+
 func (d *Drivers) Delete(id string) error {
 	dri, err := d.Get(id)
 	if err == nil {
@@ -139,6 +141,7 @@ func (d *Drivers) List() ([]Driver, error) {
 	}
 	return ds, d.store.List(DriverBucket, fn)
 }
+
 func (d *Drivers) Close() error {
 	for _, d1 := range d.drivers {
 		if err := d1.Close(); err != nil {

--- a/controller/drivers/main.go
+++ b/controller/drivers/main.go
@@ -107,12 +107,12 @@ func (d *Drivers) Create(d1 Driver) error {
 	if err != nil {
 		return err
 	}
-    if err := d.store.Create(DriverBucket, fn); err != nil {
-        return err
-    }
+	if err := d.store.Create(DriverBucket, fn); err != nil {
+		return err
+	}
 	if err := d.register(d1, factory); err != nil {
-	    // Registration has failed, we need to de-allocate the DB entry
-	    _ = d.store.Delete(DriverBucket, d1.ID)
+		// Registration has failed, we need to de-allocate the DB entry
+		_ = d.store.Delete(DriverBucket, d1.ID)
 		return err
 	}
 	return nil

--- a/controller/drivers/main.go
+++ b/controller/drivers/main.go
@@ -111,7 +111,7 @@ func (d *Drivers) Create(d1 Driver) error {
 		return err
 	}
 	if err := d.register(d1, factory); err != nil {
-	    _ = d.store.Delete(DriverBucket, d1.ID)
+		_ = d.store.Delete(DriverBucket, d1.ID)
 		return err
 	}
 	return nil


### PR DESCRIPTION
Scenario:

- Create ph_board driver with invalid I2C address
  - Call to register driver fails with error, not storing the driver in the drivers slice.
    - UI shows driver instance, as it was still written to the
      underlying store.

This fixes:

- Removing a driver which returned an error on registration from the
  store (consistency)
- Allowing the removal of a driver which is in the store but not in
  the loaded map (which could happen after the driver fails to
  register due to removed hardware on reload)
- Closing the driver upon removal.
