### PR TITLE
Fix GitHub action caches

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/cache@v2.1.6
         with:
           path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node_modules-
       - name: Install

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/cache@v2.1.6
         with:
           path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node_modules-
       - name: Install

--- a/.github/workflows/smoke_.yml
+++ b/.github/workflows/smoke_.yml
@@ -11,6 +11,12 @@ jobs:
       - uses: actions/setup-node@v2.4.0
         with:
           node-version: '16'
+      - uses: actions/cache@v2.1.6
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node_modules-
       - run: make install
       - run: make go
       - run: make ui

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/cache@v2.1.6
         with:
           path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node_modules-
       - name: Install


### PR DESCRIPTION
Fix GitHub action caches to use `yarn.lock` file instead `package-lock.json` file.