### PR TITLE
Show current calibration point for temperature

### DIFF
--- a/front-end/assets/translations/en.csv
+++ b/front-end/assets/translations/en.csv
@@ -421,4 +421,4 @@ temperature:calibrate, Calibrate
 temperature:calibration:set_temperature, Set Temperature
 temperature:calibration:apply, Apply
 temperature:current_reading, Current Reading
-temperature:warn_delete: This action will delete
+temperature:warn_delete, This action will delete

--- a/front-end/src/temperature/main.jsx
+++ b/front-end/src/temperature/main.jsx
@@ -107,7 +107,7 @@ class main extends React.Component {
 
   calibrateProbe (e, probe) {
     let defaultValue = ''
-    if(probe.calibration_points && probe.calibration_points[0]) {
+    if (probe.calibration_points && probe.calibration_points[0]) {
       defaultValue = probe.calibration_points[0].expected
     }
 

--- a/front-end/src/temperature/main.jsx
+++ b/front-end/src/temperature/main.jsx
@@ -16,7 +16,8 @@ class main extends React.Component {
     this.state = {
       addProbe: false,
       showCalibrate: false,
-      currentProbe: null
+      currentProbe: null,
+      defaultCalibrationPoint: ''
     }
     this.probeList = this.probeList.bind(this)
     this.handleToggleAddProbeDiv = this.handleToggleAddProbeDiv.bind(this)
@@ -105,7 +106,16 @@ class main extends React.Component {
   }
 
   calibrateProbe (e, probe) {
-    this.setState({ currentProbe: probe, showCalibrate: true })
+    let defaultValue = ''
+    if(probe.calibration_points && probe.calibration_points[0]) {
+      defaultValue = probe.calibration_points[0].expected
+    }
+
+    this.setState({
+      currentProbe: probe,
+      showCalibrate: true,
+      defaultCalibrationPoint: defaultValue
+    })
   }
 
   dismissModal () {
@@ -167,7 +177,7 @@ class main extends React.Component {
         <CalibrationModal
           probe={this.state.currentProbe}
           currentReading={this.props.currentReading}
-          defaultValue={this.props.currentReading[this.state.currentProbe.id]}
+          defaultValue={this.state.defaultCalibrationPoint}
           readProbe={this.props.readTC}
           calibrateProbe={this.props.calibrateProbe}
           cancel={this.dismissModal}


### PR DESCRIPTION
## Description

Defaults the temperature calibration modal to to the existing calibration point if it exists.

## Related Issue
Fixes #884 
