### PR TITLE
(feat) auto api documentation

### DIFF
--- a/controller/utils/doc.go
+++ b/controller/utils/doc.go
@@ -1,0 +1,78 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/gorilla/mux"
+	"log"
+	"os"
+)
+
+type container struct {
+	Req  interface{}
+	Resp interface{}
+}
+
+var (
+	docTypes = make(map[string]map[string]*container)
+)
+
+func APIDoc(r *mux.Route, in, out interface{}) {
+	path, err := r.GetPathTemplate()
+	if err != nil {
+		log.Println("API Doc error:", err)
+		return
+	}
+	mts, err := r.GetMethods()
+	if err != nil {
+		log.Println("API Doc error:", err)
+		return
+	}
+	fmt.Println("Methods:", mts)
+	docs := make(map[string]*container)
+	if ds, ok := docTypes[path]; ok {
+		docs = ds
+	}
+	for _, m := range mts {
+		_, ok := docs[m]
+		if ok {
+			continue
+		}
+		docs[m] = &container{Req: in, Resp: out}
+		break
+	}
+	docTypes[path] = docs
+	log.Println("API Doc path:", path)
+}
+
+func SummarizeAPI() {
+	fi, err := os.Create("api.txt")
+	if err != nil {
+		log.Println("ERROR: Failed to open api.txt file. Error:", err)
+		return
+	}
+	defer fi.Close()
+
+	for path, verbs := range docTypes {
+		fmt.Println("Path", path, "Methods:", verbs)
+		for verb, ct := range verbs {
+			fi.WriteString(fmt.Sprintf("%6s\t%s\n", verb, path))
+			if ct == nil {
+				continue
+			}
+			fmt.Println("data:", path, verb)
+			if ct.Req != nil {
+				fi.WriteString("Input:\n")
+				enc := json.NewEncoder(fi)
+				enc.SetIndent("", " ")
+				enc.Encode(ct.Req)
+			}
+			if ct.Resp != nil {
+				fi.WriteString("Output:\n")
+				enc := json.NewEncoder(fi)
+				enc.SetIndent("", " ")
+				enc.Encode(ct.Resp)
+			}
+		}
+	}
+}

--- a/controller/utils/doc.go
+++ b/controller/utils/doc.go
@@ -3,9 +3,10 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/gorilla/mux"
 	"log"
 	"os"
+
+	"github.com/gorilla/mux"
 )
 
 type container struct {


### PR DESCRIPTION
Add routes with documentations .Doc(req, resp)
```go
 r.HandleFunc("/api/inlets", e.create).Methods("PUT").Doc(nil, new(Inlet))
```
To generate api.txt, invoke set environment variable REEF_PI_LIST_API on startup
```
REEF_PI_LIST_API=1 make start-dev
```
and that will automatically generate
```
   PUT	/api/inlets
Input:
{
 "id": "",
 "name": "",
 "pin": 0,
 "equipment": "",
 "reverse": false,
 "driver": ""
}
```
We'll iterate from here on, by adding Doc calls to in all handler with appropirate req/resp types and then update the documentation format to markdown, or do some more fancy thing (default variable with example data?)

Replacing : https://github.com/reef-pi/reef-pi/pull/753