### PR TITLE
(feat)make macros reversible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ __snapshots__
 coverage
 .vscode
 front-end/src/utils/translations/*.json
+test-data

--- a/controller/modules/macro/api.go
+++ b/controller/modules/macro/api.go
@@ -1,7 +1,6 @@
 package macro
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -50,7 +49,6 @@ func (c *Subsystem) delete(w http.ResponseWriter, r *http.Request) {
 func (c *Subsystem) update(w http.ResponseWriter, r *http.Request) {
 	var m Macro
 	fn := func(id string) error {
-		m.Enable = false // macros are always enabled by run
 		return c.Update(id, m)
 	}
 	utils.JSONUpdateResponse(&m, fn, w, r)
@@ -62,10 +60,7 @@ func (c *Subsystem) run(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			return err
 		}
-		if m.Enable {
-			return fmt.Errorf("Macro: %s is already running", m.Name)
-		}
-		go c.Run(m)
+		go c.Run(m, false)
 		return nil
 	}
 	utils.JSONDeleteResponse(fn, w, r)

--- a/controller/modules/macro/macro_test.go
+++ b/controller/modules/macro/macro_test.go
@@ -47,7 +47,7 @@ func TestMacro(t *testing.T) {
 		t.Error("Failed to get using api. Error:", err)
 	}
 	m.ID = "1"
-	if err := s.Run(m); err != nil {
+	if err := s.Run(m, false); err != nil {
 		t.Error(err)
 	}
 	if err := tr.Do("GET", "/api/macros", strings.NewReader(`{}`), nil); err != nil {

--- a/controller/modules/macro/step.go
+++ b/controller/modules/macro/step.go
@@ -36,35 +36,35 @@ type Step struct {
 	Config json.RawMessage `json:"config"`
 }
 
-func (s *Step) Run(c controller.Controller) error {
+func (s *Step) Run(c controller.Controller, reverse bool) error {
 	switch s.Type {
 	case storage.EquipmentBucket, storage.ATOBucket, storage.TemperatureBucket,
-		storage.DoserBucket, storage.PhBucket, storage.TimerBucket:
+		storage.DoserBucket, storage.PhBucket, storage.TimerBucket, "subsystem":
 		var g GenericStep
 		if err := json.Unmarshal(s.Config, &g); err != nil {
 			return err
+		}
+		state := g.On
+		if reverse {
+			state = !state
+		}
+		if s.Type == "subsystem" {
+			sub, err := c.Subsystem(g.ID)
+			if err != nil {
+				return err
+			}
+			if state {
+				sub.Start()
+				return nil
+			}
+			sub.Stop()
+			return nil
 		}
 		sub, err := c.Subsystem(s.Type)
 		if err != nil {
 			return err
 		}
-		return sub.On(g.ID, g.On)
-	case "subsystem":
-		var g GenericStep
-		if err := json.Unmarshal(s.Config, &g); err != nil {
-			return err
-		}
-		sub, err := c.Subsystem(g.ID)
-		if err != nil {
-			return err
-		}
-		if g.On {
-			sub.Start()
-			return nil
-		} else {
-			sub.Stop()
-			return nil
-		}
+		return sub.On(g.ID, state)
 	case "wait":
 		var w WaitStep
 		if err := json.Unmarshal(s.Config, &w); err != nil {

--- a/controller/modules/macro/step.go
+++ b/controller/modules/macro/step.go
@@ -9,19 +9,6 @@ import (
 	"github.com/reef-pi/reef-pi/controller/storage"
 )
 
-var stepTypes = []string{
-	"wait",
-	"subsystem",
-	"macro",
-	"equipment",
-	"ato",
-	"tc",
-	"lighting",
-	"ph",
-	"doser",
-	"timer",
-}
-
 type GenericStep struct {
 	ID string `json:"id"`
 	On bool   `json:"on"`
@@ -39,7 +26,7 @@ type Step struct {
 func (s *Step) Run(c controller.Controller, reverse bool) error {
 	switch s.Type {
 	case storage.EquipmentBucket, storage.ATOBucket, storage.TemperatureBucket,
-		storage.DoserBucket, storage.PhBucket, storage.TimerBucket, "subsystem":
+		storage.DoserBucket, storage.PhBucket, storage.TimerBucket, storage.MacroBucket, "subsystem":
 		var g GenericStep
 		if err := json.Unmarshal(s.Config, &g); err != nil {
 			return err

--- a/controller/modules/macro/step_test.go
+++ b/controller/modules/macro/step_test.go
@@ -15,39 +15,39 @@ func TestStep(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.Run(c); err != nil {
+	if err := s.Run(c, false); err != nil {
 		t.Error(err)
 	}
 	s.Config = []byte(`[]`)
-	if err := s.Run(c); err == nil {
+	if err := s.Run(c, false); err == nil {
 		t.Error("Equipment step with invalid config should raise error")
 	}
 
 	s.Type = "foo"
 	s.Config = []byte(`{}`)
-	if err := s.Run(c); err == nil {
+	if err := s.Run(c, false); err == nil {
 		t.Error("Unknown type should raise error")
 	}
 	s.Type = "wait"
-	if err := s.Run(c); err != nil {
+	if err := s.Run(c, false); err != nil {
 		t.Error(err)
 	}
 	s.Config = []byte(`[]`)
-	if err := s.Run(c); err == nil {
+	if err := s.Run(c, false); err == nil {
 		t.Error("Invalid wait step config should raise error")
 	}
 
 	s.Type = "subsystem"
 	s.Config = []byte(`{ "on": true}`)
-	if err := s.Run(c); err != nil {
+	if err := s.Run(c, false); err != nil {
 		t.Error(err)
 	}
 	s.Config = []byte(`{ "on": false}`)
-	if err := s.Run(c); err != nil {
+	if err := s.Run(c, false); err != nil {
 		t.Error(err)
 	}
 	s.Config = []byte(`[]`)
-	if err := s.Run(c); err == nil {
+	if err := s.Run(c, false); err == nil {
 		t.Error("Invalid subsystem system config should raise error")
 	}
 }

--- a/controller/modules/macro/subsystem.go
+++ b/controller/modules/macro/subsystem.go
@@ -38,5 +38,5 @@ func (s *Subsystem) On(id string, b bool) error {
 	if err != nil {
 		return err
 	}
-	return s.Run(m)
+	return s.Run(m, b)
 }


### PR DESCRIPTION
Macros can be reversible from now on. A boolean attribute "reversible" will be associated with every macro indicating users have explicitly designated them as reversible. From now on  macro run call will havea reverse flag, and when it is set to true and the macro is declared as reversible, reef-pi will execute the macro steps in reverse order and all target within each step will be reversed except the wait step, which acts same. Equipment, ato, timers ... all will be on or off depending upon how its normally configured.