### PR TITLE
(feat) serve api doc straight from the controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ ui-dev:
 	npm run ui-dev
 
 .PHONY: deb
-deb: ui
+deb: ui api-doc
 	mkdir -p dist/var/lib/reef-pi/ui dist/usr/bin dist/etc/reef-pi
 	cp bin/reef-pi dist/usr/bin/reef-pi
 	cp -r ui/* dist/var/lib/reef-pi/ui
@@ -121,3 +121,5 @@ spec:
 .PHONY: serve-spec
 serve-spec:
 	npx redoc-cli serve swagger.json -p 8888
+api-doc:
+	npx redoc-cli bundle swagger.json -o ui/assets/api.html

--- a/front-end/src/summary.jsx
+++ b/front-end/src/summary.jsx
@@ -25,6 +25,7 @@ export default class Summary extends React.Component {
           <li className='list-inline-item'>{i18n.t('running')} {this.props.info.version}, on {this.props.info.model}</li>
           <li className='list-inline-item'>{i18n.t('since')} {this.props.info.uptime} | </li>
           <li className='list-inline-item'>IP {this.props.info.ip} | </li>
+          <li className='list-inline-item'><a href='/assets/api.html'>API</a> | </li>
           <li className='list-inline-item text-danger'>{i18n.t('errors')}({this.props.errors.length})</li>
         </ul>
       </nav>


### PR DESCRIPTION
users will be able to see the relevant api docs for their reef-pi version from controller itself under /assets/api.html path