### PR TITLE
add systemd watchdog support

### DIFF
--- a/build/reef-pi.service
+++ b/build/reef-pi.service
@@ -2,6 +2,8 @@
 Description=raspberry pi based reef tank controller
 
 [Service]
+Type=notify
+WatchdogSec=60s
 ExecStart=/usr/bin/reef-pi daemon -config /etc/reef-pi/config.yaml
 WorkingDirectory=/var/lib/reef-pi
 Restart=always

--- a/controller/daemon/reef_pi.go
+++ b/controller/daemon/reef_pi.go
@@ -79,6 +79,7 @@ func (r *ReefPi) Start() error {
 		go r.h.Start()
 	}
 	go r.watchdog.Start()
+	log.Println("reef-pi is up and running")
 
 	return nil
 }

--- a/controller/watchdog/watchdog.go
+++ b/controller/watchdog/watchdog.go
@@ -1,0 +1,33 @@
+package watchdog
+
+import (
+	"net"
+	"github.com/coreos/go-systemd/daemon"
+	"log"
+	"time"
+)
+
+type Watchdog interface {
+	watch()
+}
+
+func watch() {
+	interval, err := daemon.SdWatchdogEnabled(false)
+	if err != nil || interval == 0 {
+		log.Println("Warning: Watchdog not running, Error:", err)
+		return
+	}
+	for {
+		address := "127.0.0.1:80"
+		conn, err := net.Dial("tcp", address)
+		defer conn.Close()
+		if err == nil {
+			log.Println("INFO: notifiying watchdog")
+			daemon.SdNotify(false, daemon.SdNotifyWatchdog)
+			//conn.Close()
+		} else {
+			log.Println("Warning: Failed watchdog health check, Error:", err)
+		}
+		time.Sleep(interval / 3)
+	}
+}


### PR DESCRIPTION
While submitting a PR, please make sure the build is ok with Travis CI. If not fix it, and if you need help feel free to ask :blush: .

<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding support for systemd watchdog, so reef-pi service can be restarted if it hangs.  My golang isn't great, so please let me know if there are any issues.  The current health check is just to make sure that the address that is configured for reef-pi to listen on is accessible and acking to syn packets.

## Related Issue

NA

## Motivation and Context

Add support for systemd watchdog to allow systemd to restart reef-pi if it stops responding on the port/address it is listening on.

## Screenshots (if appropriate):
