### PR TITLE
Make macro and steps logging consistent

### DIFF
--- a/controller/modules/macro/macro.go
+++ b/controller/modules/macro/macro.go
@@ -49,7 +49,7 @@ func (s *Subsystem) Delete(id string) error {
 		return err
 	}
 	if err := s.controller.Store().Delete(UsageBucket, id); err != nil {
-		log.Println("ERROR:  macro subsystem: Failed to deleted usage details for macro:", id)
+		log.Println("ERROR:  macro-subsystem: Failed to deleted usage details for macro:", id)
 	}
 	return nil
 }
@@ -58,7 +58,7 @@ func (s *Subsystem) Run(m Macro, reverse bool) error {
 	if reverse && !m.Reversible {
 		return fmt.Errorf("macro is not reversible")
 	}
-	log.Println("macro subsystem. Running:", m.Name)
+	log.Println("macro-subsystem. Running:", m.Name)
 	steps := m.Steps
 	if reverse {
 		steps = []Step{}
@@ -68,9 +68,9 @@ func (s *Subsystem) Run(m Macro, reverse bool) error {
 	}
 	for i, step := range steps {
 		if err := step.Run(s.controller, reverse); err != nil {
-			log.Println("ERROR: macro subsystem. Failed to execute step:", i, "of macro", m.Name, ". Error:", err)
+			log.Println("ERROR: macro-subsystem. Failed to execute step:", i, "of macro", m.Name, ". Error:", err)
 		}
 	}
-	log.Println("macro subsystem. Finished:", m.Name)
+	log.Println("macro-subsystem. Finished:", m.Name)
 	return s.Update(m.ID, m)
 }


### PR DESCRIPTION
Make macro and steps both log with macro-subsystem.  Makes
logging consistent and easier to parse.