### PR TITLE
fix: ph controller does not allow 'nothing'

### DIFF
--- a/front-end/src/ph/edit_ph.jsx
+++ b/front-end/src/ph/edit_ph.jsx
@@ -328,7 +328,7 @@ const EditPh = ({
                 'is-invalid': ShowError('upperFunction', touched, errors)
               })}
             >
-              <option value='nothing'>{i18next.t('ph:controlnothing')}</option>
+              <option value=''>{i18next.t('ph:controlnothing')}</option>
               {options()}
             </Field>
             <ErrorFor errors={errors} touched={touched} name='upperFunction' />
@@ -340,7 +340,7 @@ const EditPh = ({
             <div className='input-group'>
               <Field
                 name='lowerThreshold'
-                readOnly={readOnly || values.control === 'nothing' || values.upperFunction === undefined || values.upperFunction === 'nothing'}
+                readOnly={readOnly || values.control === 'nothing' || values.upperFunction === undefined || values.upperFunction === ''}
                 className={classNames('form-control', {
                   'is-invalid': ShowError('lowerThreshold', touched, errors)
                 })}
@@ -367,7 +367,7 @@ const EditPh = ({
                 'is-invalid': ShowError('lowerFunction', touched, errors)
               })}
             >
-              <option value='nothing'>{i18next.t('ph:controlnothing')}</option>
+              <option value=''>{i18next.t('ph:controlnothing')}</option>
               {options()}
             </Field>
             <ErrorFor errors={errors} touched={touched} name='lowerFunction' />
@@ -380,7 +380,7 @@ const EditPh = ({
             <div className='input-group'>
               <Field
                 name='upperThreshold'
-                readOnly={readOnly || values.control === 'nothing' || values.lowerFunction === undefined || values.lowerFunction === 'nothing'}
+                readOnly={readOnly || values.control === 'nothing' || values.lowerFunction === undefined || values.lowerFunction === ''}
                 className={classNames('form-control', {
                   'is-invalid': ShowError('upperThreshold', touched, errors)
                 })}

--- a/front-end/src/ph/ph_form.jsx
+++ b/front-end/src/ph/ph_form.jsx
@@ -24,9 +24,9 @@ const PhForm = withFormik({
       minAlert: (data.notify && data.notify.min) || 0,
       control: 'nothing',
       lowerThreshold: data.min || 0,
-      lowerFunction: data.downer_eq || 'nothing',
+      lowerFunction: data.downer_eq || '',
       upperThreshold: data.max || 0,
-      upperFunction: data.upper_eq || 'nothing',
+      upperFunction: data.upper_eq || '',
       hysteresis: data.hysteresis || 0,
       chart: data.chart || { ymin: 0, ymax: 100, color: '#000', unit: '' }
     }

--- a/front-end/src/ph/ph_schema.jsx
+++ b/front-end/src/ph/ph_schema.jsx
@@ -54,12 +54,12 @@ const PhSchema = Yup.object().shape({
       if (control === 'macro' || control === 'equipment') {
         return schema
           .when('upperFunction', (upperFunc, schema) => {
-            if (upperFunc === undefined || upperFunc === 'nothing') { return schema }
+            if (upperFunc === undefined || upperFunc === '') { return schema }
             return schema
               .required(i18next.t('ph:lower_threshold_required'))
               .typeError(i18next.t('ph:lower_threshold_type'))
               .test('lessThan', i18next.t('ph:lower_threshold_less_than'), function (min) {
-                if (this.parent.lowerFunction === undefined || this.parent.lowerFunction === 'nothing') { return true }
+                if (this.parent.lowerFunction === undefined || this.parent.lowerFunction === '') { return true }
                 return min < this.parent.upperThreshold
               })
           })
@@ -73,7 +73,6 @@ const PhSchema = Yup.object().shape({
             if (lowerFunc === undefined) { return true }
             return lowerFunc !== this.parent.upperFunction
           })
-          .required(i18next.t('ph:lower_function_required'))
       } else { return schema }
     }),
   upperThreshold: Yup.number()
@@ -81,12 +80,12 @@ const PhSchema = Yup.object().shape({
       if (control === 'macro' || control === 'equipment') {
         return schema
           .when('lowerFunction', (lowerFunc, schema) => {
-            if (lowerFunc === undefined || lowerFunc === 'nothing') { return schema }
+            if (lowerFunc === undefined || lowerFunc === '') { return schema }
             return schema
               .required(i18next.t('ph:upper_threshold_required'))
               .typeError(i18next.t('ph:upper_threshold_type'))
               .test('greaterThan', i18next.t('ph:upper_threshold_less_than'), function (max) {
-                if (this.parent.upperFunction === undefined || this.parent.upperFunction === 'nothing') { return true }
+                if (this.parent.upperFunction === undefined || this.parent.upperFunction === '') { return true }
                 return max > this.parent.lowerThreshold
               })
           })


### PR DESCRIPTION
When one of upperFunction or lowerFunction is 'nothing' the controller bails out.
No using '' instead of 'nothing'. tcs seems to work correctly with heater/cooler='nothing'.