### PR TITLE
(feat)Add Prometheus metrics integration

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,14 @@
   version = "1.0.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  pruneopts = "UT"
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+
+[[projects]]
   digest = "1:5f7414cf41466d4b4dd7ec52b2cd3e481e08cfd11e7e24fef730c0e483e88bb1"
   name = "github.com/coreos/bbolt"
   packages = ["."]
@@ -43,6 +51,14 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
+
+[[projects]]
+  digest = "1:318f1c959a8a740366fce4b1e1eb2fd914036b4af58fbd0a003349b305f118ad"
+  name = "github.com/golang/protobuf"
+  packages = ["proto"]
+  pruneopts = "UT"
+  revision = "b5d812f8a3706043e23a9cd5babf2e5423744d30"
+  version = "v1.3.1"
 
 [[projects]]
   digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
@@ -97,12 +113,67 @@
   revision = "d3d8c0c5c68dc6caccebb7d720f36e64bafd0a62"
 
 [[projects]]
+  digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  pruneopts = "UT"
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
+
+[[projects]]
   branch = "master"
   digest = "1:34534b73e925d20cc72cf202f8b482fdcbe3a1b113e19375f31aadabd0f0f97d"
   name = "github.com/nfnt/resize"
   packages = ["."]
   pruneopts = "UT"
   revision = "83c6a9932646f83e3267f353373d47347b6036b2"
+
+[[projects]]
+  digest = "1:ef03fb1dae4d010196652653f00a8002e94c19bcabdc8ca5100a804ffef63a47"
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/internal",
+    "prometheus/promauto",
+    "prometheus/promhttp",
+  ]
+  pruneopts = "UT"
+  revision = "505eaef017263e299324067d40ca2c48f6a2cf50"
+  version = "v0.9.2"
+
+[[projects]]
+  branch = "master"
+  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  pruneopts = "UT"
+  revision = "fd36f4220a901265f90734c3183c5f0c91daa0b8"
+
+[[projects]]
+  digest = "1:35cf6bdf68db765988baa9c4f10cc5d7dda1126a54bd62e252dbcd0b1fc8da90"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = "UT"
+  revision = "cfeb6f9992ffa54aaa4f2170ade4067ee478b250"
+  version = "v0.2.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:c31163bd62461e0c5f7ddc7363e39ef8d9e929693e77b5c11c709b05f9cb9219"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/util",
+    "iostats",
+    "nfs",
+    "xfs",
+  ]
+  pruneopts = "UT"
+  revision = "55ae3d9d557340b5bc24cd8aa5f6fa2c2ab31352"
 
 [[projects]]
   branch = "master"
@@ -193,6 +264,9 @@
     "github.com/gorilla/sessions",
     "github.com/kidoman/embd",
     "github.com/nfnt/resize",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promauto",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/reef-pi/adafruitio",
     "github.com/reef-pi/drivers",
     "github.com/reef-pi/drivers/hal/pca9685",

--- a/controller/daemon/api.go
+++ b/controller/daemon/api.go
@@ -59,6 +59,9 @@ func (r *ReefPi) API() error {
 }
 
 func (r *ReefPi) UnAuthenticatedAPI(router *mux.Router) {
+	if r.settings.Prometheus {
+		r.prometheus()
+	}
 	router.HandleFunc("/auth/signin", r.a.SignIn).Methods("POST")
 	router.HandleFunc("/auth/signout", r.a.SignOut).Methods("GET")
 }

--- a/controller/daemon/api.go
+++ b/controller/daemon/api.go
@@ -52,6 +52,9 @@ func (r *ReefPi) API() error {
 	}
 	r.AuthenticatedAPI(router)
 	r.UnAuthenticatedAPI(router)
+	if r.settings.Prometheus {
+		r.prometheus()
+	}
 	if os.Getenv("REEF_PI_LIST_API") == "1" {
 		summarizeAPI(router)
 	}
@@ -59,9 +62,6 @@ func (r *ReefPi) API() error {
 }
 
 func (r *ReefPi) UnAuthenticatedAPI(router *mux.Router) {
-	if r.settings.Prometheus {
-		r.prometheus()
-	}
 	router.HandleFunc("/auth/signin", r.a.SignIn).Methods("POST")
 	router.HandleFunc("/auth/signout", r.a.SignOut).Methods("GET")
 }

--- a/controller/daemon/prometheus.go
+++ b/controller/daemon/prometheus.go
@@ -1,10 +1,11 @@
 package daemon
 
 import (
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 func (r ReefPi) prometheus() {
-	http.Handle("/api/metrics", promhttp.Handler())
+	http.Handle("/x/metrics", promhttp.Handler())
 }

--- a/controller/daemon/prometheus.go
+++ b/controller/daemon/prometheus.go
@@ -1,0 +1,10 @@
+package daemon
+
+import (
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"net/http"
+)
+
+func (r ReefPi) prometheus() {
+	http.Handle("/api/metrics", promhttp.Handler())
+}

--- a/controller/daemon/reef_pi.go
+++ b/controller/daemon/reef_pi.go
@@ -53,7 +53,7 @@ func New(version, database string) (*ReefPi, error) {
 	}
 	fn := func(t, m string) error { return logError(store, t, m) }
 
-	tele := telemetry.Initialize(Bucket, store, fn, s.Notification)
+	tele := telemetry.Initialize(Bucket, store, fn, s.Prometheus)
 	bus := i2c.Bus(i2c.MockBus())
 	if !s.Capabilities.DevMode {
 		b, err := i2c.New()

--- a/controller/modules/ato/ato.go
+++ b/controller/modules/ato/ato.go
@@ -143,7 +143,7 @@ func (c *Controller) Check(a ATO) {
 		return
 	}
 	log.Println("ato sub-system:  sensor", a.Name, "value:", reading)
-	c.c.Telemetry().EmitMetric("ato-"+a.Name+"-reading", reading)
+	c.c.Telemetry().EmitMetric("ato", a.Name+"-reading", float64(reading))
 	if a.Control {
 		if err := c.Control(a, reading); err != nil {
 			log.Println("ERROR: Failed to execute ato control logic. Error:", err)
@@ -155,7 +155,7 @@ func (c *Controller) Check(a ATO) {
 	}
 	c.NotifyIfNeeded(a)
 	c.statsMgr.Update(a.ID, usage)
-	c.c.Telemetry().EmitMetric("ato-"+a.Name+"-usage", usage.Pump)
+	c.c.Telemetry().EmitMetric("ato", a.Name+"-usage", float64(usage.Pump))
 }
 
 func (c *Controller) Run(a ATO, quit chan struct{}) {

--- a/controller/modules/lighting/light.go
+++ b/controller/modules/lighting/light.go
@@ -113,6 +113,6 @@ func (c *Controller) syncLight(light Light) {
 			v = float64(ch.Max)
 		}
 		c.UpdateChannel(light.Jack, ch, v)
-		c.c.Telemetry().EmitMetric(light.Name+"-"+ch.Name, v)
+		c.c.Telemetry().EmitMetric(light.Name, ch.Name, v)
 	}
 }

--- a/controller/modules/ph/probe.go
+++ b/controller/modules/ph/probe.go
@@ -140,7 +140,7 @@ func (c *Controller) Run(p Probe, quit chan struct{}) {
 				sum:  reading,
 			}
 			c.statsMgr.Update(p.ID, m)
-			c.c.Telemetry().EmitMetric("ph-"+p.Name, reading)
+			c.c.Telemetry().EmitMetric("ph", p.Name, reading)
 		case <-quit:
 			ticker.Stop()
 			return

--- a/controller/modules/temperature/control.go
+++ b/controller/modules/temperature/control.go
@@ -25,7 +25,7 @@ func (c *Controller) Check(tc TC) {
 	}
 	u.Temperature = reading
 	log.Println("temperature sub-system:  sensor", tc.Name, "value:", reading)
-	c.c.Telemetry().EmitMetric(tc.Name+"-reading", reading)
+	c.c.Telemetry().EmitMetric(tc.Name, "reading", reading)
 	if tc.Control {
 		if err := c.control(tc, &u); err != nil {
 			log.Println("ERROR: Failed to execute temperature control logic. Error:", err)
@@ -50,10 +50,10 @@ func (c *Controller) control(tc TC, u *Usage) error {
 		c.switchOffAll(tc)
 	}
 	if tc.Heater != "" {
-		c.c.Telemetry().EmitMetric(tc.Name+"-cooler", u.Cooler)
+		c.c.Telemetry().EmitMetric(tc.Name, "cooler", float64(u.Cooler))
 	}
 	if tc.Cooler != "" {
-		c.c.Telemetry().EmitMetric(tc.Name+"-heater", u.Heater)
+		c.c.Telemetry().EmitMetric(tc.Name, "heater", float64(u.Heater))
 	}
 	return nil
 }

--- a/controller/settings/settings.go
+++ b/controller/settings/settings.go
@@ -11,6 +11,7 @@ type Settings struct {
 	HTTPS        bool              `json:"https"`
 	Pprof        bool              `json:"pprof"`
 	RPI_PWMFreq  int               `json:"rpi_pwm_freq"`
+	Prometheus   bool              `json:"prometheus"`
 }
 
 var DefaultSettings = Settings{

--- a/controller/telemetry/api.go
+++ b/controller/telemetry/api.go
@@ -1,32 +1,11 @@
 package telemetry
 
 import (
-	"log"
 	"net/http"
 	"time"
 
-	"github.com/reef-pi/reef-pi/controller/storage"
 	"github.com/reef-pi/reef-pi/controller/utils"
 )
-
-const DBKey = "telemetry"
-
-func Initialize(b string, store storage.Store, logError ErrorLogger, notify bool) Telemetry {
-	var c TelemetryConfig
-	if err := store.Get(b, DBKey, &c); err != nil {
-		log.Println("ERROR: Failed to load telemtry config from saved settings. Initializing")
-		c = DefaultTelemetryConfig
-		store.Update(b, DBKey, c)
-	}
-	// for upgrades, this value will be 0. Remove in 3.0
-	if c.HistoricalLimit < 1 {
-		c.HistoricalLimit = HistoricalLimit
-	}
-	if c.CurrentLimit < 1 {
-		c.CurrentLimit = CurrentLimit
-	}
-	return NewTelemetry(b, store, c, logError)
-}
 
 func (t *telemetry) GetConfig(w http.ResponseWriter, req *http.Request) {
 	fn := func(_ string) (interface{}, error) {

--- a/controller/telemetry/health.go
+++ b/controller/telemetry/health.go
@@ -86,7 +86,7 @@ func (h *hc) Check() {
 		log.Println("ERROR: Failed to obtain load average. Error:", err)
 		return
 	}
-	h.t.EmitMetric("system-load5", loadStat.Load5)
+	h.t.EmitMetric("system", "load5", loadStat.Load5)
 
 	vmStat, err := mem.VirtualMemory()
 	if err != nil {
@@ -102,7 +102,7 @@ func (h *hc) Check() {
 		memorySum:  usedMemory,
 		Time:       TeleTime(time.Now()),
 	}
-	h.t.EmitMetric("system-mem-used", usedMemory)
+	h.t.EmitMetric("system", "mem-used", usedMemory)
 	log.Println("health check: Used memory:", usedMemory, " Load5:", loadStat.Load5)
 	h.statsMgr.Update(HealthStatsKey, metric)
 	h.NotifyIfNeeded(usedMemory, loadStat.Load5)

--- a/controller/telemetry/stats.go
+++ b/controller/telemetry/stats.go
@@ -161,17 +161,19 @@ func (t *telemetry) Alert(subject, body string) (bool, error) {
 }
 
 func (t *telemetry) EmitMetric(module, name string, v float64) {
-	feed := module + "-" + name
+	feed := module + "_" + name
 	aio := t.config.AdafruitIO
 	feed = strings.ToLower(aio.Prefix + feed)
+	feed = strings.Replace(feed, " ", "_", -1)
+	pName := strings.Replace(feed, "-", "_", -1)
 
 	if t.config.Prometheus {
 		t.mu.Lock()
 		g, ok := t.pMs[feed]
 		if !ok {
 			g = promauto.NewGauge(prometheus.GaugeOpts{
-				Name: feed,
-				Help: feed,
+				Name: pName,
+				Help: "Module:" + module + " Item:" + name,
 			})
 			t.pMs[feed] = g
 		}

--- a/controller/telemetry/stats.go
+++ b/controller/telemetry/stats.go
@@ -7,12 +7,17 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/reef-pi/reef-pi/controller/storage"
 
 	"math"
 
 	"github.com/reef-pi/adafruitio"
 )
+
+const DBKey = "telemetry"
 
 func TwoDecimal(f float64) float64 {
 	return math.Round(f*100) / 100
@@ -22,7 +27,7 @@ type ErrorLogger func(string, string) error
 
 type Telemetry interface {
 	Alert(string, string) (bool, error)
-	EmitMetric(string, interface{})
+	EmitMetric(string, string, float64)
 	CreateFeedIfNotExist(string)
 	DeleteFeedIfExist(string)
 	NewStatsManager(storage.Store, string) StatsManager
@@ -47,6 +52,7 @@ type TelemetryConfig struct {
 	AdafruitIO      AdafruitIO   `json:"adafruitio"`
 	Mailer          MailerConfig `json:"mailer"`
 	Notify          bool         `json:"notify"`
+	Prometheus      bool         `json:"prometheus"`
 	Throttle        int          `json:"throttle"`
 	HistoricalLimit int          `json:"historical_limit"`
 	CurrentLimit    int          `json:"current_limit"`
@@ -68,6 +74,25 @@ type telemetry struct {
 	logError   ErrorLogger
 	store      storage.Store
 	bucket     string
+	pMs        map[string]prometheus.Gauge
+}
+
+func Initialize(b string, store storage.Store, logError ErrorLogger, prom bool) Telemetry {
+	var c TelemetryConfig
+	if err := store.Get(b, DBKey, &c); err != nil {
+		log.Println("ERROR: Failed to load telemtry config from saved settings. Initializing")
+		c = DefaultTelemetryConfig
+		store.Update(b, DBKey, c)
+	}
+	c.Prometheus = prom
+	// for upgrades, this value will be 0. Remove in 3.0
+	if c.HistoricalLimit < 1 {
+		c.HistoricalLimit = HistoricalLimit
+	}
+	if c.CurrentLimit < 1 {
+		c.CurrentLimit = CurrentLimit
+	}
+	return NewTelemetry(b, store, c, logError)
 }
 
 func NewTelemetry(b string, store storage.Store, config TelemetryConfig, lr ErrorLogger) *telemetry {
@@ -85,6 +110,7 @@ func NewTelemetry(b string, store storage.Store, config TelemetryConfig, lr Erro
 		logError:   lr,
 		store:      store,
 		bucket:     b,
+		pMs:        make(map[string]prometheus.Gauge),
 	}
 }
 
@@ -134,9 +160,24 @@ func (t *telemetry) Alert(subject, body string) (bool, error) {
 	return true, nil
 }
 
-func (t *telemetry) EmitMetric(feed string, v interface{}) {
+func (t *telemetry) EmitMetric(module, name string, v float64) {
+	feed := module + "-" + name
 	aio := t.config.AdafruitIO
 	feed = strings.ToLower(aio.Prefix + feed)
+
+	if t.config.Prometheus {
+		t.mu.Lock()
+		g, ok := t.pMs[feed]
+		if !ok {
+			g = promauto.NewGauge(prometheus.GaugeOpts{
+				Name: feed,
+				Help: feed,
+			})
+			t.pMs[feed] = g
+		}
+		t.mu.Unlock()
+		g.Add(v)
+	}
 	if !aio.Enable {
 		//log.Println("Telemetry disabled. Skipping emitting", v, "on", feed)
 		return

--- a/controller/telemetry/stats.go
+++ b/controller/telemetry/stats.go
@@ -161,7 +161,7 @@ func (t *telemetry) Alert(subject, body string) (bool, error) {
 }
 
 func (t *telemetry) EmitMetric(module, name string, v float64) {
-	feed := module + "_" + name
+	feed := module + "-" + name
 	aio := t.config.AdafruitIO
 	feed = strings.ToLower(aio.Prefix + feed)
 	feed = strings.Replace(feed, " ", "_", -1)

--- a/controller/telemetry/telemetry_test.go
+++ b/controller/telemetry/telemetry_test.go
@@ -1,15 +1,13 @@
 package telemetry
 
 import (
-	"math/rand"
 	"testing"
 	"time"
 )
 
 func TestEmitMetric(t *testing.T) {
 	telemetry := TestTelemetry()
-	rand.Seed(time.Now().Unix())
-	telemetry.EmitMetric("test", rand.Intn(100))
+	telemetry.EmitMetric("test", "foo", 1.23)
 	telemetry.config.Throttle = 2
 	sent, err := telemetry.Alert("test-alert", "")
 	if err != nil {

--- a/front-end/assets/translations/en.csv
+++ b/front-end/assets/translations/en.csv
@@ -85,6 +85,7 @@ configuration:settings:notification,Notification
 configuration:settings:display,Display
 configuration:settings:use_https,Use HTTPS
 configuration:settings:enable_profiling,Enable profiling
+configuration:settings:enable_prometheus,Enable prometheus
 configuration:settings:capabilities,Capabilities
 configuration:settings:alert_health_check,Alert on health check
 configuration:settings:max_memory,Max memory

--- a/front-end/src/configuration/settings.jsx
+++ b/front-end/src/configuration/settings.jsx
@@ -232,6 +232,20 @@ class settings extends React.Component {
                 </div>
               </div>
             </div>
+            <div className='row'>
+              <div className='col-6'>
+                <div className='form-group'>
+                  <label htmlFor='enable_prometheus'>{i18n.t('configuration:settings:enable_prometheus')}</label>
+                  <input
+                    type='checkbox'
+                    id='enable_pprof'
+                    onClick={this.updateCheckbox('prometheus')}
+                    defaultChecked={this.state.settings.prometheus}
+                    className='form-control'
+                  />
+                </div>
+              </div>
+            </div>
           </div>
         </div>
         <div className='row'>

--- a/front-end/src/configuration/settings_schema.jsx
+++ b/front-end/src/configuration/settings_schema.jsx
@@ -15,6 +15,7 @@ const SettingsSchema = Yup.object().shape({
   }),
   https: Yup.bool(),
   pprof: Yup.bool(),
+  prometheus: Yup.bool(),
   rpi_pwm_freq: Yup.number().positive().integer()
 })
 


### PR DESCRIPTION
If enabled (Configuration -> Enable prometheus), reef-pill provide an api (/x/metrics) for prometheus to scrape go runtime metrics (gc, go routines, heap usage etc) as well as all normal telemetry (ato, ph, temperature etc).

This will allow users to run dedicated prometheus server for metrics storage and use grafana and any other tool to chart it. 