### PR TITLE
Use nvm latest version for golang ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,30 @@
-language: go
-go:
-  - "1.13"
-before_install:
-  - curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
-  - sudo  apt-get install -y nodejs libasound2-dev
-  - sudo npm install -g npm
-script:
-  - ./build/ci.sh
-  - bash <(curl -s https://codecov.io/bash) -cF go
-  - make pi
-  - bundle install
-  - sudo chown -R $USER /home/travis/.npm
-  - /usr/bin/npm install --no-optional
-  - make build-ui
-  - npm run js-lint
-  - make sass-lint
-  - npm test
-  - bash <(curl -s https://codecov.io/bash) -cF javascript
-  - make clean
-  - make go
-  - make deb
+matrix:
+  include:
+    - language: go
+      go:
+        - "1.13"
+      before_install:
+        - sudo apt-get install -y libasound2-dev
+        - nvm use node
+      install:
+        - npm ci
+      script:
+        - ./build/ci.sh
+        - bash <(curl -s https://codecov.io/bash) -cF go
+        - make pi
+        - bundle install
+        - make clean
+        - make go
+        - make deb
+
+    - language: node_js
+      node_js:
+        - "lts/*"
+      install:
+        - npm ci
+      script:
+        - npm run build
+        - npm run js-lint
+        - npm run sass-lint
+        - npm test
+        - bash <(curl -s https://codecov.io/bash) -cF javascript


### PR DESCRIPTION
Use nvm latest version for golang ci
Split ci between back end and front end
switch to npm ci to improve ci speed

Fixes #1207 