### PR TITLE
Add OpenAPI documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,10 +118,6 @@ race-test:
 spec:
 	swagger generate spec /w ./commands/ -i swagger.yml -o swagger.json -m
 
-.PHONY: serve-swagger
-serve-swagger:
-	swagger serve /flavor:swagger .\swagger.json
-
-.PHONY: serve-doc
-serve-doc:
+.PHONY: serve-spec
+serve-spec:
 	npx redoc-cli serve .\swagger.json -p 8888

--- a/Makefile
+++ b/Makefile
@@ -113,3 +113,15 @@ endif
 .PHONY: race
 race-test:
 	./scripts/race.sh 12
+
+.PHONY: spec
+spec:
+	swagger generate spec /w ./commands/ -i swagger.yml -o swagger.json -m
+
+.PHONY: serve-swagger
+serve-swagger:
+	swagger serve /flavor:swagger .\swagger.json
+
+.PHONY: serve-doc
+serve-doc:
+	npx redoc-cli serve .\swagger.json -p 8888

--- a/commands/doc.go
+++ b/commands/doc.go
@@ -1,0 +1,29 @@
+// Package classification reef-pi.
+//
+// Documentation of reef-pi API.
+//
+//     Schemes: http
+//     BasePath: /
+//     Version: 1.0.0
+//     Host: localhost:8080
+//
+//     Consumes:
+//     - application/json
+//
+//     Produces:
+//     - application/json
+//
+//     Security:
+//     - basic
+//
+//    SecurityDefinitions:
+//    basic:
+//      type: basic
+//
+// swagger:meta
+
+// @openapi:info
+// 	version: 0.0.1
+// 	title: reef-pi
+// 	description: reef-pi API
+package main

--- a/controller/connectors/analog_input.go
+++ b/controller/connectors/analog_input.go
@@ -17,6 +17,7 @@ import (
 
 const AnalogInputBucket = storage.AnalogInputBucket
 
+// swagger:model analogInput
 type AnalogInput struct {
 	ID     string `json:"id"`
 	Name   string `json:"name"`
@@ -116,11 +117,107 @@ func (c *AnalogInputs) Delete(id string) error {
 }
 
 func (c *AnalogInputs) LoadAPI(r *mux.Router) {
+
+	// swagger:route GET /api/analog_inputs AnalogInput analogInputList
+	// List all Analog Inputs.
+	// List all Analog Inputs in reef-pi.
+	// responses:
+	// 	200: body:[]analogInput
+	// 	500:
 	r.HandleFunc("/api/analog_inputs", c.list).Methods("GET")
+
+	// swagger:operation GET /api/analog_inputs/{id} AnalogInput analogInputGet
+	// Get an Analog Input by id.
+	// Get an existing Analog Input.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the analog input
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
+	//   schema:
+	//    $ref: '#/definitions/analogInput'
+	//  404:
+	//   description: Not Found
 	r.HandleFunc("/api/analog_inputs/{id}", c.get).Methods("GET")
+
+	// swagger:operation PUT /api/analog_inuputs AnalogInput analogInputCreate
+	// Create an analog input.
+	// Create a new analog input.
+	// ---
+	// parameters:
+	//  - in: body
+	//    name: analog input
+	//    description: The analog input to create
+	//    required: true
+	//    schema:
+	//     $ref: '#/definitions/analogInput'
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/analog_inputs", c.create).Methods("PUT")
+
+	//swagger:operation POST /api/analog_inputs/{id} AnalogInput analogInputUpdate
+	// Update an Analog Input.
+	// Update an existing Analog Input.
+	//---
+	//parameters:
+	// - in: path
+	//   name: id
+	//   description: The Id of the analog input to update
+	//   required: true
+	//   schema:
+	//    type: integer
+	// - in: body
+	//   name: analog input
+	//   description: The analog input to update
+	//   required: true
+	//   schema:
+	//    $ref: '#/definitions/analogInput'
+	//responses:
+	// 200:
+	//  description: OK
+	// 404:
+	//  description: Not Found
 	r.HandleFunc("/api/analog_inputs/{id}", c.update).Methods("POST")
+
+	// swagger:operation DELETE /api/analog_inputs/{id} AnalogInput analogInputDelete
+	// Delete an Analog Input.
+	// Delete an existing Analog Input.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the analog input to delete
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/analog_inputs/{id}", c.delete).Methods("DELETE")
+
+	// swagger:operation POST /api/analog_inputs/{id}/read AnalogInput analogInputRead
+	// Read an Analog Input.
+	// Read an Analog Input.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the analog input to read
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
+	//  404:
+	//   description: Not Found
 	r.HandleFunc("/api/analog_inputs/{id}/read", c.read).Methods("POST")
 }
 

--- a/controller/connectors/inlet.go
+++ b/controller/connectors/inlet.go
@@ -17,6 +17,7 @@ import (
 
 const InletBucket = storage.InletBucket
 
+// swagger:model inlet
 type Inlet struct {
 	ID        string `json:"id"`
 	Name      string `json:"name"`
@@ -32,11 +33,107 @@ type Inlets struct {
 }
 
 func (e *Inlets) LoadAPI(r *mux.Router) {
+
+	// swagger:operation GET /api/inlets/{id} Inlet inletGet
+	// Get an Inlet by id.
+	// Get an existing Inlet.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the inlet
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
+	//   schema:
+	//    $ref: '#/definitions/inlet'
+	//  404:
+	//   description: Not Found
 	r.HandleFunc("/api/inlets/{id}", e.get).Methods("GET")
+
+	// swagger:route GET /api/inlets Inlet inletList
+	// List all Inlets.
+	// List all inlets in reef-pi.
+	// responses:
+	// 	200: body:[]inlet
 	r.HandleFunc("/api/inlets", e.list).Methods("GET")
+
+	// swagger:operation PUT /api/inlets Inlet inletCreate
+	// Create an Inlet.
+	// Create a new Inlet.
+	// ---
+	// parameters:
+	//  - in: body
+	//    name: inlet
+	//    description: The inlet to create
+	//    required: true
+	//    schema:
+	//     $ref: '#/definitions/inlet'
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/inlets", e.create).Methods("PUT")
+
+	// swagger:operation DELETE /api/inlets/{id} Inlet inletDelete
+	// Delete an Inlet.
+	// Delete an existing Inlet.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the inlet to delete
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/inlets/{id}", e.delete).Methods("DELETE")
+
+	//swagger:operation POST /api/inlets/{id} Inlet inletUpdate
+	//Update an Inlet.
+	//Update an existing Inlet.
+	//
+	//---
+	//parameters:
+	// - in: path
+	//   name: id
+	//   description: The Id of the inlet to update
+	//   required: true
+	//   schema:
+	//    type: integer
+	// - in: body
+	//   name: inlet
+	//   description: The inlet to update
+	//   required: true
+	//   schema:
+	//    $ref: '#/definitions/inlet'
+	//responses:
+	// 200:
+	//  description: OK
+	// 404:
+	//  description: Not Found
 	r.HandleFunc("/api/inlets/{id}", e.update).Methods("POST")
+
+	// swagger:operation POST /api/inlets/{id}/read Inlet inletRead
+	// Read an Inlet.
+	// Read an Inlet.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the inlet to read
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
+	//  404:
+	//   description: Not Found
 	r.HandleFunc("/api/inlets/{id}/read", e.read).Methods("POST")
 }
 

--- a/controller/connectors/jack.go
+++ b/controller/connectors/jack.go
@@ -17,6 +17,7 @@ import (
 
 const JackBucket = storage.JackBucket
 
+// swagger:model jack
 type Jack struct {
 	ID      string `json:"id"`
 	Name    string `json:"name"`
@@ -122,11 +123,112 @@ func (c *Jacks) Delete(id string) error {
 }
 
 func (c *Jacks) LoadAPI(r *mux.Router) {
+
+	// swagger:route GET /api/jacks Jack jackList
+	// List all jacks.
+	// List all jacks in reef-pi.
+	// responses:
+	// 	200: body:[]jack
+	// 	500:
 	r.HandleFunc("/api/jacks", c.list).Methods("GET")
+
+	// swagger:operation GET /api/jacks/{id} Jack jackGet
+	// Get a Jack by id.
+	// Get an existing Jack.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the jack
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
+	//   schema:
+	//    $ref: '#/definitions/jack'
+	//  404:
+	//   description: Not Found
 	r.HandleFunc("/api/jacks/{id}", c.get).Methods("GET")
+
+	// swagger:operation PUT /api/jacks Jack jackCreate
+	// Create a Jack.
+	// Create a new Jack.
+	// ---
+	// parameters:
+	//  - in: body
+	//    name: jack
+	//    description: The jack to create
+	//    required: true
+	//    schema:
+	//     $ref: '#/definitions/jack'
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/jacks", c.create).Methods("PUT")
+
+	//swagger:operation POST /api/jacks/{id} Jack jackUpdate
+	// Update a Jack.
+	// Update an existing Jack.
+	//
+	//---
+	//parameters:
+	// - in: path
+	//   name: id
+	//   description: The Id of the jack to update
+	//   required: true
+	//   schema:
+	//    type: integer
+	// - in: body
+	//   name: jack
+	//   description: The jack to update
+	//   required: true
+	//   schema:
+	//    $ref: '#/definitions/jack'
+	//responses:
+	// 200:
+	//  description: OK
+	// 404:
+	//  description: Not Found
 	r.HandleFunc("/api/jacks/{id}", c.update).Methods("POST")
+
+	// swagger:operation DELETE /api/jacks/{id} Jack jackDelete
+	// Delete a Jack.
+	// Delete an existing Jack.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the jack to delete
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/jacks/{id}", c.delete).Methods("DELETE")
+
+	// swagger:operation POST /api/jacks/{id}/control Jack jackControl
+	// Control a Jack.
+	// Control a Jack.
+	// ---
+	//parameters:
+	// - in: path
+	//   name: id
+	//   description: The Id of the jack to control
+	//   required: true
+	//   schema:
+	//    type: integer
+	// - in: body
+	//   name: jack
+	//   description: The jack to update
+	//   required: true
+	//   schema:
+	//    $ref: '#/definitions/jack'
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/jacks/{id}/control", c.control).Methods("POST")
 }
 

--- a/controller/connectors/outlet.go
+++ b/controller/connectors/outlet.go
@@ -16,6 +16,7 @@ import (
 
 const OutletBucket = storage.OutletBucket
 
+// swagger:model outlet
 type Outlet struct {
 	ID        string `json:"id"`
 	Name      string `json:"name"`
@@ -128,10 +129,89 @@ func (c *Outlets) Get(id string) (Outlet, error) {
 }
 
 func (e *Outlets) LoadAPI(r *mux.Router) {
+
+	// swagger:operation GET /api/outlets/{id} Outlet outletGet
+	// Get an Outlet by id.
+	// Get an existing Outlet.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the outlet
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
+	//   schema:
+	//    $ref: '#/definitions/outlet'
+	//  404:
+	//   description: Not Found
 	r.HandleFunc("/api/outlets/{id}", e.get).Methods("GET")
+
+	// swagger:route GET /api/outlets Outlet outletList
+	// List all Outlets.
+	// List all Outlets in reef-pi.
+	// responses:
+	// 	200: body:[]outlet
+	// 	500:
 	r.HandleFunc("/api/outlets", e.list).Methods("GET")
+
+	// swagger:operation PUT /api/outlets Outlet outletCreate
+	// Create an Outlet.
+	// Create a new Outlet.
+	// ---
+	// parameters:
+	//  - in: body
+	//    name: outlet
+	//    description: The outlet to create
+	//    required: true
+	//    schema:
+	//     $ref: '#/definitions/outlet'
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/outlets", e.create).Methods("PUT")
+
+	// swagger:operation DELETE /api/outlets/{id} Outlet outletDelete
+	// Delete an Outlet.
+	// Delete an existing Outlet.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the outlet to delete
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/outlets/{id}", e.delete).Methods("DELETE")
+
+	// swagger:operation POST /api/outlets/{id} Outlet outletUpdate
+	// Update an Outlet.
+	// Update an existing Outlet.
+	//---
+	//parameters:
+	// - in: path
+	//   name: id
+	//   description: The Id of the outlet to update
+	//   required: true
+	//   schema:
+	//    type: integer
+	// - in: body
+	//   name: outlet
+	//   description: The outlet to update
+	//   required: true
+	//   schema:
+	//    $ref: '#/definitions/outlet'
+	//responses:
+	// 200:
+	//  description: OK
+	// 404:
+	//  description: Not Found
 	r.HandleFunc("/api/outlets/{id}", e.update).Methods("POST")
 }
 func (c *Outlets) get(w http.ResponseWriter, r *http.Request) {

--- a/controller/daemon/api.go
+++ b/controller/daemon/api.go
@@ -1,12 +1,13 @@
 package daemon
 
 import (
-	"github.com/gorilla/mux"
-	"github.com/reef-pi/reef-pi/controller/settings"
-	"github.com/reef-pi/reef-pi/controller/utils"
 	"log"
 	"net/http"
 	"os"
+
+	"github.com/gorilla/mux"
+	"github.com/reef-pi/reef-pi/controller/settings"
+	"github.com/reef-pi/reef-pi/controller/utils"
 )
 
 var DefaultCredentials = utils.Credentials{
@@ -47,21 +48,143 @@ func (r *ReefPi) UnAuthenticatedAPI(router *mux.Router) {
 func (r *ReefPi) AuthenticatedAPI(router *mux.Router) {
 	http.Handle("/api/", r.a.Authenticate(router.ServeHTTP))
 
+	// swagger:route GET /api/capabilities Capabilities capabilitiesList
+	// List all capabilities.
+	// List all capabilities in reef-pi.
+	// responses:
+	// 	200: body:capabilities
 	router.HandleFunc("/api/capabilities", r.GetCapabilities).Methods("GET")
+
 	for _, sController := range r.subsystems {
 		sController.LoadAPI(router)
 	}
+
+	// swagger:route GET /api/settings Settings settingsList
+	// List all settings.
+	// List all settings in reef-pi.
+	// responses:
+	// 	200: body:settings
 	utils.APIDoc(router.HandleFunc("/api/settings", r.GetSettings).Methods("GET"), nil, &settings.DefaultSettings)
+
+	// swagger:operation POST /api/settings Settings settingsUpdate
+	// Update settings.
+	// Update settings.
+	//---
+	//parameters:
+	// - in: body
+	//   name: settings
+	//   description: The settings to update
+	//   required: true
+	//   schema:
+	//    $ref: '#/definitions/settings'
+	//responses:
+	// 200:
+	//  description: OK
 	router.HandleFunc("/api/settings", r.UpdateSettings).Methods("POST")
+
+	// swagger:operation POST /api/credentials Credentials credentialsUpdate
+	// Update credentials.
+	// Update username and password.
+	//---
+	//parameters:
+	// - in: body
+	//   name: credentials
+	//   description: The new credentials
+	//   required: true
+	//   schema:
+	//    $ref: '#/definitions/credentials'
+	//responses:
+	// 200:
+	//  description: OK
 	router.HandleFunc("/api/credentials", r.a.UpdateCredentials).Methods("POST")
+
+	// swagger:route GET /api/telemetry Telemetry telemetryGet
+	// List telemetry configuration.
+	// List telemetry configuration.
+	// responses:
+	// 	200: body:telemetryConfig
 	router.HandleFunc("/api/telemetry", r.telemetry.GetConfig).Methods("GET")
+
+	// swagger:operation POST /api/telemetry Telemetry telemetryUpdate
+	// Update telemetry configuration.
+	// Update telemetry configuration.
+	//---
+	//parameters:
+	// - in: body
+	//   name: telemetryConfig
+	//   description: The telemetry configuration
+	//   required: true
+	//   schema:
+	//    $ref: '#/definitions/telemetryConfig'
+	//responses:
+	// 200:
+	//  description: OK
 	router.HandleFunc("/api/telemetry", r.telemetry.UpdateConfig).Methods("POST")
+
+	// swagger:route POST /api/telemetry/test_message Telemetry telemetryTest
+	// Test telemetry.
+	// Send a telemetry test message.
+	// responses:
+	//  200:
 	router.HandleFunc("/api/telemetry/test_message", r.telemetry.SendTestMessage).Methods("POST")
+
+	// swagger:route DELETE /api/errors/clear Errors errorsClear
+	// Clear errors.
+	// Clear errors.
+	// responses:
+	//  200:
 	router.HandleFunc("/api/errors/clear", r.clearErrors).Methods("DELETE")
+
+	// swagger:operation DELETE /api/errors/{id} Errors errorsDelete
+	// Delete an error.
+	// Delete an error.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the error to delete
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
 	router.HandleFunc("/api/errors/{id}", r.deleteError).Methods("DELETE")
+
+	// swagger:operation GET /api/errors/{id} Errors errorGet
+	// Get an error by id.
+	// Get an existing error.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the error
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
+	//   schema:
+	//    $ref: '#/definitions/error'
+	//  404:
+	//   description: Not Found
 	router.HandleFunc("/api/errors/{id}", r.getError).Methods("GET")
+
+	// swagger:route GET /api/errors Errors errorsList
+	// List errors.
+	// List errors.
+	// responses:
+	// 	200: body:[]error
 	router.HandleFunc("/api/errors", r.listErrors).Methods("GET")
+
+	// swagger:route GET /api/me Me meGet
+	// Ping API.
+	// Ping API to determine if server is running.
+	// responses:
+	// 	200:
 	router.HandleFunc("/api/me", r.a.Me).Methods("GET")
+
 	if r.h != nil {
 		router.HandleFunc("/api/health_stats", r.h.GetStats).Methods("GET")
 	}
@@ -70,7 +193,28 @@ func (r *ReefPi) AuthenticatedAPI(router *mux.Router) {
 		sController.LoadAPI(router)
 	}
 	if r.settings.Capabilities.Dashboard {
+
+		// swagger:route GET /api/dashboard Dashboard dashboardGet
+		// Get dashboard.
+		// Get dashboard.
+		// responses:
+		// 	200: body:dashboard
 		router.HandleFunc("/api/dashboard", r.GetDashboard).Methods("GET")
+
+		// swagger:operation POST /api/dashboard Dashboard dashboardUpdate
+		// Update dasboard configuration.
+		// Update dasboard configuration.
+		//---
+		//parameters:
+		// - in: body
+		//   name: dashboardConfiguration
+		//   description: The dashboard configuration
+		//   required: true
+		//   schema:
+		//    $ref: '#/definitions/dashboard'
+		//responses:
+		// 200:
+		//  description: OK
 		router.HandleFunc("/api/dashboard", r.UpdateDashboard).Methods("POST")
 	}
 }

--- a/controller/daemon/dashboard.go
+++ b/controller/daemon/dashboard.go
@@ -8,6 +8,7 @@ import (
 	"github.com/reef-pi/reef-pi/controller/utils"
 )
 
+//swagger:model dashboard
 type Dashboard struct {
 	Column      int       `json:"column"`
 	Row         int       `json:"row"`

--- a/controller/daemon/error.go
+++ b/controller/daemon/error.go
@@ -10,6 +10,7 @@ import (
 	"github.com/reef-pi/reef-pi/controller/utils"
 )
 
+//swagger:model error
 type Error struct {
 	Message string `json:"message"`
 	Time    string `json:"time"`

--- a/controller/drivers/api.go
+++ b/controller/drivers/api.go
@@ -11,12 +11,139 @@ import (
 )
 
 func (d *Drivers) LoadAPI(r *mux.Router) {
+
+	// swagger:route GET /api/drivers Driver driverList
+	// List all Drivers.
+	// List all Drivers in reef-pi.
+	// responses:
+	// 	200: body:[]driver
+	// 	500:
 	r.HandleFunc("/api/drivers", d.list).Methods("GET")
+
+	// swagger:operation GET /api/drivers/options Driver driverListOptions
+	// Get driver parametres
+	// List all drivers with configuration options.
+	// ---
+	// responses:
+	//  200:
+	//   description: Map of drivers and parameters
+	//   schema:
+	//    type: object
+	//    additionalProperties:
+	//     type: array
+	//     items:
+	//      type: object
+	//      properties:
+	//       name:
+	//        type: string
+	//        example: address
+	//        description: The name of the parameter
+	//       type:
+	//        type: string
+	//        example: string
+	//        description: The data type of the parameter
+	//       order:
+	//        type: integer
+	//        example: 1
+	//        description: The order in which to display the parameter
+	//       default:
+	//        type: object
+	//        example: 192.168.1.23:9999
+	//        description: The recommended default value
 	r.HandleFunc("/api/drivers/options", d.listOptions).Methods("GET")
+
+	// swagger:operation GET /api/drivers/{id} Driver driverGet
+	// Get a driver by id.
+	// Get an existing driver.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the driver
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
+	//   schema:
+	//    $ref: '#/definitions/driver'
+	//  404:
+	//   description: Not Found
 	r.HandleFunc("/api/drivers/{id:[0-9]+}", d.get).Methods("GET")
+
+	// swagger:operation PUT /api/drivers Driver driverCreate
+	// Create a Driver.
+	// Create a new Driver.
+	// ---
+	// parameters:
+	//  - in: body
+	//    name: driver
+	//    description: The driver to create
+	//    required: true
+	//    schema:
+	//     $ref: '#/definitions/driver'
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/drivers", d.create).Methods("PUT")
+
+	// swagger:operation DELETE /api/drivers/{id} Driver driverDelete
+	// Delete an Driver.
+	// Delete an existing Driver.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the driver to delete
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/drivers/{id}", d.delete).Methods("DELETE")
+
+	// swagger:operation POST /api/drivers/{id} Driver driverUpdate
+	// Update a Driver.
+	// Update an existing Driver.
+	//---
+	//parameters:
+	// - in: path
+	//   name: id
+	//   description: The Id of the driver to update
+	//   required: true
+	//   schema:
+	//    type: integer
+	// - in: body
+	//   name: driver
+	//   description: The driver to update
+	//   required: true
+	//   schema:
+	//    $ref: '#/definitions/driver'
+	//responses:
+	// 200:
+	//  description: OK
+	// 404:
+	//  description: Not Found
 	r.HandleFunc("/api/drivers/{id:[0-9]+}", d.update).Methods("POST")
+
+	// swagger:operation POST /api/drivers/validate Driver driverValidate
+	// Validate a driver configuration.
+	// Validate a driver configuration.
+	//---
+	//parameters:
+	// - in: body
+	//   name: outlet
+	//   description: The driver to validate
+	//   required: true
+	//   schema:
+	//    $ref: '#/definitions/driver'
+	//responses:
+	// 200:
+	//  description: OK
+	// 400:
+	//  description: Not Valid
 	r.HandleFunc("/api/drivers/validate", d.validate).Methods("POST")
 }
 

--- a/controller/drivers/main.go
+++ b/controller/drivers/main.go
@@ -18,6 +18,7 @@ const (
 	_rpi         = "rpi"
 )
 
+// swagger:model driver
 type Driver struct {
 	ID         string                 `json:"id"`
 	Name       string                 `json:"name"`

--- a/controller/modules/ato/api.go
+++ b/controller/modules/ato/api.go
@@ -9,20 +9,117 @@ import (
 )
 
 func (c *Controller) LoadAPI(r *mux.Router) {
+
+	// swagger:operation GET /api/atos/{id} ATO atoGet
+	// Get an ATO by id.
+	// Get an existing ATO.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the ATO
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
+	//   schema:
+	//    $ref: '#/definitions/ato'
+	//  404:
+	//   description: Not Found
 	r.HandleFunc("/api/atos/{id}", c.get).Methods("GET")
+
+	// swagger:route GET /api/atos ATO atoList
+	// List all ATOs.
+	// List all ATOs in reef-pi.
+	// responses:
+	// 	200: body:[]ato
 	r.HandleFunc("/api/atos", c.list).Methods("GET")
+
+	// swagger:operation PUT /api/atos ATO atoCreate
+	// Create an ATO.
+	// Create a new ATO.
+	// ---
+	// parameters:
+	//  - in: body
+	//    name: ato
+	//    description: The ato to create
+	//    required: true
+	//    schema:
+	//     $ref: '#/definitions/ato'
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/atos", c.create).Methods("PUT")
+
+	// swagger:operation POST /api/atos/{id} ATO atoUpdate
+	// Update an ATO.
+	// Update an existing ATO.
+	//---
+	//parameters:
+	// - in: path
+	//   name: id
+	//   description: The Id of the ato to update
+	//   required: true
+	//   schema:
+	//    type: integer
+	// - in: body
+	//   name: ato
+	//   description: The ato to update
+	//   required: true
+	//   schema:
+	//    $ref: '#/definitions/ato'
+	//responses:
+	// 200:
+	//  description: OK
+	// 404:
+	//  description: Not Found
 	r.HandleFunc("/api/atos/{id}", c.update).Methods("POST")
+
+	// swagger:operation DELETE /api/atos/{id} ATO atoDelete
+	// Delete an ATO.
+	// Delete an existing ATO.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the ato to delete
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/atos/{id}", c.delete).Methods("DELETE")
+
+	// swagger:operation GET /api/atos/{id}/usage ATO atoUsage
+	// Get usage history.
+	// Get usage history for a given ATO.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the ato
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
+	//  404:
+	//   description: Not Found
 	r.HandleFunc("/api/atos/{id}/usage", c.getUsage).Methods("GET")
 }
 
 func (c *Controller) get(w http.ResponseWriter, r *http.Request) {
+
 	fn := func(id string) (interface{}, error) {
 		return c.Get(id)
 	}
 	utils.JSONGetResponse(fn, w, r)
 }
+
 func (c Controller) list(w http.ResponseWriter, r *http.Request) {
 	fn := func() (interface{}, error) {
 		return c.List()

--- a/controller/modules/ato/ato.go
+++ b/controller/modules/ato/ato.go
@@ -14,6 +14,7 @@ type Notify struct {
 	Max    int  `json:"max"`
 }
 
+// swagger:model ato
 type ATO struct {
 	ID             string        `json:"id"`
 	IsMacro        bool          `json:"is_macro"`

--- a/controller/modules/ato/doc.go
+++ b/controller/modules/ato/doc.go
@@ -1,0 +1,13 @@
+package ato
+
+// A BodyParams model for ATO.
+//
+// This is used for operations that want an ATO as body of the request
+// swagger:parameters atoCreate atoUpdate
+type BodyParams struct {
+	// The ATO to submit.
+	//
+	// in: body
+	// required: true
+	ATO *ATO `json:"ato"`
+}

--- a/controller/modules/camera/api.go
+++ b/controller/modules/camera/api.go
@@ -9,10 +9,49 @@ import (
 )
 
 func (c *Controller) LoadAPI(r *mux.Router) {
+
+	// swagger:route GET /api/camera/config Camera cameraConfig
+	// Get the camera configuration.
+	// Get the camera configuration.
+	// responses:
+	// 	200: body:cameraConfig
 	r.HandleFunc("/api/camera/config", c.get).Methods("GET")
+
+	// swagger:operation POST /api/camera/config Camera cameraConfig
+	// Save camera configuration.
+	// Save camera configuration.
+	// ---
+	// parameters:
+	//  - in: body
+	//    name: config
+	//    description: camera configuration
+	//    required: true
+	//    schema:
+	//     $ref: '#/definitions/cameraConfig'
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/camera/config", c.update).Methods("POST")
+
+	// swagger:route POST /api/camera/shoot Camera cameraConfig
+	// Shoot a picture.
+	// Shoot a picture.
+	// responses:
+	// 	200:
 	r.HandleFunc("/api/camera/shoot", c.shoot).Methods("POST")
+
+	// swagger:route GET /api/camera/latest Camera cameraLatest
+	// Get latest picture.
+	// Get latest picture.
+	// responses:
+	// 	200:
 	r.HandleFunc("/api/camera/latest", c.latest).Methods("GET")
+
+	// swagger:route GET /api/camera/list Camera cameraList
+	// List images.
+	// List all images.
+	// responses:
+	// 	200:
 	r.HandleFunc("/api/camera/list", c.list).Methods("GET")
 
 }

--- a/controller/modules/camera/config.go
+++ b/controller/modules/camera/config.go
@@ -16,6 +16,7 @@ type MotionConfig struct {
 	Height int    `json:"height"`
 }
 
+// swagger:model cameraConfig
 type Config struct {
 	Enable         bool          `json:"enable"`
 	ImageDirectory string        `json:"image_directory"`

--- a/controller/modules/doser/api.go
+++ b/controller/modules/doser/api.go
@@ -9,13 +9,154 @@ import (
 )
 
 func (c *Controller) LoadAPI(r *mux.Router) {
+
+	// swagger:route GET /api/doser/pumps Doser doserList
+	// List all dosers.
+	// List all dosers in reef-pi.
+	// responses:
+	// 	200: body:[]pump
 	r.HandleFunc("/api/doser/pumps", c.list).Methods("GET")
+
+	// swagger:operation GET /api/doser/pumps/{id} Doser doserGet
+	// Get a doser by id.
+	// Get an existing doser.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the doser
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
+	//   schema:
+	//    $ref: '#/definitions/pump'
+	//  404:
+	//   description: Not Found
 	r.HandleFunc("/api/doser/pumps/{id}", c.get).Methods("GET")
+
+	// swagger:operation PUT /api/doser/pumps Doser doserCreate
+	// Create a doser.
+	// Create a new doser.
+	// ---
+	// parameters:
+	//  - in: body
+	//    name: doser
+	//    description: The doser to create
+	//    required: true
+	//    schema:
+	//     $ref: '#/definitions/pump'
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/doser/pumps", c.create).Methods("PUT")
+
+	// swagger:operation POST /api/doser/pumps/{id} Doser doserUpdate
+	// Update a doser.
+	// Update an existing doser.
+	//---
+	//parameters:
+	// - in: path
+	//   name: id
+	//   description: The Id of the doser to update
+	//   required: true
+	//   schema:
+	//    type: integer
+	// - in: body
+	//   name: doser
+	//   description: The doser to update
+	//   required: true
+	//   schema:
+	//    $ref: '#/definitions/pump'
+	//responses:
+	// 200:
+	//  description: OK
+	// 404:
+	//  description: Not Found
 	r.HandleFunc("/api/doser/pumps/{id}", c.update).Methods("POST")
+
+	// swagger:operation DELETE /api/doser/pumps/{id} Doser doserDelete
+	// Delete a doser.
+	// Delete an existing doser.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the doser to delete
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/doser/pumps/{id}", c.delete).Methods("DELETE")
+
+	// swagger:operation GET /api/doser/pumps/{id}/usage Doser doserUsage
+	// Get usage history.
+	// Get usage history for a given Doser.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the doser
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
+	//  404:
+	//   description: Not Found
 	r.HandleFunc("/api/doser/pumps/{id}/usage", c.getUsage).Methods("GET")
+
+	// swagger:operation POST /api/doser/pumps/{id}/calibrate Doser doserCalibrate
+	// Calibrate a doser.
+	// Calibrate a doser.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the doser
+	//    required: true
+	//    schema:
+	//     type: integer
+	//  - in: body
+	//    name:
+	//    description:
+	//    required: true
+	//    schema:
+	//     $ref: '#/definitions/doserCalibrationDetails'
+	// responses:
+	//  200:
+	//   description: OK
+	//  404:
+	//   description: Not Found
 	r.HandleFunc("/api/doser/pumps/{id}/calibrate", c.calibrate).Methods("POST")
+
+	// swagger:operation POST /api/doser/pumps/{id}/schedule Doser doserSchedule
+	// Schedule dosing.
+	// Schedule dosing.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the doser
+	//    required: true
+	//    schema:
+	//     type: integer
+	//  - in: body
+	//    name:
+	//    description:
+	//    required: true
+	//    schema:
+	//     $ref: '#/definitions/dosingRegiment'
+	// responses:
+	//  200:
+	//   description: OK
+	//  404:
+	//   description: Not Found
 	r.HandleFunc("/api/doser/pumps/{id}/schedule", c.schedule).Methods("POST")
 }
 

--- a/controller/modules/doser/pump.go
+++ b/controller/modules/doser/pump.go
@@ -11,6 +11,7 @@ import (
 	"github.com/reef-pi/reef-pi/controller/telemetry"
 )
 
+// swagger:model pump
 type Pump struct {
 	ID       string         `json:"id"`
 	Name     string         `json:"name"`

--- a/controller/modules/doser/types.go
+++ b/controller/modules/doser/types.go
@@ -6,6 +6,7 @@ import (
 	cron "github.com/robfig/cron/v3"
 )
 
+//swagger:model dosingRegiment
 type DosingRegiment struct {
 	Enable   bool     `json:"enable"`
 	Schedule Schedule `json:"schedule"`
@@ -13,6 +14,7 @@ type DosingRegiment struct {
 	Speed    float64  `json:"speed"`
 }
 
+//swagger:model doserCalibrationDetails
 type CalibrationDetails struct {
 	Speed    float64 `json:"speed"`
 	Duration float64 `json:"duration"`

--- a/controller/modules/equipment/api.go
+++ b/controller/modules/equipment/api.go
@@ -10,14 +10,114 @@ import (
 
 //API
 func (e *Controller) LoadAPI(r *mux.Router) {
+
+	// swagger:operation GET /api/equipment/{id} Equipment equipmentGet
+	// Get an equipment by id.
+	// Get an existing equipment by id.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the equipment
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
+	//   schema:
+	//    $ref: '#/definitions/equipment'
+	//  404:
+	//   description: Not Found
 	r.HandleFunc("/api/equipment/{id}", e.GetEquipment).Methods("GET")
+
+	// swagger:route GET /api/equipment Equipment equipmentList
+	// List all equipment.
+	// List all equipment in reef-pi.
+	// responses:
+	// 	200: body:[]equipment
 	r.HandleFunc("/api/equipment", e.ListEquipment).Methods("GET")
+
+	// swagger:operation PUT /api/equipment Equipment equipmentCreate
+	// Create an equipment.
+	// Create a new equipment.
+	// ---
+	// parameters:
+	//  - in: body
+	//    name: equipment
+	//    description: The equipment to create
+	//    required: true
+	//    schema:
+	//     $ref: '#/definitions/equipment'
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/equipment", e.CreateEquipment).Methods("PUT")
+
+	// swagger:operation POST /api/equipment Equipment equipmentUpdate
+	// Update an equipment.
+	// Update an existing equipment.
+	//---
+	//parameters:
+	// - in: path
+	//   name: id
+	//   description: The Id of the equipment to update
+	//   required: true
+	//   schema:
+	//    type: integer
+	// - in: body
+	//   name: equipment
+	//   description: The equipment to update
+	//   required: true
+	//   schema:
+	//    $ref: '#/definitions/equipment'
+	//responses:
+	// 200:
+	//  description: OK
+	// 404:
+	//  description: Not Found
 	r.HandleFunc("/api/equipment/{id}", e.UpdateEquipment).Methods("POST")
+
+	// swagger:operation DELETE /api/equipment/{id} Equipment equipmentDelete
+	// Delete an equipment.
+	// Delete an existing equipment.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the equipment to delete
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/equipment/{id}", e.DeleteEquipment).Methods("DELETE")
+
+	// swagger:operation POST /api/equipment/{id}/control Equipment equipmentControl
+	// Control an equipment.
+	// Control an equipment.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the equipment to control
+	//    required: true
+	//    schema:
+	//     type: integer
+	//  - in: body
+	//    name: action
+	//    description: The action to take
+	//    required: true
+	//    schema:
+	//     $ref: '#/definitions/equipmentAction'
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/equipment/{id}/control", e.control).Methods("POST")
 }
 
+//swagger:model equipmentAction
 type EquipmentAction struct {
 	On bool `json:"on"`
 }

--- a/controller/modules/equipment/equipment.go
+++ b/controller/modules/equipment/equipment.go
@@ -9,6 +9,7 @@ import (
 
 const Bucket = storage.EquipmentBucket
 
+//swagger:model equipment
 type Equipment struct {
 	ID     string `json:"id"`
 	Name   string `json:"name"`

--- a/controller/modules/lighting/api.go
+++ b/controller/modules/lighting/api.go
@@ -9,10 +9,88 @@ import (
 )
 
 func (c *Controller) LoadAPI(r *mux.Router) {
+
+	// swagger:route GET /api/lights Lights lightsList
+	// List all lights.
+	// List all lights in reef-pi.
+	// responses:
+	// 	200: body:[]light
 	r.HandleFunc("/api/lights", c.ListLights).Methods("GET")
+
+	// swagger:operation PUT /api/lights Lights lightsCreate
+	// Create a light.
+	// Create a new light.
+	// ---
+	// parameters:
+	//  - in: body
+	//    name: light
+	//    description: The light to create
+	//    required: true
+	//    schema:
+	//     $ref: '#/definitions/light'
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/lights", c.CreateLight).Methods("PUT")
+
+	// swagger:operation GET /api/lights/{id} Lights lightsGet
+	// Get a light by id.
+	// Get an existing light by id.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the light
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
+	//   schema:
+	//    $ref: '#/definitions/light'
+	//  404:
+	//   description: Not Found
 	r.HandleFunc("/api/lights/{id}", c.GetLight).Methods("GET")
+
+	// swagger:operation POST /api/lights Lights lightUpdate
+	// Update a light.
+	// Update an existing light.
+	//---
+	//parameters:
+	// - in: path
+	//   name: id
+	//   description: The Id of the light to update
+	//   required: true
+	//   schema:
+	//    type: integer
+	// - in: body
+	//   name: light
+	//   description: The light to update
+	//   required: true
+	//   schema:
+	//    $ref: '#/definitions/light'
+	//responses:
+	// 200:
+	//  description: OK
+	// 404:
+	//  description: Not Found
 	r.HandleFunc("/api/lights/{id}", c.UpdateLight).Methods("POST")
+
+	// swagger:operation DELETE /api/light/{id} Lights lightDelete
+	// Delete a light.
+	// Delete an existing light.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the light to delete
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/lights/{id}", c.DeleteLight).Methods("DELETE")
 }
 

--- a/controller/modules/lighting/channel.go
+++ b/controller/modules/lighting/channel.go
@@ -7,6 +7,7 @@ import (
 	"github.com/reef-pi/reef-pi/controller/pwm_profile"
 )
 
+//swagger:model channel
 type Channel struct {
 	Name        string                  `json:"name"`
 	On          bool                    `json:"on"`

--- a/controller/modules/macro/api.go
+++ b/controller/modules/macro/api.go
@@ -2,19 +2,132 @@ package macro
 
 import (
 	"errors"
-	"github.com/gorilla/mux"
 	"net/http"
+
+	"github.com/gorilla/mux"
 
 	"github.com/reef-pi/reef-pi/controller/utils"
 )
 
 func (t *Subsystem) LoadAPI(r *mux.Router) {
+
+	// swagger:route GET /api/macros Macros macroList
+	// List all macros.
+	// List all macros in reef-pi.
+	// responses:
+	// 	200: body:[]macro
 	r.HandleFunc("/api/macros", t.list).Methods("GET")
+
+	// swagger:operation PUT /api/macros Macros macroCreate
+	// Create a macro.
+	// Create a new macro.
+	// ---
+	// parameters:
+	//  - in: body
+	//    name: macro
+	//    description: The macro to create
+	//    required: true
+	//    schema:
+	//     $ref: '#/definitions/macro'
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/macros", t.create).Methods("PUT")
+
+	// swagger:operation GET /api/macros/{id} Macros macroGet
+	// Get a macro by id.
+	// Get an existing macro by id.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the macro
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
+	//   schema:
+	//    $ref: '#/definitions/macro'
+	//  404:
+	//   description: Not Found
 	r.HandleFunc("/api/macros/{id}", t.get).Methods("GET")
+
+	// swagger:operation POST /api/macros/{id} Macros macroUpdate
+	// Update a macro.
+	// Update an existing macro.
+	//---
+	//parameters:
+	// - in: path
+	//   name: id
+	//   description: The Id of the macro to update
+	//   required: true
+	//   schema:
+	//    type: integer
+	// - in: body
+	//   name: macro
+	//   description: The macro to update
+	//   required: true
+	//   schema:
+	//    $ref: '#/definitions/macro'
+	//responses:
+	// 200:
+	//  description: OK
+	// 404:
+	//  description: Not Found
 	r.HandleFunc("/api/macros/{id}", t.update).Methods("POST")
+
+	// swagger:operation DELETE /api/macros/{id} Macros macroDelete
+	// Delete a macro.
+	// Delete an existing macro.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the macro to delete
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/macros/{id}", t.delete).Methods("DELETE")
+
+	// swagger:operation POST /api/macros/{id}/run Macros macroRun
+	// Run a macro.
+	// Run a macro.
+	//---
+	//parameters:
+	// - in: path
+	//   name: id
+	//   description: The Id of the macro to run
+	//   required: true
+	//   schema:
+	//    type: integer
+	//responses:
+	// 200:
+	//  description: OK
+	// 404:
+	//  description: Not Found
 	r.HandleFunc("/api/macros/{id}/run", t.run).Methods("POST")
+
+	// swagger:operation POST /api/macros/{id}/revert Macros macroRevert
+	// Reverse a macro.
+	// Revert a macro in reverse.
+	//---
+	//parameters:
+	// - in: path
+	//   name: id
+	//   description: The Id of the macro to revert
+	//   required: true
+	//   schema:
+	//    type: integer
+	//responses:
+	// 200:
+	//  description: OK
+	// 404:
+	//  description: Not Found
 	r.HandleFunc("/api/macros/{id}/revert", t.revert).Methods("POST")
 }
 

--- a/controller/modules/macro/macro.go
+++ b/controller/modules/macro/macro.go
@@ -6,6 +6,7 @@ import (
 	"log"
 )
 
+//swagger:model macro
 type Macro struct {
 	ID         string `json:"id"`
 	Name       string `json:"name"`

--- a/controller/modules/ph/api.go
+++ b/controller/modules/ph/api.go
@@ -40,7 +40,7 @@ func (e *Controller) LoadAPI(r *mux.Router) {
 	r.HandleFunc("/api/phprobes", e.listProbes).Methods("GET")
 
 	// swagger:operation PUT /api/phprobes PhProbes phProbeCreate
-	// Create an ph probe.
+	// Create a ph probe.
 	// Create a new ph probe.
 	// ---
 	// parameters:
@@ -112,8 +112,76 @@ func (e *Controller) LoadAPI(r *mux.Router) {
 	//   schema:
 	//    $ref: '#/definitions/statsResponse'
 	r.HandleFunc("/api/phprobes/{id}/readings", e.getReadings).Methods("GET")
+
+	// swagger:operation POST /api/phprobes/{id}/calibrate PhProbes phProbeCalibrate
+	// Calibrate a ph probe.
+	// Set calibration points for one or two point calibration
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the ph probe to calibrate
+	//    required: true
+	//    schema:
+	//     type: integer
+	//  - in: body
+	//    name: measurements
+	//    description: The calibration measurements
+	//    required: true
+	//    schema:
+	//     type: array
+	//     items:
+	//      type: object
+	//      properties:
+	//       expected:
+	//        type: float64
+	//        format: float
+	//        description: The expected value
+	//       observed:
+	//        type: float64
+	//        format: float
+	//        description: The actual value observed
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/phprobes/{id}/calibrate", e.calibrate).Methods("POST")
+
+	// swagger:operation GET /api/phprobes/{id}/read PhProbes phProbeRead
+	// Get ph probe reading.
+	// Get ph probe reading.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the ph probe to read
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/phprobes/{id}/read", e.read).Methods("GET")
+
+	// swagger:operation POST /api/phprobes/{id}/calibratepoint PhProbes phProbeCalibrateSingle
+	// Calibrate a ph probe.
+	// Set a calibration point for one or two point calibration
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the ph probe to calibrate
+	//    required: true
+	//    schema:
+	//     type: integer
+	//  - in: body
+	//    name: measurements
+	//    description: The calibration measurement
+	//    required: true
+	//    schema:
+	//     $ref: '#/definitions/calibrationPoint'
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/phprobes/{id}/calibratepoint", e.calibratePoint).Methods("POST")
 }
 

--- a/controller/modules/ph/api.go
+++ b/controller/modules/ph/api.go
@@ -11,11 +11,106 @@ import (
 )
 
 func (e *Controller) LoadAPI(r *mux.Router) {
+
+	// swagger:operation GET /api/phprobes/{id} PhProbes phProbeGet
+	// Get an ph probe by id.
+	// Get an existing ph probe by id.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the ph probe
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
+	//   schema:
+	//    $ref: '#/definitions/phProbe'
+	//  404:
+	//   description: Not Found
 	r.HandleFunc("/api/phprobes/{id}", e.getProbe).Methods("GET")
+
+	// swagger:route GET /api/phprobes PhProbes phProbeList
+	// List all ph probes.
+	// List all ph probes in reef-pi.
+	// responses:
+	// 	200: body:[]phProbe
 	r.HandleFunc("/api/phprobes", e.listProbes).Methods("GET")
+
+	// swagger:operation PUT /api/phprobes PhProbes phProbeCreate
+	// Create an ph probe.
+	// Create a new ph probe.
+	// ---
+	// parameters:
+	//  - in: body
+	//    name: phProbe
+	//    description: The ph probe to create
+	//    required: true
+	//    schema:
+	//     $ref: '#/definitions/phProbe'
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/phprobes", e.createProbe).Methods("PUT")
+
+	// swagger:operation POST /api/phprobes/{id} PhProbes phProbeUpdate
+	// Update a ph probe.
+	// Update an existing ph probe.
+	//---
+	//parameters:
+	// - in: path
+	//   name: id
+	//   description: The Id of the ph probe to update
+	//   required: true
+	//   schema:
+	//    type: integer
+	// - in: body
+	//   name: phProbe
+	//   description: The ph probe to update
+	//   required: true
+	//   schema:
+	//    $ref: '#/definitions/phProbe'
+	//responses:
+	// 200:
+	//  description: OK
+	// 404:
+	//  description: Not Found
 	r.HandleFunc("/api/phprobes/{id}", e.updateProbe).Methods("POST")
+
+	// swagger:operation DELETE /api/phprobes/{id} PhProbes phProbeDelete
+	// Delete a ph probe.
+	// Delete an existing ph probe.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the ph probe to delete
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/phprobes/{id}", e.deleteProbe).Methods("DELETE")
+
+	// swagger:operation GET /api/phprobes/{id}/readings PhProbes phProbeReadings
+	// Get ph probe readings.
+	// Get ph probe readings.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the ph probe to delete
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
+	//   schema:
+	//    $ref: '#/definitions/statsResponse'
 	r.HandleFunc("/api/phprobes/{id}/readings", e.getReadings).Methods("GET")
 	r.HandleFunc("/api/phprobes/{id}/calibrate", e.calibrate).Methods("POST")
 	r.HandleFunc("/api/phprobes/{id}/read", e.read).Methods("GET")

--- a/controller/modules/ph/probe.go
+++ b/controller/modules/ph/probe.go
@@ -55,6 +55,7 @@ func (p *Probe) loadHomeostasis(c controller.Controller) {
 	p.h = controller.NewHomeostasis(c, hConf)
 }
 
+//swagger:model calibrationPoint
 type CalibrationPoint struct {
 	Type     string  `json:"type"`
 	Expected float64 `json:"expected"`

--- a/controller/modules/ph/probe.go
+++ b/controller/modules/ph/probe.go
@@ -23,6 +23,7 @@ type Notify struct {
 	Max    float64 `json:"max"`
 }
 
+//swagger:model phProbe
 type Probe struct {
 	ID          string        `json:"id"`
 	Name        string        `json:"name"`

--- a/controller/modules/system/api.go
+++ b/controller/modules/system/api.go
@@ -75,7 +75,12 @@ func (c *Controller) LoadAPI(r *mux.Router) {
 	//   description: OK
 	r.HandleFunc("/api/admin/reload", c.reload).Methods("POST")
 
-	//TODO: [ML] Add api documentation for upgrade
+	// swagger:route POST /api/admin/upgrade Admin adminUpgrade
+	// Upgrade reef-pi.
+	// Upgrade reef-pi.
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/admin/upgrade", c.upgrade).Methods("POST")
 
 	// swagger:route GET /api/info Admin adminInfo

--- a/controller/modules/system/api.go
+++ b/controller/modules/system/api.go
@@ -12,14 +12,77 @@ import (
 )
 
 func (c *Controller) LoadAPI(r *mux.Router) {
+
+	// swagger:route POST /api/display/on Display systemDisplayOn
+	// Turn display on.
+	// Turn display on.
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/display/on", c.EnableDisplay).Methods("POST")
+
+	// swagger:route POST /api/display/off Display systemDisplayOff
+	// Turn display off.
+	// Turn display off.
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/display/off", c.DisableDisplay).Methods("POST")
+
+	// swagger:operation POST /api/display Display systemDisplayPost
+	// Set display brigthness
+	// Set display brightness
+	// ---
+	// parameters:
+	//  - in: body
+	//    name: displayconfig
+	//    required: true
+	//    schema:
+	//     $ref: '#/definitions/displayConfig'
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/display", c.SetBrightness).Methods("POST")
+
+	// swagger:route GET /api/display Display systemDisplayGet
+	// Get current display state.
+	// Get current display state.
+	// responses:
+	//  200: displayState
 	r.HandleFunc("/api/display", c.GetDisplayState).Methods("GET")
+
+	// swagger:route POST /api/admin/poweroff Admin adminPowerOff
+	// Shut down the raspberry pi.
+	// Shut down the raspberry pi.
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/admin/poweroff", c.Poweroff).Methods("POST")
+
+	// swagger:route POST /api/admin/reboot Admin adminReboot
+	// Reboot the raspberry pi.
+	// Reboot the raspberry pi.
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/admin/reboot", c.Reboot).Methods("POST")
+
+	// swagger:route POST /api/admin/reload Admin adminReload
+	// Reload reef-pi.
+	// Reload reef-pi to apply any capability changes or other modules that are registered at startup.
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/admin/reload", c.reload).Methods("POST")
+
+	//TODO: [ML] Add api documentation for upgrade
 	r.HandleFunc("/api/admin/upgrade", c.upgrade).Methods("POST")
+
+	// swagger:route GET /api/info Admin adminInfo
+	// Get system summary.
+	// Get system summary.
+	// responses:
+	//  200: systemSummary
 	r.HandleFunc("/api/info", c.GetSummary).Methods("GET")
 	if c.config.Pprof {
 		c.enablePprof(r)

--- a/controller/modules/system/display.go
+++ b/controller/modules/system/display.go
@@ -11,11 +11,13 @@ const (
 	BrightnessFile = "/sys/class/backlight/rpi_backlight/brightness"
 )
 
+//swagger:model displayState
 type DisplayState struct {
 	On         bool `json:"on"`
 	Brightness int  `json:"brightness"`
 }
 
+//swagger:model displayConfig
 type DisplayConfig struct {
 	Enable     bool `json:"enable"`
 	Brightness int  `json:"brightness"`

--- a/controller/modules/system/info.go
+++ b/controller/modules/system/info.go
@@ -15,6 +15,7 @@ const (
 	_modelFilePath = "/proc/device-tree/model"
 )
 
+//swagger:model systemSummary
 type Summary struct {
 	Name           string `json:"name"`
 	IP             string `json:"ip"`

--- a/controller/modules/temperature/api.go
+++ b/controller/modules/temperature/api.go
@@ -10,14 +10,146 @@ import (
 )
 
 func (t *Controller) LoadAPI(r *mux.Router) {
+
+	// swagger:route GET /api/tcs Temperature tcsList
+	// List all temperature controllers.
+	// List all temperature controllers in reef-pi.
+	// responses:
+	// 	200: body:[]temperatureController
 	r.HandleFunc("/api/tcs", t.list).Methods("GET")
+
+	// swagger:route GET /api/tcs/sensors Temperature tcsList
+	// List all temperature sensors.
+	// List all temperature sensors detected by the OS.
+	// responses:
+	// 	200:
+	//   description: An array of sensor ids
 	r.HandleFunc("/api/tcs/sensors", t.sensors).Methods("GET")
+
+	// swagger:operation PUT /api/tcs Temperature tcsCreate
+	// Create a temperature controller.
+	// Create a new temperature controller.
+	// ---
+	// parameters:
+	//  - in: body
+	//    name: temperatureController
+	//    description: The temperature controller to create
+	//    required: true
+	//    schema:
+	//     $ref: '#/definitions/temperatureController'
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/tcs", t.create).Methods("PUT")
+
+	// swagger:operation GET /api/tcs/{id} Temperature tcsGet
+	// Get an temperature controller by id.
+	// Get an existing temperature controller by id.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the temperature controller
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
+	//   schema:
+	//    $ref: '#/definitions/temperatureController'
+	//  404:
+	//   description: Not Found
 	r.HandleFunc("/api/tcs/{id}", t.get).Methods("GET")
+
+	// swagger:operation GET /api/tcs/{id}/current_reading Temperature tcsRead
+	// Get temperature controller reading.
+	// Get temperature controller reading.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the temperature controller to read
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/tcs/{id}/current_reading", t.currentReading).Methods("GET")
+
+	// swagger:operation GET /api/tcs/{id}/read Temperature tcsRead
+	// Get temperature controller reading.
+	// Get temperature controller reading.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the temperature controller to read
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/tcs/{id}/read", t.read).Methods("GET")
+
+	// swagger:operation POST /api/tcs/{id} Temperature tcsUpdate
+	// Update a temperature controller.
+	// Update an existing temperature controller.
+	//---
+	//parameters:
+	// - in: path
+	//   name: id
+	//   description: The Id of the temperature controller to update
+	//   required: true
+	//   schema:
+	//    type: integer
+	// - in: body
+	//   name: temperatureController
+	//   description: The temperature controller to update
+	//   required: true
+	//   schema:
+	//    $ref: '#/definitions/temperatureController'
+	//responses:
+	// 200:
+	//  description: OK
+	// 404:
+	//  description: Not Found
 	r.HandleFunc("/api/tcs/{id}", t.update).Methods("POST")
+
+	// swagger:operation DELETE /api/tcs/{id} Temperature tcsDelete
+	// Delete a temperature controller.
+	// Delete an existing temperature controller.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the temperature controller to delete
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/tcs/{id}", t.delete).Methods("DELETE")
+
+	// swagger:operation GET /api/tcs/{id}/usage Temperature tcsUsage
+	// Get usage history.
+	// Get usage history for a given temperature controller.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the temperature controller
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
+	//  404:
+	//   description: Not Found
 	r.HandleFunc("/api/tcs/{id}/usage", t.getUsage).Methods("GET")
 }
 func (t *Controller) currentReading(w http.ResponseWriter, r *http.Request) {

--- a/controller/modules/temperature/tc.go
+++ b/controller/modules/temperature/tc.go
@@ -19,6 +19,7 @@ type Notify struct {
 	Min    float64 `json:"min"`
 }
 
+//swagger:model temperatureController
 type TC struct {
 	sync.Mutex
 	ID                string            `json:"id"`

--- a/controller/modules/timer/api.go
+++ b/controller/modules/timer/api.go
@@ -9,10 +9,86 @@ import (
 )
 
 func (c *Controller) LoadAPI(r *mux.Router) {
+
+	// swagger:operation GET /api/timers/{id} Timers timerGet
+	// Get timer.
+	// Get timer.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the timer
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
+	//   schema:
+	//    $ref: '#/definitions/timerJob'
 	r.HandleFunc("/api/timers/{id}", c.GetJob).Methods("GET")
+
+	// swagger:route GET /api/timers Timers timerList
+	// List all timer jobs.
+	// List all timer jobs in reef-pi.
+	// responses:
+	// 	200: body:[]timerJob
 	r.HandleFunc("/api/timers", c.ListJobs).Methods("GET")
+
+	// swagger:operation PUT /api/timers Timers timerCreate
+	// Create a timer job.
+	// Create a new timer job.
+	// ---
+	// parameters:
+	//  - in: body
+	//    name: timer
+	//    description: The timer job to create
+	//    required: true
+	//    schema:
+	//     $ref: '#/definitions/timerJob'
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/timers", c.CreateJob).Methods("PUT")
+
+	// swagger:operation POST /api/timers/{id} Timers timerUpdate
+	// Update a timer job.
+	// Update an existing timer job.
+	//---
+	//parameters:
+	// - in: path
+	//   name: id
+	//   description: The Id of the timer job to update
+	//   required: true
+	//   schema:
+	//    type: integer
+	// - in: body
+	//   name: timer
+	//   description: The timer job to update
+	//   required: true
+	//   schema:
+	//    $ref: '#/definitions/timerJob'
+	//responses:
+	// 200:
+	//  description: OK
+	// 404:
+	//  description: Not Found
 	r.HandleFunc("/api/timers/{id}", c.UpdateJob).Methods("POST")
+
+	// swagger:operation DELETE /api/timers/{id} Timers timerDelete
+	// Delete a timer job.
+	// Delete an existing timer job.
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: id
+	//    description: The Id of the timer job to delete
+	//    required: true
+	//    schema:
+	//     type: integer
+	// responses:
+	//  200:
+	//   description: OK
 	r.HandleFunc("/api/timers/{id}", c.DeleteJob).Methods("DELETE")
 }
 

--- a/controller/modules/timer/job.go
+++ b/controller/modules/timer/job.go
@@ -13,6 +13,7 @@ import (
 
 const Bucket = storage.TimerBucket
 
+//swagger:model timerJob
 type Job struct {
 	ID     string          `json:"id"`
 	Name   string          `json:"name"`

--- a/controller/settings/capabilities.go
+++ b/controller/settings/capabilities.go
@@ -1,5 +1,6 @@
 package settings
 
+//swagger:model capabilities
 type Capabilities struct {
 	DevMode       bool `json:"dev_mode"`
 	Dashboard     bool `json:"dashboard"`

--- a/controller/settings/settings.go
+++ b/controller/settings/settings.go
@@ -1,5 +1,6 @@
 package settings
 
+//swagger:model settings
 type Settings struct {
 	Name         string            `json:"name"`
 	Interface    string            `json:"interface"`

--- a/controller/telemetry/stats.go
+++ b/controller/telemetry/stats.go
@@ -48,6 +48,7 @@ type AdafruitIO struct {
 	Prefix string `json:"prefix"`
 }
 
+//swagger:model telemetryConfig
 type TelemetryConfig struct {
 	AdafruitIO      AdafruitIO   `json:"adafruitio"`
 	Mailer          MailerConfig `json:"mailer"`

--- a/controller/telemetry/stats_manager.go
+++ b/controller/telemetry/stats_manager.go
@@ -15,6 +15,7 @@ type Metric interface {
 	Before(Metric) bool
 }
 
+// swagger:model statsResponse
 type StatsResponse struct {
 	Current    []Metric `json:"current"`
 	Historical []Metric `json:"historical"`

--- a/controller/utils/auth.go
+++ b/controller/utils/auth.go
@@ -41,21 +41,19 @@ func NewAuth(b string, store storage.Store) Auth {
 
 func (a *auth) Authenticate(fn http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		if false {
-			log.Printf("API Request:'%6s %s' from: %s\n", req.Method, req.URL.String(), req.RemoteAddr)
-			authSession, err := a.cookiejar.Get(req, "auth")
-			if err != nil {
-				log.Println("unauthorized request.", req.RemoteAddr, "error:", err)
-				http.Error(w, "Unauthorized.", 401)
-				return
-			}
-			if user := authSession.Values["user"]; user == nil {
-				log.Println("unauthorized request. user is not set.", req.RemoteAddr)
-				http.Error(w, "Unauthorized.", 401)
-				return
-			}
-			authSession.Save(req, w)
+		log.Printf("API Request:'%6s %s' from: %s\n", req.Method, req.URL.String(), req.RemoteAddr)
+		authSession, err := a.cookiejar.Get(req, "auth")
+		if err != nil {
+			log.Println("unauthorized request.", req.RemoteAddr, "error:", err)
+			http.Error(w, "Unauthorized.", 401)
+			return
 		}
+		if user := authSession.Values["user"]; user == nil {
+			log.Println("unauthorized request. user is not set.", req.RemoteAddr)
+			http.Error(w, "Unauthorized.", 401)
+			return
+		}
+		authSession.Save(req, w)
 		fn(w, req)
 	}
 }

--- a/controller/utils/auth.go
+++ b/controller/utils/auth.go
@@ -10,6 +10,7 @@ import (
 	"github.com/reef-pi/reef-pi/controller/storage"
 )
 
+//swagger:model credentials
 type Credentials struct {
 	User     string `json:"user"`
 	Password string `json:"password"`
@@ -40,19 +41,21 @@ func NewAuth(b string, store storage.Store) Auth {
 
 func (a *auth) Authenticate(fn http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		log.Printf("API Request:'%6s %s' from: %s\n", req.Method, req.URL.String(), req.RemoteAddr)
-		authSession, err := a.cookiejar.Get(req, "auth")
-		if err != nil {
-			log.Println("unauthorized request.", req.RemoteAddr, "error:", err)
-			http.Error(w, "Unauthorized.", 401)
-			return
+		if false {
+			log.Printf("API Request:'%6s %s' from: %s\n", req.Method, req.URL.String(), req.RemoteAddr)
+			authSession, err := a.cookiejar.Get(req, "auth")
+			if err != nil {
+				log.Println("unauthorized request.", req.RemoteAddr, "error:", err)
+				http.Error(w, "Unauthorized.", 401)
+				return
+			}
+			if user := authSession.Values["user"]; user == nil {
+				log.Println("unauthorized request. user is not set.", req.RemoteAddr)
+				http.Error(w, "Unauthorized.", 401)
+				return
+			}
+			authSession.Save(req, w)
 		}
-		if user := authSession.Values["user"]; user == nil {
-			log.Println("unauthorized request. user is not set.", req.RemoteAddr)
-			http.Error(w, "Unauthorized.", 401)
-			return
-		}
-		authSession.Save(req, w)
 		fn(w, req)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,10 @@ require (
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/sessions v1.2.0
 	github.com/kidoman/embd v0.0.0-20170508013040-d3d8c0c5c68d
+	github.com/kr/pretty v0.2.0 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/prometheus/client_golang v1.6.0
-	github.com/prometheus/common v0.9.1
 	github.com/reef-pi/adafruitio v0.0.0-20171007064130-a3cae37cdd64
 	github.com/reef-pi/drivers v0.0.0-20200414053832-62f23bd379c8
 	github.com/reef-pi/hal v0.0.0-20200226044219-163a37bab6d9

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,7 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coreos/go-systemd/v22 v22.0.0 h1:XJIw/+VlJ+87J+doOxznsAWIdmWuViOVhkQamW5YV28=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -23,6 +24,7 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
+github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/godbus/dbus/v5 v5.0.3 h1:ZqHaoEF7TBzh4jzPmqVhE/5A1z9of6orkAe5uHoAeME=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -40,6 +42,8 @@ github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:W
 github.com/golang/protobuf v1.4.0 h1:oOuy+ugB+P/kBdUnG5QaMXSIyJ1q38wWSojYCb3z5VQ=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -67,10 +71,16 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
+github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
+github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
+github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
@@ -113,6 +123,9 @@ github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzG
 github.com/shirou/gopsutil v2.20.4+incompatible h1:cMT4rxS55zx9NVUnCkrmXCsEB/RNfG9SwHY9evtX8Ng=
 github.com/shirou/gopsutil v2.20.4+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
+github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -123,6 +136,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 go.etcd.io/bbolt v1.3.4 h1:hi1bXHMVrlQh6WwxAy+qZCV/SYIlqo+Ushwdpa4tAKg=
 go.etcd.io/bbolt v1.3.4/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8 h1:idBdZTd9UioThJp8KpM/rTSinK/ChZFBE43/WtIy8zg=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -139,6 +154,7 @@ golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190429190828-d89cdac9e872/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/manager/instance.go
+++ b/manager/instance.go
@@ -2,12 +2,14 @@ package manager
 
 import (
 	"encoding/json"
-	"github.com/reef-pi/reef-pi/controller/storage"
-	"github.com/reef-pi/reef-pi/controller/telemetry"
 	"net/http"
 
-	"github.com/gorilla/mux"
+	"github.com/reef-pi/reef-pi/controller/storage"
+	"github.com/reef-pi/reef-pi/controller/telemetry"
+
 	"log"
+
+	"github.com/gorilla/mux"
 
 	"github.com/reef-pi/reef-pi/controller/utils"
 )
@@ -16,6 +18,7 @@ const (
 	InstancesBucket = "instances"
 )
 
+//swagger:model instance
 type Instance struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1,12 +1,13 @@
 package manager
 
 import (
+	"log"
+	"net/http"
+
 	"github.com/gorilla/mux"
 	"github.com/reef-pi/reef-pi/controller/storage"
 	"github.com/reef-pi/reef-pi/controller/telemetry"
 	"github.com/reef-pi/reef-pi/controller/utils"
-	"log"
-	"net/http"
 )
 
 type mgr struct {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  version: 0.0.1
+  title: reef-pi
+  description: reef-pi API
+servers: []
+paths: {}
+components:
+  schemas:
+    Inlet:
+      type: object
+      properties:
+        driver:
+          type: string
+        equipment:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        pin:
+          type: integer
+        reverse:
+          type: boolean

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "recharts": "^2.0.0-beta.6",
     "redux": "^4.0.5",
     "redux-mock-store": "1.5.4",
+    "redoc-cli": "^0.9.8",
     "redux-thunk": "2.3.0",
     "sass-lint": "1.13.1",
     "sass-loader": "8.0.0",

--- a/swagger.json
+++ b/swagger.json
@@ -1,0 +1,2777 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "@openapi:info",
+    "version": "0.0.1"
+  },
+  "paths": {
+    "/api/analog_inputs": {
+      "get": {
+        "description": "List all Analog Inputs in reef-pi.",
+        "tags": [
+          "AnalogInput"
+        ],
+        "summary": "List all Analog Inputs.",
+        "operationId": "analogInputList",
+        "responses": {
+          "200": {
+            "description": "analogInput",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/analogInput"
+              }
+            }
+          },
+          "500": {}
+        }
+      }
+    },
+    "/api/analog_inputs/{id}": {
+      "get": {
+        "description": "Get an existing Analog Input.",
+        "tags": [
+          "AnalogInput"
+        ],
+        "summary": "Get an Analog Input by id.",
+        "operationId": "analogInputGet",
+        "parameters": [
+          {
+            "description": "The Id of the analog input",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/analogInput"
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "post": {
+        "description": "Update an existing Analog Input.",
+        "tags": [
+          "AnalogInput"
+        ],
+        "summary": "Update an Analog Input.",
+        "operationId": "analogInputUpdate",
+        "parameters": [
+          {
+            "description": "The Id of the analog input to update",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The analog input to update",
+            "name": "analog input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/analogInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete an existing Analog Input.",
+        "tags": [
+          "AnalogInput"
+        ],
+        "summary": "Delete an Analog Input.",
+        "operationId": "analogInputDelete",
+        "parameters": [
+          {
+            "description": "The Id of the analog input to delete",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/analog_inputs/{id}/read": {
+      "post": {
+        "description": "Read an Analog Input.",
+        "tags": [
+          "AnalogInput"
+        ],
+        "summary": "Read an Analog Input.",
+        "operationId": "analogInputRead",
+        "parameters": [
+          {
+            "description": "The Id of the analog input to read",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/api/analog_inuputs": {
+      "put": {
+        "description": "Create a new analog input.",
+        "tags": [
+          "AnalogInput"
+        ],
+        "summary": "Create an analog input.",
+        "operationId": "analogInputCreate",
+        "parameters": [
+          {
+            "description": "The analog input to create",
+            "name": "analog input",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/analogInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/atos": {
+      "get": {
+        "description": "List all ATOs in reef-pi.",
+        "tags": [
+          "ATO"
+        ],
+        "summary": "List all ATOs.",
+        "operationId": "atoList",
+        "responses": {
+          "200": {
+            "description": "ato",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ato"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Create a new ATO.",
+        "tags": [
+          "ATO"
+        ],
+        "summary": "Create an ATO.",
+        "operationId": "atoCreate",
+        "parameters": [
+          {
+            "x-go-name": "ATO",
+            "description": "The ato to create",
+            "name": "ato",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ato"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/atos/{id}": {
+      "get": {
+        "description": "Get an existing ATO.",
+        "tags": [
+          "ATO"
+        ],
+        "summary": "Get an ATO by id.",
+        "operationId": "atoGet",
+        "parameters": [
+          {
+            "description": "The Id of the ATO",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ato"
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "post": {
+        "description": "Update an existing ATO.",
+        "tags": [
+          "ATO"
+        ],
+        "summary": "Update an ATO.",
+        "operationId": "atoUpdate",
+        "parameters": [
+          {
+            "x-go-name": "ATO",
+            "description": "The Id of the ato to update",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The ato to update",
+            "name": "ato",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ato"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete an existing ATO.",
+        "tags": [
+          "ATO"
+        ],
+        "summary": "Delete an ATO.",
+        "operationId": "atoDelete",
+        "parameters": [
+          {
+            "description": "The Id of the ato to delete",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/atos/{id}/usage": {
+      "get": {
+        "description": "Get usage history for a given ATO.",
+        "tags": [
+          "ATO"
+        ],
+        "summary": "Get usage history.",
+        "operationId": "atoUsage",
+        "parameters": [
+          {
+            "description": "The Id of the ato",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/api/camera/config": {
+      "get": {
+        "description": "Get the camera configuration.",
+        "tags": [
+          "Camera"
+        ],
+        "summary": "Get the camera configuration.",
+        "operationId": "cameraConfig",
+        "responses": {
+          "200": {
+            "description": "cameraConfig",
+            "schema": {
+              "$ref": "#/definitions/cameraConfig"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Save camera configuration.",
+        "tags": [
+          "Camera"
+        ],
+        "summary": "Save camera configuration.",
+        "operationId": "cameraConfig",
+        "parameters": [
+          {
+            "description": "camera configuration",
+            "name": "config",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/cameraConfig"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/camera/latest": {
+      "get": {
+        "description": "Get latest picture.",
+        "tags": [
+          "Camera"
+        ],
+        "summary": "Get latest picture.",
+        "operationId": "cameraLatest",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/camera/list": {
+      "get": {
+        "description": "List all images.",
+        "tags": [
+          "Camera"
+        ],
+        "summary": "List images.",
+        "operationId": "cameraList",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/camera/shoot": {
+      "post": {
+        "description": "Shoot a picture.",
+        "tags": [
+          "Camera"
+        ],
+        "summary": "Shoot a picture.",
+        "operationId": "cameraConfig",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/capabilities": {
+      "get": {
+        "description": "List all capabilities in reef-pi.",
+        "tags": [
+          "Capabilities"
+        ],
+        "summary": "List all capabilities.",
+        "operationId": "capabilitiesList",
+        "responses": {
+          "200": {
+            "description": "capabilities",
+            "schema": {
+              "$ref": "#/definitions/capabilities"
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials": {
+      "post": {
+        "description": "Update username and password.",
+        "tags": [
+          "Credentials"
+        ],
+        "summary": "Update credentials.",
+        "operationId": "credentialsUpdate",
+        "parameters": [
+          {
+            "description": "The new credentials",
+            "name": "credentials",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/credentials"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/dashboard": {
+      "get": {
+        "description": "Get dashboard.",
+        "tags": [
+          "Dashboard"
+        ],
+        "summary": "Get dashboard.",
+        "operationId": "dashboardGet",
+        "responses": {
+          "200": {
+            "description": "dashboard",
+            "schema": {
+              "$ref": "#/definitions/dashboard"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Update dasboard configuration.",
+        "tags": [
+          "Dashboard"
+        ],
+        "summary": "Update dasboard configuration.",
+        "operationId": "dashboardUpdate",
+        "parameters": [
+          {
+            "description": "The dashboard configuration",
+            "name": "dashboardConfiguration",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/dashboard"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/doser/pumps": {
+      "get": {
+        "description": "List all dosers in reef-pi.",
+        "tags": [
+          "Doser"
+        ],
+        "summary": "List all dosers.",
+        "operationId": "doserList",
+        "responses": {
+          "200": {
+            "description": "pump",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/pump"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Create a new doser.",
+        "tags": [
+          "Doser"
+        ],
+        "summary": "Create a doser.",
+        "operationId": "doserCreate",
+        "parameters": [
+          {
+            "description": "The doser to create",
+            "name": "doser",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/pump"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/doser/pumps/{id}": {
+      "get": {
+        "description": "Get an existing doser.",
+        "tags": [
+          "Doser"
+        ],
+        "summary": "Get a doser by id.",
+        "operationId": "doserGet",
+        "parameters": [
+          {
+            "description": "The Id of the doser",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/pump"
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "post": {
+        "description": "Update an existing doser.",
+        "tags": [
+          "Doser"
+        ],
+        "summary": "Update a doser.",
+        "operationId": "doserUpdate",
+        "parameters": [
+          {
+            "description": "The Id of the doser to update",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The doser to update",
+            "name": "doser",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/pump"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete an existing doser.",
+        "tags": [
+          "Doser"
+        ],
+        "summary": "Delete a doser.",
+        "operationId": "doserDelete",
+        "parameters": [
+          {
+            "description": "The Id of the doser to delete",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/doser/pumps/{id}/calibrate": {
+      "post": {
+        "description": "Calibrate a doser.",
+        "tags": [
+          "Doser"
+        ],
+        "summary": "Calibrate a doser.",
+        "operationId": "doserCalibrate",
+        "parameters": [
+          {
+            "description": "The Id of the doser",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/doserCalibrationDetails"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/api/doser/pumps/{id}/schedule": {
+      "post": {
+        "description": "Schedule dosing.",
+        "tags": [
+          "Doser"
+        ],
+        "summary": "Schedule dosing.",
+        "operationId": "doserSchedule",
+        "parameters": [
+          {
+            "description": "The Id of the doser",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/dosingRegiment"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/api/doser/pumps/{id}/usage": {
+      "get": {
+        "description": "Get usage history for a given Doser.",
+        "tags": [
+          "Doser"
+        ],
+        "summary": "Get usage history.",
+        "operationId": "doserUsage",
+        "parameters": [
+          {
+            "description": "The Id of the doser",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/api/drivers": {
+      "get": {
+        "description": "List all Drivers in reef-pi.",
+        "tags": [
+          "Driver"
+        ],
+        "summary": "List all Drivers.",
+        "operationId": "driverList",
+        "responses": {
+          "200": {
+            "description": "driver",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/driver"
+              }
+            }
+          },
+          "500": {}
+        }
+      },
+      "put": {
+        "description": "Create a new Driver.",
+        "tags": [
+          "Driver"
+        ],
+        "summary": "Create a Driver.",
+        "operationId": "driverCreate",
+        "parameters": [
+          {
+            "description": "The driver to create",
+            "name": "driver",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/driver"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/drivers/options": {
+      "get": {
+        "description": "Get driver parametres\nList all drivers with configuration options.",
+        "tags": [
+          "Driver"
+        ],
+        "operationId": "driverListOptions",
+        "responses": {
+          "200": {
+            "description": "Map of drivers and parameters",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "default": {
+                      "description": "The recommended default value",
+                      "type": "object",
+                      "example": "192.168.1.23:9999"
+                    },
+                    "name": {
+                      "description": "The name of the parameter",
+                      "type": "string",
+                      "example": "address"
+                    },
+                    "order": {
+                      "description": "The order in which to display the parameter",
+                      "type": "integer",
+                      "example": 1
+                    },
+                    "type": {
+                      "description": "The data type of the parameter",
+                      "type": "string",
+                      "example": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/drivers/validate": {
+      "post": {
+        "description": "Validate a driver configuration.",
+        "tags": [
+          "Driver"
+        ],
+        "summary": "Validate a driver configuration.",
+        "operationId": "driverValidate",
+        "parameters": [
+          {
+            "description": "The driver to validate",
+            "name": "outlet",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/driver"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Not Valid"
+          }
+        }
+      }
+    },
+    "/api/drivers/{id}": {
+      "get": {
+        "description": "Get an existing driver.",
+        "tags": [
+          "Driver"
+        ],
+        "summary": "Get a driver by id.",
+        "operationId": "driverGet",
+        "parameters": [
+          {
+            "description": "The Id of the driver",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/driver"
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "post": {
+        "description": "Update an existing Driver.",
+        "tags": [
+          "Driver"
+        ],
+        "summary": "Update a Driver.",
+        "operationId": "driverUpdate",
+        "parameters": [
+          {
+            "description": "The Id of the driver to update",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The driver to update",
+            "name": "driver",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/driver"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete an existing Driver.",
+        "tags": [
+          "Driver"
+        ],
+        "summary": "Delete an Driver.",
+        "operationId": "driverDelete",
+        "parameters": [
+          {
+            "description": "The Id of the driver to delete",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/equipment": {
+      "get": {
+        "description": "List all equipment in reef-pi.",
+        "tags": [
+          "Equipment"
+        ],
+        "summary": "List all equipment.",
+        "operationId": "equipmentList",
+        "responses": {
+          "200": {
+            "description": "equipment",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/equipment"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Create a new equipment.",
+        "tags": [
+          "Equipment"
+        ],
+        "summary": "Create an equipment.",
+        "operationId": "equipmentCreate",
+        "parameters": [
+          {
+            "description": "The equipment to create",
+            "name": "equipment",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/equipment"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "post": {
+        "description": "Update an existing equipment.",
+        "tags": [
+          "Equipment"
+        ],
+        "summary": "Update an equipment.",
+        "operationId": "equipmentUpdate",
+        "parameters": [
+          {
+            "description": "The Id of the equipment to update",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The equipment to update",
+            "name": "equipment",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/equipment"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/api/equipment/{id}": {
+      "get": {
+        "description": "Get an existing equipment by id.",
+        "tags": [
+          "Equipment"
+        ],
+        "summary": "Get an equipment by id.",
+        "operationId": "equipmentGet",
+        "parameters": [
+          {
+            "description": "The Id of the equipment",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/equipment"
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete an existing equipment.",
+        "tags": [
+          "Equipment"
+        ],
+        "summary": "Delete an equipment.",
+        "operationId": "equipmentDelete",
+        "parameters": [
+          {
+            "description": "The Id of the equipment to delete",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/equipment/{id}/control": {
+      "post": {
+        "description": "Control an equipment.",
+        "tags": [
+          "Equipment"
+        ],
+        "summary": "Control an equipment.",
+        "operationId": "equipmentControl",
+        "parameters": [
+          {
+            "description": "The Id of the equipment to control",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The action to take",
+            "name": "action",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/equipmentAction"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/errors": {
+      "get": {
+        "description": "List errors.",
+        "tags": [
+          "Errors"
+        ],
+        "summary": "List errors.",
+        "operationId": "errorsList",
+        "responses": {
+          "200": {
+            "description": "error",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/error"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/errors/clear": {
+      "delete": {
+        "description": "Clear errors.",
+        "tags": [
+          "Errors"
+        ],
+        "summary": "Clear errors.",
+        "operationId": "errorsClear",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/errors/{id}": {
+      "get": {
+        "description": "Get an existing error.",
+        "tags": [
+          "Errors"
+        ],
+        "summary": "Get an error by id.",
+        "operationId": "errorGet",
+        "parameters": [
+          {
+            "description": "The Id of the error",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete an error.",
+        "tags": [
+          "Errors"
+        ],
+        "summary": "Delete an error.",
+        "operationId": "errorsDelete",
+        "parameters": [
+          {
+            "description": "The Id of the error to delete",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/inlets": {
+      "get": {
+        "description": "List all inlets in reef-pi.",
+        "tags": [
+          "Inlet"
+        ],
+        "summary": "List all Inlets.",
+        "operationId": "inletList",
+        "responses": {
+          "200": {
+            "description": "inlet",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/inlet"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Create a new Inlet.",
+        "tags": [
+          "Inlet"
+        ],
+        "summary": "Create an Inlet.",
+        "operationId": "inletCreate",
+        "parameters": [
+          {
+            "description": "The inlet to create",
+            "name": "inlet",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/inlet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/inlets/{id}": {
+      "get": {
+        "description": "Get an existing Inlet.",
+        "tags": [
+          "Inlet"
+        ],
+        "summary": "Get an Inlet by id.",
+        "operationId": "inletGet",
+        "parameters": [
+          {
+            "description": "The Id of the inlet",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/inlet"
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "post": {
+        "description": "Update an existing Inlet.",
+        "tags": [
+          "Inlet"
+        ],
+        "summary": "Update an Inlet.",
+        "operationId": "inletUpdate",
+        "parameters": [
+          {
+            "description": "The Id of the inlet to update",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The inlet to update",
+            "name": "inlet",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/inlet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete an existing Inlet.",
+        "tags": [
+          "Inlet"
+        ],
+        "summary": "Delete an Inlet.",
+        "operationId": "inletDelete",
+        "parameters": [
+          {
+            "description": "The Id of the inlet to delete",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/inlets/{id}/read": {
+      "post": {
+        "description": "Read an Inlet.",
+        "tags": [
+          "Inlet"
+        ],
+        "summary": "Read an Inlet.",
+        "operationId": "inletRead",
+        "parameters": [
+          {
+            "description": "The Id of the inlet to read",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/api/jacks": {
+      "get": {
+        "description": "List all jacks in reef-pi.",
+        "tags": [
+          "Jack"
+        ],
+        "summary": "List all jacks.",
+        "operationId": "jackList",
+        "responses": {
+          "200": {
+            "description": "jack",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/jack"
+              }
+            }
+          },
+          "500": {}
+        }
+      },
+      "put": {
+        "description": "Create a new Jack.",
+        "tags": [
+          "Jack"
+        ],
+        "summary": "Create a Jack.",
+        "operationId": "jackCreate",
+        "parameters": [
+          {
+            "description": "The jack to create",
+            "name": "jack",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/jack"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/jacks/{id}": {
+      "get": {
+        "description": "Get an existing Jack.",
+        "tags": [
+          "Jack"
+        ],
+        "summary": "Get a Jack by id.",
+        "operationId": "jackGet",
+        "parameters": [
+          {
+            "description": "The Id of the jack",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/jack"
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "post": {
+        "description": "Update an existing Jack.",
+        "tags": [
+          "Jack"
+        ],
+        "summary": "Update a Jack.",
+        "operationId": "jackUpdate",
+        "parameters": [
+          {
+            "description": "The Id of the jack to update",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The jack to update",
+            "name": "jack",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/jack"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete an existing Jack.",
+        "tags": [
+          "Jack"
+        ],
+        "summary": "Delete a Jack.",
+        "operationId": "jackDelete",
+        "parameters": [
+          {
+            "description": "The Id of the jack to delete",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/jacks/{id}/control": {
+      "post": {
+        "description": "Control a Jack.",
+        "tags": [
+          "Jack"
+        ],
+        "summary": "Control a Jack.",
+        "operationId": "jackControl",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/light/{id}": {
+      "delete": {
+        "description": "Delete an existing light.",
+        "tags": [
+          "Lights"
+        ],
+        "summary": "Delete a light.",
+        "operationId": "lightDelete",
+        "parameters": [
+          {
+            "description": "The Id of the light to delete",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/lights": {
+      "get": {
+        "description": "List all lights in reef-pi.",
+        "tags": [
+          "Lights"
+        ],
+        "summary": "List all lights.",
+        "operationId": "lightsList",
+        "responses": {
+          "200": {
+            "description": "light",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/light"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Create a new light.",
+        "tags": [
+          "Lights"
+        ],
+        "summary": "Create a light.",
+        "operationId": "lightsCreate",
+        "parameters": [
+          {
+            "description": "The light to create",
+            "name": "light",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/light"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "post": {
+        "description": "Update an existing light.",
+        "tags": [
+          "Lights"
+        ],
+        "summary": "Update a light.",
+        "operationId": "lightUpdate",
+        "parameters": [
+          {
+            "description": "The Id of the light to update",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The light to update",
+            "name": "light",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/light"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/api/lights/{id}": {
+      "get": {
+        "description": "Get an existing light by id.",
+        "tags": [
+          "Lights"
+        ],
+        "summary": "Get a light by id.",
+        "operationId": "lightsGet",
+        "parameters": [
+          {
+            "description": "The Id of the light",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/light"
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/api/me": {
+      "get": {
+        "description": "Ping API to determine if server is running.",
+        "tags": [
+          "Me"
+        ],
+        "summary": "Ping API.",
+        "operationId": "meGet",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/outlets": {
+      "get": {
+        "description": "List all Outlets in reef-pi.",
+        "tags": [
+          "Outlet"
+        ],
+        "summary": "List all Outlets.",
+        "operationId": "outletList",
+        "responses": {
+          "200": {
+            "description": "outlet",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/outlet"
+              }
+            }
+          },
+          "500": {}
+        }
+      },
+      "put": {
+        "description": "Create a new Outlet.",
+        "tags": [
+          "Outlet"
+        ],
+        "summary": "Create an Outlet.",
+        "operationId": "outletCreate",
+        "parameters": [
+          {
+            "description": "The outlet to create",
+            "name": "outlet",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/outlet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/outlets/{id}": {
+      "get": {
+        "description": "Get an existing Outlet.",
+        "tags": [
+          "Outlet"
+        ],
+        "summary": "Get an Outlet by id.",
+        "operationId": "outletGet",
+        "parameters": [
+          {
+            "description": "The Id of the outlet",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/outlet"
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "post": {
+        "description": "Update an existing Outlet.",
+        "tags": [
+          "Outlet"
+        ],
+        "summary": "Update an Outlet.",
+        "operationId": "outletUpdate",
+        "parameters": [
+          {
+            "description": "The Id of the outlet to update",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The outlet to update",
+            "name": "outlet",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/outlet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete an existing Outlet.",
+        "tags": [
+          "Outlet"
+        ],
+        "summary": "Delete an Outlet.",
+        "operationId": "outletDelete",
+        "parameters": [
+          {
+            "description": "The Id of the outlet to delete",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/settings": {
+      "get": {
+        "description": "List all settings in reef-pi.",
+        "tags": [
+          "Settings"
+        ],
+        "summary": "List all settings.",
+        "operationId": "settingsList",
+        "responses": {
+          "200": {
+            "description": "settings",
+            "schema": {
+              "$ref": "#/definitions/settings"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Update settings.",
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Update settings.",
+        "operationId": "settingsUpdate",
+        "parameters": [
+          {
+            "description": "The settings to update",
+            "name": "settings",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/settings"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/telemetry": {
+      "get": {
+        "description": "List telemetry configuration.",
+        "tags": [
+          "Telemetry"
+        ],
+        "summary": "List telemetry configuration.",
+        "operationId": "telemetryGet",
+        "responses": {
+          "200": {
+            "description": "telemetryConfig",
+            "schema": {
+              "$ref": "#/definitions/telemetryConfig"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Update telemetry configuration.",
+        "tags": [
+          "Telemetry"
+        ],
+        "summary": "Update telemetry configuration.",
+        "operationId": "telemetryUpdate",
+        "parameters": [
+          {
+            "description": "The telemetry configuration",
+            "name": "telemetryConfig",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/telemetryConfig"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/telemetry/test_message": {
+      "post": {
+        "description": "Send a telemetry test message.",
+        "tags": [
+          "Telemetry"
+        ],
+        "summary": "Test telemetry.",
+        "operationId": "telemetryTest",
+        "responses": {
+          "200": {}
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AdafruitIO": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-go-name": "Enable"
+        },
+        "prefix": {
+          "type": "string",
+          "x-go-name": "Prefix"
+        },
+        "token": {
+          "type": "string",
+          "x-go-name": "Token"
+        },
+        "user": {
+          "type": "string",
+          "x-go-name": "User"
+        }
+      },
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/telemetry"
+    },
+    "Chart": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "x-go-name": "ID"
+        },
+        "type": {
+          "type": "string",
+          "x-go-name": "Type"
+        }
+      },
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/daemon"
+    },
+    "Duration": {
+      "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
+      "type": "integer",
+      "format": "int64",
+      "x-go-package": "time"
+    },
+    "HealthCheckNotify": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-go-name": "Enable"
+        },
+        "max_cpu": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "MaxCPU"
+        },
+        "max_memory": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "MaxMemory"
+        }
+      },
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/settings"
+    },
+    "MailerConfig": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "string",
+          "x-go-name": "From"
+        },
+        "password": {
+          "type": "string",
+          "x-go-name": "Password"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Port"
+        },
+        "server": {
+          "type": "string",
+          "x-go-name": "Server"
+        },
+        "to": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "To"
+        }
+      },
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/telemetry"
+    },
+    "Metric": {
+      "type": "object",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/telemetry"
+    },
+    "MotionConfig": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-go-name": "Enable"
+        },
+        "height": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Height"
+        },
+        "url": {
+          "type": "string",
+          "x-go-name": "URL"
+        },
+        "width": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Width"
+        }
+      },
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/camera"
+    },
+    "Notify": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-go-name": "Enable"
+        },
+        "max": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Max"
+        }
+      },
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/ato"
+    },
+    "ProfileSpec": {
+      "type": "object",
+      "properties": {
+        "config": {
+          "type": "object",
+          "x-go-name": "Config"
+        },
+        "max": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "Max"
+        },
+        "min": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "Min"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "type": {
+          "type": "string",
+          "x-go-name": "Type"
+        }
+      },
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/pwm_profile"
+    },
+    "Schedule": {
+      "type": "object",
+      "properties": {
+        "day": {
+          "type": "string",
+          "x-go-name": "Day"
+        },
+        "hour": {
+          "type": "string",
+          "x-go-name": "Hour"
+        },
+        "minute": {
+          "type": "string",
+          "x-go-name": "Minute"
+        },
+        "month": {
+          "type": "string",
+          "x-go-name": "Month"
+        },
+        "second": {
+          "type": "string",
+          "x-go-name": "Second"
+        },
+        "week": {
+          "type": "string",
+          "x-go-name": "Week"
+        }
+      },
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/doser"
+    },
+    "analogInput": {
+      "type": "object",
+      "properties": {
+        "driver": {
+          "type": "string",
+          "x-go-name": "Driver"
+        },
+        "id": {
+          "type": "string",
+          "x-go-name": "ID"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "pin": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Pin"
+        }
+      },
+      "x-go-name": "AnalogInput",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/connectors"
+    },
+    "ato": {
+      "type": "object",
+      "properties": {
+        "control": {
+          "type": "boolean",
+          "x-go-name": "Control"
+        },
+        "disable_on_alert": {
+          "type": "boolean",
+          "x-go-name": "DisableOnAlert"
+        },
+        "enable": {
+          "type": "boolean",
+          "x-go-name": "Enable"
+        },
+        "id": {
+          "type": "string",
+          "x-go-name": "ID"
+        },
+        "inlet": {
+          "type": "string",
+          "x-go-name": "Inlet"
+        },
+        "is_macro": {
+          "type": "boolean",
+          "x-go-name": "IsMacro"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "notify": {
+          "$ref": "#/definitions/Notify"
+        },
+        "period": {
+          "$ref": "#/definitions/Duration"
+        },
+        "pump": {
+          "type": "string",
+          "x-go-name": "Pump"
+        }
+      },
+      "x-go-name": "ATO",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/ato"
+    },
+    "cameraConfig": {
+      "type": "object",
+      "properties": {
+        "capture_flags": {
+          "type": "string",
+          "x-go-name": "CaptureFlags"
+        },
+        "enable": {
+          "type": "boolean",
+          "x-go-name": "Enable"
+        },
+        "image_directory": {
+          "type": "string",
+          "x-go-name": "ImageDirectory"
+        },
+        "motion": {
+          "$ref": "#/definitions/MotionConfig"
+        },
+        "tick_interval": {
+          "$ref": "#/definitions/Duration"
+        },
+        "upload": {
+          "type": "boolean",
+          "x-go-name": "Upload"
+        }
+      },
+      "x-go-name": "Config",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/camera"
+    },
+    "capabilities": {
+      "type": "object",
+      "properties": {
+        "ato": {
+          "type": "boolean",
+          "x-go-name": "ATO"
+        },
+        "camera": {
+          "type": "boolean",
+          "x-go-name": "Camera"
+        },
+        "configuration": {
+          "type": "boolean",
+          "x-go-name": "Configuration"
+        },
+        "dashboard": {
+          "type": "boolean",
+          "x-go-name": "Dashboard"
+        },
+        "dev_mode": {
+          "type": "boolean",
+          "x-go-name": "DevMode"
+        },
+        "doser": {
+          "type": "boolean",
+          "x-go-name": "Doser"
+        },
+        "equipment": {
+          "type": "boolean",
+          "x-go-name": "Equipment"
+        },
+        "health_check": {
+          "type": "boolean",
+          "x-go-name": "HealthCheck"
+        },
+        "lighting": {
+          "type": "boolean",
+          "x-go-name": "Lighting"
+        },
+        "macro": {
+          "type": "boolean",
+          "x-go-name": "Macro"
+        },
+        "ph": {
+          "type": "boolean",
+          "x-go-name": "Ph"
+        },
+        "temperature": {
+          "type": "boolean",
+          "x-go-name": "Temperature"
+        },
+        "timers": {
+          "type": "boolean",
+          "x-go-name": "Timers"
+        }
+      },
+      "x-go-name": "Capabilities",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/settings"
+    },
+    "channel": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "type": "string",
+          "x-go-name": "Color"
+        },
+        "manual": {
+          "type": "boolean",
+          "x-go-name": "Manual"
+        },
+        "max": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "Max"
+        },
+        "min": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "Min"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "on": {
+          "type": "boolean",
+          "x-go-name": "On"
+        },
+        "pin": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Pin"
+        },
+        "profile": {
+          "$ref": "#/definitions/ProfileSpec"
+        },
+        "value": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "Value"
+        }
+      },
+      "x-go-name": "Channel",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/lighting"
+    },
+    "credentials": {
+      "type": "object",
+      "properties": {
+        "password": {
+          "type": "string",
+          "x-go-name": "Password"
+        },
+        "user": {
+          "type": "string",
+          "x-go-name": "User"
+        }
+      },
+      "x-go-name": "Credentials",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/utils"
+    },
+    "dashboard": {
+      "type": "object",
+      "properties": {
+        "column": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Column"
+        },
+        "grid_details": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Chart"
+            }
+          },
+          "x-go-name": "GridDetails"
+        },
+        "height": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Height"
+        },
+        "row": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Row"
+        },
+        "width": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Width"
+        }
+      },
+      "x-go-name": "Dashboard",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/daemon"
+    },
+    "doserCalibrationDetails": {
+      "type": "object",
+      "properties": {
+        "duration": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "Duration"
+        },
+        "speed": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "Speed"
+        }
+      },
+      "x-go-name": "CalibrationDetails",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/doser"
+    },
+    "dosingRegiment": {
+      "type": "object",
+      "properties": {
+        "duration": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "Duration"
+        },
+        "enable": {
+          "type": "boolean",
+          "x-go-name": "Enable"
+        },
+        "schedule": {
+          "$ref": "#/definitions/Schedule"
+        },
+        "speed": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "Speed"
+        }
+      },
+      "x-go-name": "DosingRegiment",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/doser"
+    },
+    "driver": {
+      "type": "object",
+      "properties": {
+        "config": {
+          "type": "object",
+          "x-go-name": "Config"
+        },
+        "id": {
+          "type": "string",
+          "x-go-name": "ID"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Parameters"
+        },
+        "pinmap": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "x-go-name": "PinMap"
+        },
+        "type": {
+          "type": "string",
+          "x-go-name": "Type"
+        }
+      },
+      "x-go-name": "Driver",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/drivers"
+    },
+    "equipment": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "x-go-name": "ID"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "on": {
+          "type": "boolean",
+          "x-go-name": "On"
+        },
+        "outlet": {
+          "type": "string",
+          "x-go-name": "Outlet"
+        }
+      },
+      "x-go-name": "Equipment",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/equipment"
+    },
+    "equipmentAction": {
+      "type": "object",
+      "properties": {
+        "on": {
+          "type": "boolean",
+          "x-go-name": "On"
+        }
+      },
+      "x-go-name": "EquipmentAction",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/equipment"
+    },
+    "error": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Count"
+        },
+        "id": {
+          "type": "string",
+          "x-go-name": "ID"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        },
+        "time": {
+          "type": "string",
+          "x-go-name": "Time"
+        }
+      },
+      "x-go-name": "Error",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/daemon"
+    },
+    "inlet": {
+      "type": "object",
+      "properties": {
+        "driver": {
+          "type": "string",
+          "x-go-name": "Driver"
+        },
+        "equipment": {
+          "type": "string",
+          "x-go-name": "Equipment"
+        },
+        "id": {
+          "type": "string",
+          "x-go-name": "ID"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "pin": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Pin"
+        },
+        "reverse": {
+          "type": "boolean",
+          "x-go-name": "Reverse"
+        }
+      },
+      "x-go-name": "Inlet",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/connectors"
+    },
+    "jack": {
+      "type": "object",
+      "properties": {
+        "driver": {
+          "type": "string",
+          "x-go-name": "Driver"
+        },
+        "id": {
+          "type": "string",
+          "x-go-name": "ID"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "pins": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "x-go-name": "Pins"
+        },
+        "reverse": {
+          "type": "boolean",
+          "x-go-name": "Reverse"
+        }
+      },
+      "x-go-name": "Jack",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/connectors"
+    },
+    "light": {
+      "properties": {
+        "channels": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/channel"
+          },
+          "x-go-name": "Channels"
+        },
+        "enable": {
+          "type": "boolean",
+          "x-go-name": "Enable"
+        },
+        "id": {
+          "type": "string",
+          "x-go-name": "ID"
+        },
+        "jack": {
+          "type": "string",
+          "x-go-name": "Jack"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        }
+      }
+    },
+    "outlet": {
+      "type": "object",
+      "properties": {
+        "driver": {
+          "type": "string",
+          "x-go-name": "Driver"
+        },
+        "equipment": {
+          "type": "string",
+          "x-go-name": "Equipment"
+        },
+        "id": {
+          "type": "string",
+          "x-go-name": "ID"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "pin": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Pin"
+        },
+        "reverse": {
+          "type": "boolean",
+          "x-go-name": "Reverse"
+        }
+      },
+      "x-go-name": "Outlet",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/connectors"
+    },
+    "pump": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "x-go-name": "ID"
+        },
+        "jack": {
+          "type": "string",
+          "x-go-name": "Jack"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "pin": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Pin"
+        },
+        "regiment": {
+          "$ref": "#/definitions/dosingRegiment"
+        }
+      },
+      "x-go-name": "Pump",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/doser"
+    },
+    "settings": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string",
+          "x-go-name": "Address"
+        },
+        "capabilities": {
+          "$ref": "#/definitions/capabilities"
+        },
+        "display": {
+          "type": "boolean",
+          "x-go-name": "Display"
+        },
+        "health_check": {
+          "$ref": "#/definitions/HealthCheckNotify"
+        },
+        "https": {
+          "type": "boolean",
+          "x-go-name": "HTTPS"
+        },
+        "interface": {
+          "type": "string",
+          "x-go-name": "Interface"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "notification": {
+          "type": "boolean",
+          "x-go-name": "Notification"
+        },
+        "pprof": {
+          "type": "boolean",
+          "x-go-name": "Pprof"
+        },
+        "prometheus": {
+          "type": "boolean",
+          "x-go-name": "Prometheus"
+        },
+        "rpi_pwm_freq": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "RPI_PWMFreq"
+        }
+      },
+      "x-go-name": "Settings",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/settings"
+    },
+    "statsResponse": {
+      "type": "object",
+      "properties": {
+        "current": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Metric"
+          },
+          "x-go-name": "Current"
+        },
+        "historical": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Metric"
+          },
+          "x-go-name": "Historical"
+        }
+      },
+      "x-go-name": "StatsResponse",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/telemetry"
+    },
+    "telemetryConfig": {
+      "type": "object",
+      "properties": {
+        "adafruitio": {
+          "$ref": "#/definitions/AdafruitIO"
+        },
+        "current_limit": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "CurrentLimit"
+        },
+        "historical_limit": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "HistoricalLimit"
+        },
+        "mailer": {
+          "$ref": "#/definitions/MailerConfig"
+        },
+        "notify": {
+          "type": "boolean",
+          "x-go-name": "Notify"
+        },
+        "prometheus": {
+          "type": "boolean",
+          "x-go-name": "Prometheus"
+        },
+        "throttle": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Throttle"
+        }
+      },
+      "x-go-name": "TelemetryConfig",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/telemetry"
+    }
+  }
+}

--- a/swagger.json
+++ b/swagger.json
@@ -5,6 +5,45 @@
     "version": "0.0.1"
   },
   "paths": {
+    "/api/admin/poweroff": {
+      "post": {
+        "description": "Shut down the raspberry pi.",
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Shut down the raspberry pi.",
+        "operationId": "adminPowerOff",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/admin/reboot": {
+      "post": {
+        "description": "Reboot the raspberry pi.",
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Reboot the raspberry pi.",
+        "operationId": "adminReboot",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/admin/reload": {
+      "post": {
+        "description": "Reload reef-pi to apply any capability changes or other modules that are registered at startup.",
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Reload reef-pi.",
+        "operationId": "adminReload",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
     "/api/analog_inputs": {
       "get": {
         "description": "List all Analog Inputs in reef-pi.",
@@ -506,6 +545,72 @@
           "200": {
             "description": "OK"
           }
+        }
+      }
+    },
+    "/api/display": {
+      "get": {
+        "description": "Get current display state.",
+        "tags": [
+          "Display"
+        ],
+        "summary": "Get current display state.",
+        "operationId": "systemDisplayGet",
+        "responses": {
+          "200": {
+            "description": "displayState",
+            "schema": {
+              "$ref": "#/definitions/displayState"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Set display brigthness\nSet display brightness",
+        "tags": [
+          "Display"
+        ],
+        "operationId": "systemDisplayPost",
+        "parameters": [
+          {
+            "name": "displayconfig",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/displayConfig"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/display/off": {
+      "post": {
+        "description": "Turn display off.",
+        "tags": [
+          "Display"
+        ],
+        "summary": "Turn display off.",
+        "operationId": "systemDisplayOff",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/display/on": {
+      "post": {
+        "description": "Turn display on.",
+        "tags": [
+          "Display"
+        ],
+        "summary": "Turn display on.",
+        "operationId": "systemDisplayOn",
+        "responses": {
+          "200": {}
         }
       }
     },
@@ -1221,6 +1326,24 @@
         }
       }
     },
+    "/api/info": {
+      "get": {
+        "description": "Get system summary.",
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Get system summary.",
+        "operationId": "adminInfo",
+        "responses": {
+          "200": {
+            "description": "systemSummary",
+            "schema": {
+              "$ref": "#/definitions/systemSummary"
+            }
+          }
+        }
+      }
+    },
     "/api/inlets": {
       "get": {
         "description": "List all inlets in reef-pi.",
@@ -1679,6 +1802,201 @@
         }
       }
     },
+    "/api/macros": {
+      "get": {
+        "description": "List all macros in reef-pi.",
+        "tags": [
+          "Macros"
+        ],
+        "summary": "List all macros.",
+        "operationId": "macroList",
+        "responses": {
+          "200": {
+            "description": "macro",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/macro"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Create a new macro.",
+        "tags": [
+          "Macros"
+        ],
+        "summary": "Create a macro.",
+        "operationId": "macroCreate",
+        "parameters": [
+          {
+            "description": "The macro to create",
+            "name": "macro",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/macro"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/macros/{id}": {
+      "get": {
+        "description": "Get an existing macro by id.",
+        "tags": [
+          "Macros"
+        ],
+        "summary": "Get a macro by id.",
+        "operationId": "macroGet",
+        "parameters": [
+          {
+            "description": "The Id of the macro",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/macro"
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "post": {
+        "description": "Update an existing macro.",
+        "tags": [
+          "Macros"
+        ],
+        "summary": "Update a macro.",
+        "operationId": "macroUpdate",
+        "parameters": [
+          {
+            "description": "The Id of the macro to update",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The macro to update",
+            "name": "macro",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/macro"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete an existing macro.",
+        "tags": [
+          "Macros"
+        ],
+        "summary": "Delete a macro.",
+        "operationId": "macroDelete",
+        "parameters": [
+          {
+            "description": "The Id of the macro to delete",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/macros/{id}/revert": {
+      "post": {
+        "description": "Revert a macro in reverse.",
+        "tags": [
+          "Macros"
+        ],
+        "summary": "Reverse a macro.",
+        "operationId": "macroRevert",
+        "parameters": [
+          {
+            "description": "The Id of the macro to revert",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/api/macros/{id}/run": {
+      "post": {
+        "description": "Run a macro.",
+        "tags": [
+          "Macros"
+        ],
+        "summary": "Run a macro.",
+        "operationId": "macroRun",
+        "parameters": [
+          {
+            "description": "The Id of the macro to run",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
     "/api/me": {
       "get": {
         "description": "Ping API to determine if server is running.",
@@ -1830,6 +2148,283 @@
         }
       }
     },
+    "/api/phprobes": {
+      "get": {
+        "description": "List all ph probes in reef-pi.",
+        "tags": [
+          "PhProbes"
+        ],
+        "summary": "List all ph probes.",
+        "operationId": "phProbeList",
+        "responses": {
+          "200": {
+            "description": "phProbe",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/phProbe"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Create a new ph probe.",
+        "tags": [
+          "PhProbes"
+        ],
+        "summary": "Create a ph probe.",
+        "operationId": "phProbeCreate",
+        "parameters": [
+          {
+            "description": "The ph probe to create",
+            "name": "phProbe",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/phProbe"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/phprobes/{id}": {
+      "get": {
+        "description": "Get an existing ph probe by id.",
+        "tags": [
+          "PhProbes"
+        ],
+        "summary": "Get an ph probe by id.",
+        "operationId": "phProbeGet",
+        "parameters": [
+          {
+            "description": "The Id of the ph probe",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/phProbe"
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "post": {
+        "description": "Update an existing ph probe.",
+        "tags": [
+          "PhProbes"
+        ],
+        "summary": "Update a ph probe.",
+        "operationId": "phProbeUpdate",
+        "parameters": [
+          {
+            "description": "The Id of the ph probe to update",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The ph probe to update",
+            "name": "phProbe",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/phProbe"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete an existing ph probe.",
+        "tags": [
+          "PhProbes"
+        ],
+        "summary": "Delete a ph probe.",
+        "operationId": "phProbeDelete",
+        "parameters": [
+          {
+            "description": "The Id of the ph probe to delete",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/phprobes/{id}/calibrate": {
+      "post": {
+        "description": "Set calibration points for one or two point calibration",
+        "tags": [
+          "PhProbes"
+        ],
+        "summary": "Calibrate a ph probe.",
+        "operationId": "phProbeCalibrate",
+        "parameters": [
+          {
+            "description": "The Id of the ph probe to calibrate",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The calibration measurements",
+            "name": "measurements",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "expected": {
+                    "description": "The expected value",
+                    "type": "float64",
+                    "format": "float"
+                  },
+                  "observed": {
+                    "description": "The actual value observed",
+                    "type": "float64",
+                    "format": "float"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/phprobes/{id}/calibratepoint": {
+      "post": {
+        "description": "Set a calibration point for one or two point calibration",
+        "tags": [
+          "PhProbes"
+        ],
+        "summary": "Calibrate a ph probe.",
+        "operationId": "phProbeCalibrateSingle",
+        "parameters": [
+          {
+            "description": "The Id of the ph probe to calibrate",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The calibration measurement",
+            "name": "measurements",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/calibrationPoint"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/phprobes/{id}/read": {
+      "get": {
+        "description": "Get ph probe reading.",
+        "tags": [
+          "PhProbes"
+        ],
+        "summary": "Get ph probe reading.",
+        "operationId": "phProbeRead",
+        "parameters": [
+          {
+            "description": "The Id of the ph probe to read",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/phprobes/{id}/readings": {
+      "get": {
+        "description": "Get ph probe readings.",
+        "tags": [
+          "PhProbes"
+        ],
+        "summary": "Get ph probe readings.",
+        "operationId": "phProbeReadings",
+        "parameters": [
+          {
+            "description": "The Id of the ph probe to delete",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/statsResponse"
+            }
+          }
+        }
+      }
+    },
     "/api/settings": {
       "get": {
         "description": "List all settings in reef-pi.",
@@ -1868,6 +2463,237 @@
         "responses": {
           "200": {
             "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/tcs": {
+      "get": {
+        "description": "List all temperature controllers in reef-pi.",
+        "tags": [
+          "Temperature"
+        ],
+        "summary": "List all temperature controllers.",
+        "operationId": "tcsList",
+        "responses": {
+          "200": {
+            "description": "temperatureController",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/temperatureController"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Create a new temperature controller.",
+        "tags": [
+          "Temperature"
+        ],
+        "summary": "Create a temperature controller.",
+        "operationId": "tcsCreate",
+        "parameters": [
+          {
+            "description": "The temperature controller to create",
+            "name": "temperatureController",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/temperatureController"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/tcs/sensors": {
+      "get": {
+        "description": "List all temperature sensors detected by the OS.",
+        "tags": [
+          "Temperature"
+        ],
+        "summary": "List all temperature sensors.",
+        "operationId": "tcsList",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/tcs/{id}": {
+      "get": {
+        "description": "Get an existing temperature controller by id.",
+        "tags": [
+          "Temperature"
+        ],
+        "summary": "Get an temperature controller by id.",
+        "operationId": "tcsGet",
+        "parameters": [
+          {
+            "description": "The Id of the temperature controller",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/temperatureController"
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "post": {
+        "description": "Update an existing temperature controller.",
+        "tags": [
+          "Temperature"
+        ],
+        "summary": "Update a temperature controller.",
+        "operationId": "tcsUpdate",
+        "parameters": [
+          {
+            "description": "The Id of the temperature controller to update",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The temperature controller to update",
+            "name": "temperatureController",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/temperatureController"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete an existing temperature controller.",
+        "tags": [
+          "Temperature"
+        ],
+        "summary": "Delete a temperature controller.",
+        "operationId": "tcsDelete",
+        "parameters": [
+          {
+            "description": "The Id of the temperature controller to delete",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/tcs/{id}/current_reading": {
+      "get": {
+        "description": "Get temperature controller reading.",
+        "tags": [
+          "Temperature"
+        ],
+        "summary": "Get temperature controller reading.",
+        "operationId": "tcsRead",
+        "parameters": [
+          {
+            "description": "The Id of the temperature controller to read",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/tcs/{id}/read": {
+      "get": {
+        "description": "Get temperature controller reading.",
+        "tags": [
+          "Temperature"
+        ],
+        "summary": "Get temperature controller reading.",
+        "operationId": "tcsRead",
+        "parameters": [
+          {
+            "description": "The Id of the temperature controller to read",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/tcs/{id}/usage": {
+      "get": {
+        "description": "Get usage history for a given temperature controller.",
+        "tags": [
+          "Temperature"
+        ],
+        "summary": "Get usage history.",
+        "operationId": "tcsUsage",
+        "parameters": [
+          {
+            "description": "The Id of the temperature controller",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -1924,6 +2750,140 @@
         "operationId": "telemetryTest",
         "responses": {
           "200": {}
+        }
+      }
+    },
+    "/api/timers": {
+      "get": {
+        "description": "List all timer jobs in reef-pi.",
+        "tags": [
+          "Timers"
+        ],
+        "summary": "List all timer jobs.",
+        "operationId": "timerList",
+        "responses": {
+          "200": {
+            "description": "timerJob",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/timerJob"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Create a new timer job.",
+        "tags": [
+          "Timers"
+        ],
+        "summary": "Create a timer job.",
+        "operationId": "timerCreate",
+        "parameters": [
+          {
+            "description": "The timer job to create",
+            "name": "timer",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/timerJob"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/timers/{id}": {
+      "get": {
+        "description": "Get timer.",
+        "tags": [
+          "Timers"
+        ],
+        "summary": "Get timer.",
+        "operationId": "timerGet",
+        "parameters": [
+          {
+            "description": "The Id of the timer",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/timerJob"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Update an existing timer job.",
+        "tags": [
+          "Timers"
+        ],
+        "summary": "Update a timer job.",
+        "operationId": "timerUpdate",
+        "parameters": [
+          {
+            "description": "The Id of the timer job to update",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The timer job to update",
+            "name": "timer",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/timerJob"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete an existing timer job.",
+        "tags": [
+          "Timers"
+        ],
+        "summary": "Delete a timer job.",
+        "operationId": "timerDelete",
+        "parameters": [
+          {
+            "description": "The Id of the timer job to delete",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
       }
     }
@@ -2021,6 +2981,22 @@
       },
       "x-go-package": "github.com/reef-pi/reef-pi/controller/telemetry"
     },
+    "Measurement": {
+      "type": "object",
+      "properties": {
+        "expected": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "Expected"
+        },
+        "observed": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "Observed"
+        }
+      },
+      "x-go-package": "github.com/reef-pi/hal"
+    },
     "Metric": {
       "type": "object",
       "x-go-package": "github.com/reef-pi/reef-pi/controller/telemetry"
@@ -2049,6 +3025,12 @@
       },
       "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/camera"
     },
+    "Mutex": {
+      "description": "A Mutex must not be copied after first use.",
+      "type": "object",
+      "title": "A Mutex is a mutual exclusion lock.\nThe zero value for a Mutex is an unlocked mutex.",
+      "x-go-package": "sync"
+    },
     "Notify": {
       "type": "object",
       "properties": {
@@ -2057,12 +3039,17 @@
           "x-go-name": "Enable"
         },
         "max": {
-          "type": "integer",
-          "format": "int64",
+          "type": "number",
+          "format": "double",
           "x-go-name": "Max"
+        },
+        "min": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "Min"
         }
       },
-      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/ato"
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/temperature"
     },
     "ProfileSpec": {
       "type": "object",
@@ -2121,6 +3108,20 @@
         }
       },
       "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/doser"
+    },
+    "Step": {
+      "type": "object",
+      "properties": {
+        "config": {
+          "type": "object",
+          "x-go-name": "Config"
+        },
+        "type": {
+          "type": "string",
+          "x-go-name": "Type"
+        }
+      },
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/macro"
     },
     "analogInput": {
       "type": "object",
@@ -2190,6 +3191,27 @@
       },
       "x-go-name": "ATO",
       "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/ato"
+    },
+    "calibrationPoint": {
+      "type": "object",
+      "properties": {
+        "expected": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "Expected"
+        },
+        "observed": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "Observed"
+        },
+        "type": {
+          "type": "string",
+          "x-go-name": "Type"
+        }
+      },
+      "x-go-name": "CalibrationPoint",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/ph"
     },
     "cameraConfig": {
       "type": "object",
@@ -2377,6 +3399,38 @@
       "x-go-name": "Dashboard",
       "x-go-package": "github.com/reef-pi/reef-pi/controller/daemon"
     },
+    "displayConfig": {
+      "type": "object",
+      "properties": {
+        "brightness": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Brightness"
+        },
+        "enable": {
+          "type": "boolean",
+          "x-go-name": "Enable"
+        }
+      },
+      "x-go-name": "DisplayConfig",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/system"
+    },
+    "displayState": {
+      "type": "object",
+      "properties": {
+        "brightness": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Brightness"
+        },
+        "on": {
+          "type": "boolean",
+          "x-go-name": "On"
+        }
+      },
+      "x-go-name": "DisplayState",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/system"
+    },
     "doserCalibrationDetails": {
       "type": "object",
       "properties": {
@@ -2549,6 +3603,37 @@
       "x-go-name": "Inlet",
       "x-go-package": "github.com/reef-pi/reef-pi/controller/connectors"
     },
+    "instance": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string",
+          "x-go-name": "Addr"
+        },
+        "id": {
+          "type": "string",
+          "x-go-name": "ID"
+        },
+        "ignore_https": {
+          "type": "boolean",
+          "x-go-name": "IgnoreHTTPS"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "password": {
+          "type": "string",
+          "x-go-name": "Password"
+        },
+        "user": {
+          "type": "string",
+          "x-go-name": "User"
+        }
+      },
+      "x-go-name": "Instance",
+      "x-go-package": "github.com/reef-pi/reef-pi/manager"
+    },
     "jack": {
       "type": "object",
       "properties": {
@@ -2607,6 +3692,32 @@
         }
       }
     },
+    "macro": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "x-go-name": "ID"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "reversible": {
+          "type": "boolean",
+          "x-go-name": "Reversible"
+        },
+        "steps": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Step"
+          },
+          "x-go-name": "Steps"
+        }
+      },
+      "x-go-name": "Macro",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/macro"
+    },
     "outlet": {
       "type": "object",
       "properties": {
@@ -2638,6 +3749,66 @@
       },
       "x-go-name": "Outlet",
       "x-go-package": "github.com/reef-pi/reef-pi/controller/connectors"
+    },
+    "phProbe": {
+      "type": "object",
+      "properties": {
+        "analog_input": {
+          "type": "string",
+          "x-go-name": "AnalogInput"
+        },
+        "control": {
+          "type": "boolean",
+          "x-go-name": "Control"
+        },
+        "downer_eq": {
+          "type": "string",
+          "x-go-name": "DownerEq"
+        },
+        "enable": {
+          "type": "boolean",
+          "x-go-name": "Enable"
+        },
+        "hysteresis": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "Hysteresis"
+        },
+        "id": {
+          "type": "string",
+          "x-go-name": "ID"
+        },
+        "is_macro": {
+          "type": "boolean",
+          "x-go-name": "IsMacro"
+        },
+        "max": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "Max"
+        },
+        "min": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "Min"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "notify": {
+          "$ref": "#/definitions/Notify"
+        },
+        "period": {
+          "$ref": "#/definitions/Duration"
+        },
+        "upper_eq": {
+          "type": "string",
+          "x-go-name": "UpperEq"
+        }
+      },
+      "x-go-name": "Probe",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/ph"
     },
     "pump": {
       "type": "object",
@@ -2737,6 +3908,41 @@
       "x-go-name": "StatsResponse",
       "x-go-package": "github.com/reef-pi/reef-pi/controller/telemetry"
     },
+    "systemSummary": {
+      "type": "object",
+      "properties": {
+        "cpu_temperature": {
+          "type": "string",
+          "x-go-name": "CPUTemperature"
+        },
+        "current_time": {
+          "type": "string",
+          "x-go-name": "CurrentTime"
+        },
+        "ip": {
+          "type": "string",
+          "x-go-name": "IP"
+        },
+        "model": {
+          "type": "string",
+          "x-go-name": "Model"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "uptime": {
+          "type": "string",
+          "x-go-name": "Uptime"
+        },
+        "version": {
+          "type": "string",
+          "x-go-name": "Version"
+        }
+      },
+      "x-go-name": "Summary",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/system"
+    },
     "telemetryConfig": {
       "type": "object",
       "properties": {
@@ -2772,6 +3978,128 @@
       },
       "x-go-name": "TelemetryConfig",
       "x-go-package": "github.com/reef-pi/reef-pi/controller/telemetry"
+    },
+    "temperatureController": {
+      "type": "object",
+      "properties": {
+        "calibration_points": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Measurement"
+          },
+          "x-go-name": "CalibrationPoints"
+        },
+        "control": {
+          "type": "boolean",
+          "x-go-name": "Control"
+        },
+        "cooler": {
+          "type": "string",
+          "x-go-name": "Cooler"
+        },
+        "enable": {
+          "type": "boolean",
+          "x-go-name": "Enable"
+        },
+        "fahrenheit": {
+          "type": "boolean",
+          "x-go-name": "Fahrenheit"
+        },
+        "heater": {
+          "type": "string",
+          "x-go-name": "Heater"
+        },
+        "hysteresis": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "Hysteresis"
+        },
+        "id": {
+          "type": "string",
+          "x-go-name": "ID"
+        },
+        "is_macro": {
+          "type": "boolean",
+          "x-go-name": "IsMacro"
+        },
+        "max": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "Max"
+        },
+        "min": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "Min"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "notify": {
+          "$ref": "#/definitions/Notify"
+        },
+        "period": {
+          "$ref": "#/definitions/Duration"
+        },
+        "sensor": {
+          "type": "string",
+          "x-go-name": "Sensor"
+        }
+      },
+      "x-go-name": "TC",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/temperature"
+    },
+    "timerJob": {
+      "type": "object",
+      "properties": {
+        "day": {
+          "type": "string",
+          "x-go-name": "Day"
+        },
+        "enable": {
+          "type": "boolean",
+          "x-go-name": "Enable"
+        },
+        "hour": {
+          "type": "string",
+          "x-go-name": "Hour"
+        },
+        "id": {
+          "type": "string",
+          "x-go-name": "ID"
+        },
+        "minute": {
+          "type": "string",
+          "x-go-name": "Minute"
+        },
+        "month": {
+          "type": "string",
+          "x-go-name": "Month"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "second": {
+          "type": "string",
+          "x-go-name": "Second"
+        },
+        "target": {
+          "type": "object",
+          "x-go-name": "Target"
+        },
+        "type": {
+          "type": "string",
+          "x-go-name": "Type"
+        },
+        "week": {
+          "type": "string",
+          "x-go-name": "Week"
+        }
+      },
+      "x-go-name": "Job",
+      "x-go-package": "github.com/reef-pi/reef-pi/controller/modules/timer"
     }
   }
 }

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,0 +1,20 @@
+definitions:
+  light:
+    properties:
+      channels:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/channel'
+        x-go-name: Channels
+      enable:
+        type: boolean
+        x-go-name: Enable
+      id:
+        type: string
+        x-go-name: ID
+      jack:
+        type: string
+        x-go-name: Jack
+      name:
+        type: string
+        x-go-name: Name


### PR DESCRIPTION
Add open api documentation.  This is almost entirely comment documentation using [go-swagger](https://github.com/go-swagger/go-swagger).

Use make spec to update the open api spec file.
Use make serve-spec to serve the spec locally using [redoc-cli](https://github.com/Redocly/redoc/blob/master/cli/README.md).

swagger.json  can be served from github to support api documentation on reef-pi.com (or even on github itself) once this PR is reviewed and merged.