### PR TITLE
Allow temperature sensors based on the MCP9808 (jc42 kernel driver) to work.

### DIFF
--- a/controller/modules/temperature/api.go
+++ b/controller/modules/temperature/api.go
@@ -1,13 +1,14 @@
 package temperature
 
 import (
-	"net/http"
-	"path/filepath"
+    "net/http"
+    "path/filepath"
+    "strings"
 
-	"github.com/gorilla/mux"
+    "github.com/gorilla/mux"
 
-	"github.com/reef-pi/hal"
-	"github.com/reef-pi/reef-pi/controller/utils"
+    "github.com/reef-pi/hal"
+    "github.com/reef-pi/reef-pi/controller/utils"
 )
 
 var (
@@ -247,7 +248,18 @@ func (t *Controller) sensors(w http.ResponseWriter, r *http.Request) {
 		for _, f := range fs {
 			sensors = append(sensors, filepath.Base(f))
 		}
-		return sensors, nil
+        if !t.devMode {
+            files, err := filepath.Glob("/sys/devices/platform/i2c@*/*/*/hwmon/hwmon*/temp1_input")
+            if err != nil {
+                return nil, err
+            }
+
+            for _, f := range files {
+                index := strings.Index(f, "/hwmon")
+                sensors = append(sensors, "i2c/" + filepath.Base(f[:index]))
+            }
+        }
+        return sensors, nil
 	}
 	utils.JSONGetResponse(fn, w, r)
 }

--- a/controller/modules/temperature/sensor.go
+++ b/controller/modules/temperature/sensor.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"github.com/reef-pi/reef-pi/controller/utils"
+    "errors"
 	"io"
 	"log"
 	"math/rand"
@@ -24,22 +25,70 @@ func (c *Controller) Read(tc *TC) (float64, error) {
 		return utils.RoundToTwoDecimal(24.4 + (1.5 * rand.Float64())), nil
 	}
 
-	var v float64
-	var err error
+	pieces := strings.Split(tc.Sensor, "/");
 
-	for attempt := 0; attempt <= 3; attempt++ {
-		fi, err := os.Open(filepath.Join("/sys/bus/w1/devices", tc.Sensor, "w1_slave"))
-		if err != nil {
-			return -1, err
-		}
-		v, err = tc.readTemperature(fi)
-		fi.Close()
-		if err == nil {
-			return v, err
-		}
-	}
+	if pieces[0] == "w1" {
+        var v float64
+        var err error
 
-	return v, err
+        for attempt := 0; attempt <= 3; attempt++ {
+            fi, err := os.Open(filepath.Join("/sys/bus/w1/devices", pieces[1], "w1_slave"))
+            if err != nil {
+                return -1, err
+            }
+            v, err = tc.readTemperature(fi)
+            err = fi.Close()
+            if err != nil {
+                return v, err
+            }
+        }
+
+        return v, err
+    }
+    if pieces[0] == "i2c" {
+        var v float64
+        var err error
+
+        files, err := filepath.Glob("/sys/devices/platform/i2c@*/*/" + pieces[1] + "/hwmon/hwmon*/temp1_input")
+        if (err != nil) {
+            return -1, err
+        }
+
+        if len(files) == 1 {
+            fi, err := os.Open(files[0])
+            if err != nil {
+                return -1, err
+            }
+            v, err = tc.read9808(fi)
+            err = fi.Close()
+            if err != nil {
+                return v, err
+            }
+        }
+
+        return v, err
+    }
+    return -1, errors.New("Invalid sensor type")
+}
+
+func (t *TC) read9808(fi io.Reader) (float64, error) {
+    reader := bufio.NewReader(fi)
+    l1, _, err := reader.ReadLine()
+    if err != nil {
+        return -1, err
+    }
+    v, err := strconv.Atoi(string(l1))
+
+    temp := float64(v) / 1000.0
+
+    if temp < -55 || temp > 125 {
+        return -1, fmt.Errorf("temperature reading out of range: -55 < %v < 125", temp)
+    }
+
+    if t.Fahrenheit {
+        temp = ((temp * 9.0) / 5.0) + 32.0
+    }
+    return telemetry.TwoDecimal(temp), nil
 }
 
 func (t *TC) readTemperature(fi io.Reader) (float64, error) {


### PR DESCRIPTION
This path extends the code to support temperature sensors based on the MCP9808, a digital high precision i2c temperature sensor that requires no calibration.
To use, connect a MCP9808 based sensor to the i2c bus and add i2c-dev and jc42 to /etc/modules.