### PR TITLE
(feat)Add support for TpLink kasa hs110 and hs300 devices

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -185,7 +185,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ce67afd53bd465c7c6dff1eafd0729b6d8831c68871ef9ba4e9e551538b3fd30"
+  digest = "1:3e18f1fde520a67c4186609bd60f28d322aaacec35998d8d2747fdfe66cacd9a"
   name = "github.com/reef-pi/drivers"
   packages = [
     ".",
@@ -195,7 +195,7 @@
     "tplink",
   ]
   pruneopts = "UT"
-  revision = "7e1d5f80cce0480973f98337e32e58e1ecab3bc0"
+  revision = "8386717f2f3b1664df8aa24872ec4192f68de094"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -185,7 +185,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:89ad5276e0399eb6226dcdb71ee93597ebb2654df1cac9f2d42e2353ec65f877"
+  digest = "1:ce67afd53bd465c7c6dff1eafd0729b6d8831c68871ef9ba4e9e551538b3fd30"
   name = "github.com/reef-pi/drivers"
   packages = [
     ".",
@@ -195,7 +195,7 @@
     "tplink",
   ]
   pruneopts = "UT"
-  revision = "1ff7409a57aa164dce063234c64ee702483d5e8c"
+  revision = "7e1d5f80cce0480973f98337e32e58e1ecab3bc0"
 
 [[projects]]
   branch = "master"

--- a/controller/drivers/factories.go
+++ b/controller/drivers/factories.go
@@ -43,8 +43,12 @@ func AbstractFactory(t string, dev_mode bool) (Factory, error) {
 		return pico_board.HalAdapter, nil
 	case "ph-ezo":
 		return drivers.EzoHalAdapter, nil
-	case "hs1xx":
-		return tplink.HALAdapter, nil
+	case "hs103":
+		return tplink.HS103HALAdapter, nil
+	case "hs110":
+		return tplink.HS110HALAdapter, nil
+	case "hs300":
+		return tplink.HS300HALAdapter, nil
 	default:
 		return nil, fmt.Errorf("Unknown driver type:%s", t)
 	}


### PR DESCRIPTION
- HS110 is a single outlet device with current monitoring capabilities, and HS300 is a multi-outlet device with current monitoring capabilities. Adding support for both devices in for outlet /equipment control and current monitoring .
- Current monitoring is implemented as ADC hal interface and can be visualized using the ph probe ui.