### PR TITLE
Syncronize all node version in GitHub actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,6 +8,9 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '^1.13.1'
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
       - uses: codecov/codecov-action@v1
       - run: make install
       - run: make vet

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '14.15.1'
+          node-version: 14
       - uses: actions/cache@v2.1.6
         with:
           path: node_modules

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-      - name: Use Node.js 11.12
+      - name: Use Node.js 14
         uses: actions/setup-node@v1
         with:
-          node-version: 11.12
+          node-version: 14
       - uses: actions/cache@v2.1.6
         with:
           path: node_modules


### PR DESCRIPTION
Use Node version 14 in all of  the GitHub actions.