### PR TITLE
update go version in docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update -y && \
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     apt-get install -y nodejs && \
     npm install -g npm
-RUN curl https://dl.google.com/go/go1.12.4.linux-amd64.tar.gz > /tmp/go1.12.4.linux-amd64.tar.gz && \
-    tar xvzf /tmp/go1.12.4.linux-amd64.tar.gz -C /usr/local
+RUN curl https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz > /tmp/go1.13.4.linux-amd64.tar.gz && \
+    tar xvzf /tmp/go1.13.4.linux-amd64.tar.gz -C /usr/local
 
 
 ENV GOPATH=/gopath
@@ -23,11 +23,10 @@ WORKDIR /gopath/src/github.com/reef-pi/reef-pi
 COPY Makefile package.json package-lock.json /gopath/src/github.com/reef-pi/reef-pi/
 RUN npm install
 
-COPY Gopkg.lock Gopkg.toml controller/ /gopath/src/github.com/reef-pi/reef-pi/
+COPY controller/ /gopath/src/github.com/reef-pi/reef-pi/
 RUN make go-get
 
 # Copy the rest of the code base for building
 COPY . /gopath/src/github.com/reef-pi/reef-pi/
 
 RUN make bin
-USER 9000


### PR DESCRIPTION
While submitting a PR, please make sure the build is ok with Travis CI. If not fix it, and if you need help feel free to ask :blush: .

<!--- Provide a general summary of your changes in the Title above -->

## Description

The current Dockerfile does not build.  From looking at the errors it looks like the version of go it is using is too old, and go 1.13 at least is required.  

## Related Issue

NA

## Motivation and Context

I wanted to test the UI out before buying components and a raspberry pi to run it.

## Screenshots (if appropriate):
