### PR TITLE
Correct behaviour of timer invoking a macro

### DIFF
--- a/controller/modules/timer/macro.go
+++ b/controller/modules/timer/macro.go
@@ -16,7 +16,10 @@ type MacroRunner struct {
 }
 
 func (m *MacroRunner) Run() {
+	if err := m.c.On(m.target, false); err != nil {
+		log.Println("ERROR: timer sub-system, Failed to complete macro. Error:", err)
+	}
 	if err := m.c.On(m.target, true); err != nil {
-		log.Println("ERROR: timer sub-system, Failed to trigger macro. Error:", err)
+		log.Println("ERROR: timer sub-system, Failed to revert macro. Error:", err)
 	}
 }

--- a/package.json
+++ b/package.json
@@ -79,9 +79,9 @@
   "scripts": {
     "translations:sync": "node ./build/translations/csv-sync.js sync",
     "translations:chk": "node ./build/translations/csv-sync.js chk",
-    "build": "webpack -d",
+    "build": "webpack",
     "ui": "webpack --mode=production",
-    "ui-dev": "webpack -d --watch",
+    "ui-dev": "webpack --watch",
     "js-lint": "standard  front-end/src/**/*",
     "standard": "standard --fix front-end/src/**/**",
     "jest": "cross-env NODE_ENV=testing jest",


### PR DESCRIPTION
**Previously**, a timer invoking a macro would execute the macro in "reverse" and be done.  It would not revert to the previous state.

**With this change**, a timer executing a macro will execute the steps normally, and then a second time, in reverse order to revert to the previous state.