### PR TITLE
pH calibration check frequency

### DIFF
--- a/front-end/src/ph/calibration_wizard.jsx
+++ b/front-end/src/ph/calibration_wizard.jsx
@@ -28,7 +28,7 @@ export default class CalibrationWizard extends React.Component {
   componentDidMount () {
     this.timer = setInterval(() => {
       this.props.readProbe(this.props.probe.id)
-    }, 1000)
+    }, 1500)
   }
 
   componentWillUnmount () {


### PR DESCRIPTION
You probably remember this was changed to 1000ms, that was still too often for the Atlas circuit and errors appeared after 4 minutes of running. The absolute minimum appears to be 1070ms but I think 1500 guarantees there will be no timing issues. I have fully testing 1500ms and it works perfect.

While submitting a PR, please make sure the build is ok with Travis CI. If not fix it, and if you need help feel free to ask :blush: .

<!--- Provide a general summary of your changes in the Title above -->

## Description

`Describe your Pull Request Feature or BugFix`

## Related Issue

`If this PR fixes issues please list them for a better management of issues`

## Motivation and Context

`Describe the reason and the context of the enhancement`

## Screenshots (if appropriate):
