### PR TITLE
Sanitize prometheus metric names to a more strict filter

### DIFF
--- a/controller/telemetry/telemetry.go
+++ b/controller/telemetry/telemetry.go
@@ -1,20 +1,24 @@
 package telemetry
 
 import (
-    "errors"
-    "fmt"
-    "github.com/prometheus/client_golang/prometheus"
-    "github.com/prometheus/client_golang/prometheus/promauto"
-    "github.com/reef-pi/adafruitio"
-    "github.com/reef-pi/reef-pi/controller/storage"
-    "log"
-    "net/http"
-    "strings"
-    "sync"
-    "time"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/reef-pi/adafruitio"
+	"github.com/reef-pi/reef-pi/controller/storage"
 )
 
 const DBKey = "telemetry"
+
+var sanitizePrometheusMetricRegex = regexp.MustCompile("[^a-zA-Z0-9_]")
 
 type ErrorLogger func(string, string) error
 
@@ -174,8 +178,8 @@ func SanitizeAdafruitIOFeedName(name string) string {
 }
 func SanitizePrometheusMetricName(name string) string {
 	name = strings.ToLower(name)
-	name = strings.Replace(name, " ", "_", -1)
-	return strings.Replace(name, "-", "_", -1)
+	name = sanitizePrometheusMetricRegex.ReplaceAllString(name, "_")
+	return name
 }
 
 func (t *telemetry) EmitMetric(module, name string, v float64) {

--- a/controller/telemetry/telemetry_test.go
+++ b/controller/telemetry/telemetry_test.go
@@ -1,8 +1,9 @@
 package telemetry
 
 import (
-	"github.com/reef-pi/reef-pi/controller/storage"
 	"testing"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
 )
 
 func TestEmitMetric(t *testing.T) {
@@ -35,5 +36,39 @@ func TestEmitMetric(t *testing.T) {
 	}
 	if sent {
 		t.Error("Test alert not being throttled")
+	}
+}
+
+func TestSanitizePrometheusMetricName(t *testing.T) {
+	checks := []struct {
+		input  string
+		output string
+	}{
+		{
+			input:  "abc",
+			output: "abc",
+		},
+		{
+			input:  "abc-123",
+			output: "abc_123",
+		},
+		{
+			input:  "",
+			output: "",
+		},
+		{
+			input:  "ABC",
+			output: "abc",
+		},
+		{
+			input:  "abc/123/Four-Five",
+			output: "abc_123_four_five",
+		},
+	}
+	for _, c := range checks {
+		out := SanitizePrometheusMetricName(c.input)
+		if out != c.output {
+			t.Errorf("metric name not sanitized: input '%s', output '%s', expected '%s'", c.input, out, c.output)
+		}
 	}
 }


### PR DESCRIPTION
Prometheus really only wants [a-zA-Z0-9_], previously we only removed
"-" but other characters would then proceeed to blow up if you use
"/", or any number of other characters. This restricts the subset to the
smaller set of allowed characters.