### PR TITLE
(chore)Upgrade to go1.12 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - "1.10"
+  - "1.12.4"
 before_install:
   - curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
   - sudo  apt-get install -y nodejs

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,27 +6,28 @@ LABEL maintainer="code@reef-pi.com"
 RUN apt-get update -y && \
     apt-get install curl build-essential git mercurial -y
 
-RUN curl -sL https://deb.nodesource.com/setup_7.x | bash - && \
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     apt-get install -y nodejs && \
-    ln -sf /usr/bin/nodejs /usr/bin/node && \
     npm install -g npm
-RUN curl https://dl.google.com/go/go1.10.linux-amd64.tar.gz > /tmp/go1.10.linux-amd64.tar.gz && \
-    tar xvzf /tmp/go1.10.linux-amd64.tar.gz -C /usr/local 
+RUN curl https://dl.google.com/go/go1.12.4.linux-amd64.tar.gz > /tmp/go1.12.4.linux-amd64.tar.gz && \
+    tar xvzf /tmp/go1.12.4.linux-amd64.tar.gz -C /usr/local
 
-ENV PATH="/usr/local/go/bin:${PATH}"
+
 ENV GOPATH=/gopath
+ENV PATH="/usr/local/go/bin:${GOPATH}/bin:${PATH}"
 
 RUN mkdir -p /gopath/src/github.com/reef-pi/reef-pi
 WORKDIR /gopath/src/github.com/reef-pi/reef-pi
 
 # Bootstrap dependencies 
 COPY Makefile package.json package-lock.json /gopath/src/github.com/reef-pi/reef-pi/
-RUN make go-get
 RUN npm install
+
+COPY Gopkg.lock Gopkg.toml controller/ /gopath/src/github.com/reef-pi/reef-pi/
+RUN make go-get
 
 # Copy the rest of the code base for building
 COPY . /gopath/src/github.com/reef-pi/reef-pi/
 
-RUN make ui
 RUN make bin
 

--- a/controller/utils/tls.go
+++ b/controller/utils/tls.go
@@ -41,7 +41,7 @@ func GenerateCerts() error {
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
-		IsCA: true,
+		IsCA:                  true,
 	}
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)


### PR DESCRIPTION
## Description

Its 2019, time to keep up with the Go releases.

## Related Issue

N/A

## Motivation and Context

Stay on currently released and bugfixed versions of Go
