### PR TITLE
(feat)add mux wrapper with automatic documentation support

### DIFF
--- a/controller/autodoc.go
+++ b/controller/autodoc.go
@@ -1,0 +1,89 @@
+package controller
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/gorilla/mux"
+	"log"
+	"net/http"
+	"os"
+)
+
+var (
+	docTypes = make(map[string]map[string]*container)
+)
+
+type DocRouter struct {
+	mux.Router
+}
+
+type DocRoute struct {
+	mux.Route
+}
+
+type container struct {
+	Req  interface{}
+	Resp interface{}
+}
+
+func NewDocRouter() *DocRouter {
+	return &DocRouter{*mux.NewRouter()}
+}
+
+func (r *DocRoute) Doc(in, out interface{}) {
+	path, _ := r.GetPathTemplate()
+	docs := make(map[string]*container)
+	if ds, ok := docTypes[path]; ok {
+		docs = ds
+	}
+	for m, ct := range docs {
+		if ct == nil {
+			docs[m] = &container{Req: in, Resp: out}
+			return
+		}
+	}
+}
+
+func (r *DocRouter) HandleFunc(path string, f func(http.ResponseWriter, *http.Request)) *DocRoute {
+	docTypes[path] = make(map[string]*container)
+	return &DocRoute{*r.Router.HandleFunc(path, f)}
+}
+
+func (r *DocRoute) Methods(mts ...string) *DocRoute {
+	path, _ := r.GetPathTemplate()
+	for _, m := range mts {
+		docTypes[path][m] = nil
+	}
+	r.Route.Methods(mts...)
+	return r
+}
+func (r *DocRouter) Summarize() {
+	fi, err := os.Create("api.txt")
+	if err != nil {
+		log.Println("ERROR: Failed to open api.md file. Error:", err)
+		return
+	}
+	defer fi.Close()
+
+	for path, verbs := range docTypes {
+		for verb, ct := range verbs {
+			fi.WriteString(fmt.Sprintf("%6s\t%s\n", verb, path))
+			if ct == nil {
+				continue
+			}
+			fmt.Println("data:", path, verb)
+			if ct.Req != nil {
+				fi.WriteString("Input:\n")
+				enc := json.NewEncoder(fi)
+				enc.SetIndent("", " ")
+				enc.Encode(ct.Req)
+			}
+			if ct.Resp != nil {
+				fi.WriteString("Output:\n")
+				enc := json.NewEncoder(fi)
+				enc.SetIndent("", " ")
+				enc.Encode(ct.Resp)
+			}
+		}
+	}
+}

--- a/controller/connectors/analog_input.go
+++ b/controller/connectors/analog_input.go
@@ -6,10 +6,9 @@ import (
 
 	"net/http"
 
-	"github.com/gorilla/mux"
-
 	"github.com/reef-pi/hal"
 
+	"github.com/reef-pi/reef-pi/controller"
 	"github.com/reef-pi/reef-pi/controller/drivers"
 	"github.com/reef-pi/reef-pi/controller/storage"
 	"github.com/reef-pi/reef-pi/controller/utils"
@@ -115,7 +114,7 @@ func (c *AnalogInputs) Delete(id string) error {
 	return c.store.Delete(AnalogInputBucket, id)
 }
 
-func (c *AnalogInputs) LoadAPI(r *mux.Router) {
+func (c *AnalogInputs) LoadAPI(r *controller.DocRouter) {
 	r.HandleFunc("/api/analog_inputs", c.list).Methods("GET")
 	r.HandleFunc("/api/analog_inputs/{id}", c.get).Methods("GET")
 	r.HandleFunc("/api/analog_inputs", c.create).Methods("PUT")

--- a/controller/connectors/analog_input.go
+++ b/controller/connectors/analog_input.go
@@ -115,7 +115,7 @@ func (c *AnalogInputs) Delete(id string) error {
 }
 
 func (c *AnalogInputs) LoadAPI(r *controller.DocRouter) {
-	r.HandleFunc("/api/analog_inputs", c.list).Methods("GET")
+	r.HandleFunc("/api/analog_inputs", c.list).Methods("GET").Doc(nil, []*AnalogInput{new(AnalogInput)})
 	r.HandleFunc("/api/analog_inputs/{id}", c.get).Methods("GET")
 	r.HandleFunc("/api/analog_inputs", c.create).Methods("PUT")
 	r.HandleFunc("/api/analog_inputs/{id}", c.update).Methods("POST")

--- a/controller/connectors/inlet.go
+++ b/controller/connectors/inlet.go
@@ -31,12 +31,12 @@ type Inlets struct {
 }
 
 func (e *Inlets) LoadAPI(r *controller.DocRouter) {
-	r.HandleFunc("/api/inlets/{id}", e.get).Methods("GET")
-	r.HandleFunc("/api/inlets", e.list).Methods("GET")
-	r.HandleFunc("/api/inlets", e.create).Methods("PUT")
+	r.HandleFunc("/api/inlets/{id}", e.get).Methods("GET").Doc(nil, new(Inlet))
+	r.HandleFunc("/api/inlets", e.list).Methods("GET").Doc(nil, []Inlet{Inlet{}})
+	r.HandleFunc("/api/inlets", e.create).Methods("PUT").Doc(new(Inlet), nil)
 	r.HandleFunc("/api/inlets/{id}", e.delete).Methods("DELETE")
-	r.HandleFunc("/api/inlets/{id}", e.update).Methods("POST")
-	r.HandleFunc("/api/inlets/{id}/read", e.read).Methods("POST")
+	r.HandleFunc("/api/inlets/{id}", e.update).Methods("POST").Doc(new(Inlet), nil)
+	r.HandleFunc("/api/inlets/{id}/read", e.read).Methods("POST").Doc(new(int), nil)
 }
 
 func (i Inlet) inputPin(drivers *drivers.Drivers) (hal.InputPin, error) {

--- a/controller/connectors/inlet.go
+++ b/controller/connectors/inlet.go
@@ -6,9 +6,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/gorilla/mux"
-
 	"github.com/reef-pi/hal"
+	"github.com/reef-pi/reef-pi/controller"
 
 	"github.com/reef-pi/reef-pi/controller/drivers"
 	"github.com/reef-pi/reef-pi/controller/storage"
@@ -31,7 +30,7 @@ type Inlets struct {
 	drivers *drivers.Drivers
 }
 
-func (e *Inlets) LoadAPI(r *mux.Router) {
+func (e *Inlets) LoadAPI(r *controller.DocRouter) {
 	r.HandleFunc("/api/inlets/{id}", e.get).Methods("GET")
 	r.HandleFunc("/api/inlets", e.list).Methods("GET")
 	r.HandleFunc("/api/inlets", e.create).Methods("PUT")

--- a/controller/connectors/jack.go
+++ b/controller/connectors/jack.go
@@ -6,10 +6,9 @@ import (
 
 	"net/http"
 
-	"github.com/gorilla/mux"
-
 	"github.com/reef-pi/hal"
 
+	"github.com/reef-pi/reef-pi/controller"
 	"github.com/reef-pi/reef-pi/controller/drivers"
 	"github.com/reef-pi/reef-pi/controller/storage"
 	"github.com/reef-pi/reef-pi/controller/utils"
@@ -120,7 +119,7 @@ func (c *Jacks) Delete(id string) error {
 	return c.store.Delete(JackBucket, id)
 }
 
-func (c *Jacks) LoadAPI(r *mux.Router) {
+func (c *Jacks) LoadAPI(r *controller.DocRouter) {
 	r.HandleFunc("/api/jacks", c.list).Methods("GET")
 	r.HandleFunc("/api/jacks/{id}", c.get).Methods("GET")
 	r.HandleFunc("/api/jacks", c.create).Methods("PUT")

--- a/controller/connectors/outlet.go
+++ b/controller/connectors/outlet.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/gorilla/mux"
-
 	"github.com/reef-pi/hal"
 
+	"github.com/reef-pi/reef-pi/controller"
 	"github.com/reef-pi/reef-pi/controller/drivers"
 	"github.com/reef-pi/reef-pi/controller/storage"
 	"github.com/reef-pi/reef-pi/controller/utils"
@@ -127,7 +126,7 @@ func (c *Outlets) Get(id string) (Outlet, error) {
 	return o, c.store.Get(OutletBucket, id, &o)
 }
 
-func (e *Outlets) LoadAPI(r *mux.Router) {
+func (e *Outlets) LoadAPI(r *controller.DocRouter) {
 	r.HandleFunc("/api/outlets/{id}", e.get).Methods("GET")
 	r.HandleFunc("/api/outlets", e.list).Methods("GET")
 	r.HandleFunc("/api/outlets", e.create).Methods("PUT")

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1,15 +1,13 @@
 package controller
 
 import (
-	"github.com/gorilla/mux"
-
 	"github.com/reef-pi/reef-pi/controller/storage"
 	"github.com/reef-pi/reef-pi/controller/telemetry"
 )
 
 type Subsystem interface {
 	Setup() error
-	LoadAPI(*mux.Router)
+	LoadAPI(*DocRouter)
 	Start()
 	Stop()
 	On(string, bool) error

--- a/controller/drivers/api.go
+++ b/controller/drivers/api.go
@@ -3,12 +3,11 @@ package drivers
 import (
 	"net/http"
 
-	"github.com/gorilla/mux"
-
+	"github.com/reef-pi/reef-pi/controller"
 	"github.com/reef-pi/reef-pi/controller/utils"
 )
 
-func (d *Drivers) LoadAPI(r *mux.Router) {
+func (d *Drivers) LoadAPI(r *controller.DocRouter) {
 	r.HandleFunc("/api/drivers", d.list).Methods("GET")
 	r.HandleFunc("/api/drivers/{id}", d.get).Methods("GET")
 	r.HandleFunc("/api/drivers", d.create).Methods("PUT")

--- a/controller/modules/ato/api.go
+++ b/controller/modules/ato/api.go
@@ -3,12 +3,11 @@ package ato
 import (
 	"net/http"
 
-	"github.com/gorilla/mux"
-
+	"github.com/reef-pi/reef-pi/controller"
 	"github.com/reef-pi/reef-pi/controller/utils"
 )
 
-func (c *Controller) LoadAPI(r *mux.Router) {
+func (c *Controller) LoadAPI(r *controller.DocRouter) {
 	r.HandleFunc("/api/atos/{id}", c.get).Methods("GET")
 	r.HandleFunc("/api/atos", c.list).Methods("GET")
 	r.HandleFunc("/api/atos", c.create).Methods("PUT")

--- a/controller/modules/camera/api.go
+++ b/controller/modules/camera/api.go
@@ -3,12 +3,11 @@ package camera
 import (
 	"net/http"
 
-	"github.com/gorilla/mux"
-
+	"github.com/reef-pi/reef-pi/controller"
 	"github.com/reef-pi/reef-pi/controller/utils"
 )
 
-func (c *Controller) LoadAPI(r *mux.Router) {
+func (c *Controller) LoadAPI(r *controller.DocRouter) {
 	r.HandleFunc("/api/camera/config", c.get).Methods("GET")
 	r.HandleFunc("/api/camera/config", c.update).Methods("POST")
 	r.HandleFunc("/api/camera/shoot", c.shoot).Methods("POST")

--- a/controller/modules/doser/api.go
+++ b/controller/modules/doser/api.go
@@ -3,12 +3,11 @@ package doser
 import (
 	"net/http"
 
-	"github.com/gorilla/mux"
-
+	"github.com/reef-pi/reef-pi/controller"
 	"github.com/reef-pi/reef-pi/controller/utils"
 )
 
-func (c *Controller) LoadAPI(r *mux.Router) {
+func (c *Controller) LoadAPI(r *controller.DocRouter) {
 	r.HandleFunc("/api/doser/pumps", c.list).Methods("GET")
 	r.HandleFunc("/api/doser/pumps/{id}", c.get).Methods("GET")
 	r.HandleFunc("/api/doser/pumps", c.create).Methods("PUT")

--- a/controller/modules/equipment/api.go
+++ b/controller/modules/equipment/api.go
@@ -3,13 +3,12 @@ package equipment
 import (
 	"net/http"
 
-	"github.com/gorilla/mux"
-
+	"github.com/reef-pi/reef-pi/controller"
 	"github.com/reef-pi/reef-pi/controller/utils"
 )
 
 //API
-func (e *Controller) LoadAPI(r *mux.Router) {
+func (e *Controller) LoadAPI(r *controller.DocRouter) {
 	r.HandleFunc("/api/equipment/{id}", e.GetEquipment).Methods("GET")
 	r.HandleFunc("/api/equipment", e.ListEquipment).Methods("GET")
 	r.HandleFunc("/api/equipment", e.CreateEquipment).Methods("PUT")

--- a/controller/modules/lighting/api.go
+++ b/controller/modules/lighting/api.go
@@ -3,12 +3,11 @@ package lighting
 import (
 	"net/http"
 
-	"github.com/gorilla/mux"
-
+	"github.com/reef-pi/reef-pi/controller"
 	"github.com/reef-pi/reef-pi/controller/utils"
 )
 
-func (c *Controller) LoadAPI(r *mux.Router) {
+func (c *Controller) LoadAPI(r *controller.DocRouter) {
 	r.HandleFunc("/api/lights", c.ListLights).Methods("GET")
 	r.HandleFunc("/api/lights", c.CreateLight).Methods("PUT")
 	r.HandleFunc("/api/lights/{id}", c.GetLight).Methods("GET")

--- a/controller/modules/macro/api.go
+++ b/controller/modules/macro/api.go
@@ -3,12 +3,11 @@ package macro
 import (
 	"net/http"
 
-	"github.com/gorilla/mux"
-
+	"github.com/reef-pi/reef-pi/controller"
 	"github.com/reef-pi/reef-pi/controller/utils"
 )
 
-func (t *Subsystem) LoadAPI(r *mux.Router) {
+func (t *Subsystem) LoadAPI(r *controller.DocRouter) {
 	r.HandleFunc("/api/macros", t.list).Methods("GET")
 	r.HandleFunc("/api/macros", t.create).Methods("PUT")
 	r.HandleFunc("/api/macros/{id}", t.get).Methods("GET")

--- a/controller/modules/ph/api.go
+++ b/controller/modules/ph/api.go
@@ -5,12 +5,11 @@ import (
 
 	"github.com/reef-pi/hal"
 
-	"github.com/gorilla/mux"
-
+	"github.com/reef-pi/reef-pi/controller"
 	"github.com/reef-pi/reef-pi/controller/utils"
 )
 
-func (e *Controller) LoadAPI(r *mux.Router) {
+func (e *Controller) LoadAPI(r *controller.DocRouter) {
 	r.HandleFunc("/api/phprobes/{id}", e.getProbe).Methods("GET")
 	r.HandleFunc("/api/phprobes", e.listProbes).Methods("GET")
 	r.HandleFunc("/api/phprobes", e.createProbe).Methods("PUT")

--- a/controller/modules/system/api.go
+++ b/controller/modules/system/api.go
@@ -6,12 +6,11 @@ import (
 	"net/http"
 	"net/http/pprof"
 
-	"github.com/gorilla/mux"
-
+	"github.com/reef-pi/reef-pi/controller"
 	"github.com/reef-pi/reef-pi/controller/utils"
 )
 
-func (c *Controller) LoadAPI(r *mux.Router) {
+func (c *Controller) LoadAPI(r *controller.DocRouter) {
 	r.HandleFunc("/api/display/on", c.EnableDisplay).Methods("POST")
 	r.HandleFunc("/api/display/off", c.DisableDisplay).Methods("POST")
 	r.HandleFunc("/api/display", c.SetBrightness).Methods("POST")
@@ -25,7 +24,7 @@ func (c *Controller) LoadAPI(r *mux.Router) {
 	}
 }
 
-func (c *Controller) enablePprof(r *mux.Router) {
+func (c *Controller) enablePprof(r *controller.DocRouter) {
 	r.HandleFunc("/debug/pprof/", pprof.Index)
 	r.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
 	r.HandleFunc("/debug/pprof/profile", pprof.Profile)

--- a/controller/modules/temperature/api.go
+++ b/controller/modules/temperature/api.go
@@ -4,12 +4,11 @@ import (
 	"net/http"
 	"path/filepath"
 
-	"github.com/gorilla/mux"
-
+	"github.com/reef-pi/reef-pi/controller"
 	"github.com/reef-pi/reef-pi/controller/utils"
 )
 
-func (t *Controller) LoadAPI(r *mux.Router) {
+func (t *Controller) LoadAPI(r *controller.DocRouter) {
 	r.HandleFunc("/api/tcs", t.list).Methods("GET")
 	r.HandleFunc("/api/tcs/sensors", t.sensors).Methods("GET")
 	r.HandleFunc("/api/tcs", t.create).Methods("PUT")

--- a/controller/modules/timer/api.go
+++ b/controller/modules/timer/api.go
@@ -3,12 +3,11 @@ package timer
 import (
 	"net/http"
 
-	"github.com/gorilla/mux"
-
+	"github.com/reef-pi/reef-pi/controller"
 	"github.com/reef-pi/reef-pi/controller/utils"
 )
 
-func (c *Controller) LoadAPI(r *mux.Router) {
+func (c *Controller) LoadAPI(r *controller.DocRouter) {
 	r.HandleFunc("/api/timers/{id}", c.GetJob).Methods("GET")
 	r.HandleFunc("/api/timers", c.ListJobs).Methods("GET")
 	r.HandleFunc("/api/timers", c.CreateJob).Methods("PUT")

--- a/controller/noop.go
+++ b/controller/noop.go
@@ -1,8 +1,6 @@
 package controller
 
 import (
-	"github.com/gorilla/mux"
-
 	"github.com/reef-pi/reef-pi/controller/storage"
 	"github.com/reef-pi/reef-pi/controller/telemetry"
 )
@@ -10,7 +8,7 @@ import (
 type mockSubsystem struct{}
 
 func (m *mockSubsystem) Setup() error              { return nil }
-func (m *mockSubsystem) LoadAPI(r *mux.Router)     {}
+func (m *mockSubsystem) LoadAPI(r *DocRouter)      {}
 func (m *mockSubsystem) Start()                    {}
 func (m *mockSubsystem) Stop()                     {}
 func (m *mockSubsystem) On(_ string, _ bool) error { return nil }


### PR DESCRIPTION
Add routes with documentations .Doc(req, resp)
```go
 r.HandleFunc("/api/inlets", e.create).Methods("PUT").Doc(nil, new(Inlet))
```
To generate api.txt, invoke set environment variable REEF_PI_LIST_API on startup
```
REEF_PI_LIST_API=1 make start-dev
```
and that will automatically generate
```
   PUT	/api/inlets
Input:
{
 "id": "",
 "name": "",
 "pin": 0,
 "equipment": "",
 "reverse": false,
 "driver": ""
}
```
We'll iterate from here on, by adding Doc calls to in all handler with appropirate req/resp types and then update the documentation format to markdown, or do some more fancy thing (default variable with example data?)