### PR TITLE
Add support for nVidia Jetson Boards

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -28,6 +28,8 @@ jobs:
         run: make pi
       - name: pi-zero
         run: make pi-zero
+      - name: jetson
+        run: make jetson
       - name: bundler
         run: gem install bundler -v 2.1.4 --no-document
       - name: fpm

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,11 @@ pi:
 pi-zero:
 	env GOARM=6 GOOS=linux GOARCH=arm go build -o $(BINARY) -ldflags "-s -w -X main.Version=$(VERSION)"  ./commands
 
+.PHONY: jetson
+jetson:
+	env GOOS=linux GOARCH=arm64 go build -o $(BINARY) -ldflags "-s -w -X main.Version=$(VERSION)"  ./commands
+
+
 .PHONY: test
 test:
 	go test -count=1 -cover $(DETECT_RACE) ./...


### PR DESCRIPTION
This branch adds support for building for arm64 arch, which includes
nVidia's Jetson Nano, a single board PC