### PR TITLE
Rename TwoDecimal method and move to utils package

### DIFF
--- a/controller/homestatsis.go
+++ b/controller/homestatsis.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"github.com/reef-pi/reef-pi/controller/utils"
 	"log"
 	"math"
 	"time"
@@ -35,7 +36,7 @@ func (o1 Observation) Rollup(o telemetry.Metric) (telemetry.Metric, bool) {
 		Upper:  o1.Upper + o2.Upper,
 		Downer: o1.Downer + o2.Downer,
 		Time:   o1.Time,
-		Value:  telemetry.TwoDecimal((o1.total + o2.Value) / float64(o1.len+1)),
+		Value:  utils.RoundToTwoDecimal((o1.total + o2.Value) / float64(o1.len+1)),
 		total:  o1.total + o2.Value,
 		len:    o1.len + 1,
 	}, false

--- a/controller/modules/ph/probe.go
+++ b/controller/modules/ph/probe.go
@@ -3,6 +3,7 @@ package ph
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/reef-pi/reef-pi/controller/utils"
 	"log"
 	"math/rand"
 	"time"
@@ -147,10 +148,10 @@ func (c *Controller) Delete(id string) error {
 
 func (c *Controller) Read(p Probe) (float64, error) {
 	if c.devMode {
-		return telemetry.TwoDecimal(8 + rand.Float64()*2), nil
+		return utils.RoundToTwoDecimal(8 + rand.Float64()*2), nil
 	}
 	v, err := c.ais.Read(p.AnalogInput)
-	return telemetry.TwoDecimal(v), err
+	return utils.RoundToTwoDecimal(v), err
 }
 
 func (c *Controller) Run(p Probe, quit chan struct{}) error {

--- a/controller/modules/temperature/sensor.go
+++ b/controller/modules/temperature/sensor.go
@@ -3,6 +3,7 @@ package temperature
 import (
 	"bufio"
 	"fmt"
+	"github.com/reef-pi/reef-pi/controller/utils"
 	"io"
 	"log"
 	"math/rand"
@@ -10,8 +11,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-
-	"github.com/reef-pi/reef-pi/controller/telemetry"
 )
 
 func (c *Controller) Read(tc *TC) (float64, error) {
@@ -19,10 +18,10 @@ func (c *Controller) Read(tc *TC) (float64, error) {
 	if c.devMode {
 		log.Println("Temperature controller is running in dev mode, skipping sensor reading.")
 		if tc.Fahrenheit {
-			return telemetry.TwoDecimal(78.0 + (3 * rand.Float64())), nil
+			return utils.RoundToTwoDecimal(78.0 + (3 * rand.Float64())), nil
 		}
 
-		return telemetry.TwoDecimal(24.4 + (1.5 * rand.Float64())), nil
+		return utils.RoundToTwoDecimal(24.4 + (1.5 * rand.Float64())), nil
 	}
 
 	var v float64
@@ -73,5 +72,5 @@ func (t *TC) readTemperature(fi io.Reader) (float64, error) {
 	if t.Fahrenheit {
 		temp = ((temp * 9.0) / 5.0) + 32.0
 	}
-	return telemetry.TwoDecimal(temp), nil
+	return utils.RoundToTwoDecimal(temp), nil
 }

--- a/controller/telemetry/health.go
+++ b/controller/telemetry/health.go
@@ -59,8 +59,8 @@ func (m1 HealthMetric) Rollup(mx Metric) (Metric, bool) {
 		m.loadSum += m2.Load5
 		m.memorySum += m2.UsedMemory
 		m.len += 1
-		m.Load5 = TwoDecimal(m.loadSum / float64(m.len))
-		m.UsedMemory = TwoDecimal(m.memorySum / float64(m.len))
+		m.Load5 = utils.RoundToTwoDecimal(m.loadSum / float64(m.len))
+		m.UsedMemory = utils.RoundToTwoDecimal(m.memorySum / float64(m.len))
 		if m.UnderVoltage == 0 {
 			m.UnderVoltage = m2.UnderVoltage
 		}

--- a/controller/telemetry/mailer_test.go
+++ b/controller/telemetry/mailer_test.go
@@ -20,9 +20,3 @@ func TestMailer(t *testing.T) {
 		t.Error(err)
 	}
 }
-
-func TestTwoDecimal(t *testing.T) {
-	if TwoDecimal(1.2345) != 1.23 {
-		t.Error("Expected 1.23, found", TwoDecimal(1.2345))
-	}
-}

--- a/controller/telemetry/telemetry.go
+++ b/controller/telemetry/telemetry.go
@@ -1,25 +1,20 @@
 package telemetry
 
 import (
-	"errors"
-	"fmt"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/reef-pi/adafruitio"
-	"github.com/reef-pi/reef-pi/controller/storage"
-	"log"
-	"math"
-	"net/http"
-	"strings"
-	"sync"
-	"time"
+    "errors"
+    "fmt"
+    "github.com/prometheus/client_golang/prometheus"
+    "github.com/prometheus/client_golang/prometheus/promauto"
+    "github.com/reef-pi/adafruitio"
+    "github.com/reef-pi/reef-pi/controller/storage"
+    "log"
+    "net/http"
+    "strings"
+    "sync"
+    "time"
 )
 
 const DBKey = "telemetry"
-
-func TwoDecimal(f float64) float64 {
-	return math.Round(f*100) / 100
-}
 
 type ErrorLogger func(string, string) error
 

--- a/controller/utils/number.go
+++ b/controller/utils/number.go
@@ -1,0 +1,9 @@
+package utils
+
+import "math"
+
+//RoundToTwoDecimal Round float64 to 2 decimals
+func RoundToTwoDecimal(f float64) float64 {
+    return math.Round(f*100) / 100
+}
+

--- a/controller/utils/number_test.go
+++ b/controller/utils/number_test.go
@@ -1,0 +1,9 @@
+package utils
+
+import "testing"
+
+func TestTwoDecimal(t *testing.T) {
+    if rounded := RoundToTwoDecimal(1.2345); rounded != 1.23 {
+        t.Error("Expected 1.23, found", rounded)
+    }
+}


### PR DESCRIPTION
## Description

Rename `TwoDecimal` method to `RoundToTwoDecimal` and move from telemetry package to utils package

## Related Issue

None

## Motivation and Context

`TwoDecimal` method is used outside the telemetry controller in other parts and uses the same test file that the `Mailer`, but the main motivation for my side is to start to known how reef-pi project works.

## Screenshots (if appropriate):
