### PR TITLE
Clean dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,28 +9,6 @@ updates:
   schedule:
     interval: monthly
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: css-loader
-    versions:
-    - "> 3.2.1, < 4"
-  - dependency-name: enzyme
-    versions:
-    - "> 3.10.0, < 4"
-  - dependency-name: i18next
-    versions:
-    - "> 19.0.1, < 20"
-  - dependency-name: react-redux
-    versions:
-    - 7.2.2
-  - dependency-name: bootstrap
-    versions:
-    - 4.6.0
-  - dependency-name: eslint-plugin-react
-    versions:
-    - 7.22.0
-  - dependency-name: babel-jest
-    versions:
-    - 26.6.3
 - package-ecosystem: gomod
   directory: "/"
   schedule:


### PR DESCRIPTION
Clean dependabot ignores configurations for npm packages: [ignore option](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#specifying-dependencies-and-versions-to-ignore)