### PR TITLE
Navigable errors link

### DIFF
--- a/front-end/src/configuration/configuration.test.js
+++ b/front-end/src/configuration/configuration.test.js
@@ -26,7 +26,6 @@ describe('Configuration ui', () => {
 
   it('<Main />', () => {
     const m = shallow(<Main store={mockStore()} />).instance()
-    m.setBody(1)()
   })
 
   it('<Admin />', () => {

--- a/front-end/src/configuration/main.jsx
+++ b/front-end/src/configuration/main.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Route, Routes, NavLink } from 'react-router-dom'
 import Admin from './admin'
 import Settings from './settings'
 import Telemetry from 'telemetry/main'
@@ -9,55 +10,44 @@ import Drivers from 'drivers/main'
 import Errors from './errors'
 import i18n from 'utils/i18n'
 
-const components = {
-  settings: <Settings />,
-  connectors: <Connectors />,
-  drivers: <Drivers />,
-  telemetry: <Telemetry />,
-  authentication: <Auth />,
-  admin: <Admin />,
-  errors: <Errors />,
-  about: <About />
-}
+const configRoutes = [
+  <Route key="settings" index element={<Settings />} label={i18n.t(`configuration:tab:settings`)} />,
+  <Route key="connectors" path="connectors" element={<Connectors />} label={i18n.t(`configuration:tab:connectors`)} />,
+  <Route key="telemetry" path="telemetry" element={<Telemetry />} label={i18n.t(`configuration:tab:telemetry`)} />,
+  <Route key="authentication" path="authentication" element={<Auth />} label={i18n.t(`configuration:tab:authentication`)} />,
+  <Route key="drivers" path="drivers" element={<Drivers />} label={i18n.t(`configuration:tab:drivers`)} />,
+  <Route key="errors" path="errors" element={<Errors />} label={i18n.t(`configuration:tab:errors`)} />,
+  <Route key="admin" path="admin" element={<Admin />} label={i18n.t(`configuration:tab:admin`)} />,
+  <Route key="about" path="about" element={<About />} label={i18n.t(`configuration:tab:about`)} />
+]
 
-export default class Configuration extends React.Component {
-  constructor (props) {
-    super(props)
-    this.state = {
-      body: 'settings'
-    }
-    this.setBody = this.setBody.bind(this)
-  }
-
-  setBody (k) {
-    return () => {
-      this.setState({ body: k })
-    }
-  }
-
+class Configuration extends React.Component {
   render () {
     const panels = []
-    const tabs = ['settings', 'connectors', 'telemetry', 'authentication', 'drivers', 'errors', 'admin', 'about']
-    tabs.forEach((k, _) => {
-      const cname = this.state.body === k ? 'nav-item active text-info' : 'nav-item'
+    for (const route of configRoutes) {
       panels.push(
-        <li className={cname} key={'conf-tabs-' + k}>
-          <a id={'config-' + k} className='nav-link' onClick={this.setBody(k)}>
-            {i18n.t(`configuration:tab:${k}`)}{' '}
-          </a>
+        <li key={'conf-tabs' + route.key}>
+          <NavLink id={'config-' + route.key} className='nav-link' to={route.props.path || ''}>
+            {route.props.label}
+          </NavLink>
         </li>
       )
-    })
-    const body = components[this.state.body]
+    }
+
     return (
       <>
         <div className='row' key='panels'>
           <ul className='conf-nav nav nav-tabs'>{panels}</ul>
         </div>
+
         <div className='row' key='body'>
-          {body}
+          <Routes>
+            {configRoutes}
+          </Routes>
         </div>
       </>
     )
   }
 }
+
+export {Configuration as default, configRoutes as configRoutes }

--- a/front-end/src/main_panel.jsx
+++ b/front-end/src/main_panel.jsx
@@ -6,7 +6,7 @@ import Equipment from 'equipment/main'
 import Log from 'logCenter/main'
 import NotificationAlert from 'notifications/alert'
 import Lighting from 'lighting/main'
-import Configuration from 'configuration/main'
+import {default as Configuration, configRoutes} from 'configuration/main'
 import Temperature from 'temperature/main'
 import Timers from 'timers/main'
 import Doser from 'doser/main'
@@ -37,7 +37,9 @@ const routes = [
   <Route key="camera" path="/camera" element={<Camera />} label={i18n.t('capabilities:camera')} />,
   <Route key="manager" path="/manager" element={<Instances />} label={i18n.t('capabilities:manager')} />,
   <Route key="journal" path="/journal" element={<Journal />} label={i18n.t('capabilities:journal')} />,
-  <Route key="configuration" path="/configuration" element={<Configuration />} label={i18n.t('capabilities:configuration')} />,
+  <Route key="configuration" path="/configuration" element={<Configuration />} label={i18n.t('capabilities:configuration')} >
+    {configRoutes}
+  </Route>,
   <Route key="log" path="/log" element={<Log />} label={i18n.t('capabilities:log')} />
 ]
 

--- a/front-end/src/main_panel.jsx
+++ b/front-end/src/main_panel.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { BrowserRouter, Route, Routes, NavLink, useLocation } from 'react-router-dom'
 import Ato from 'ato/main'
 import Camera from 'camera/main'
 import Equipment from 'equipment/main'
@@ -22,120 +23,121 @@ import i18n from 'utils/i18n'
 import Instances from 'instances/main'
 import Journal from 'journal/main'
 
-const caps = {
-  dashboard: { label: i18n.t('capabilities:dashboard'), component: <Dashboard /> },
-  equipment: { label: i18n.t('capabilities:equipment'), component: <Equipment /> },
-  timers: { label: i18n.t('capabilities:timers'), component: <Timers /> },
-  lighting: { label: i18n.t('capabilities:lights'), component: <Lighting /> },
-  temperature: { label: i18n.t('capabilities:temperature'), component: <Temperature /> },
-  ato: { label: i18n.t('capabilities:ato'), component: <Ato /> },
-  ph: { label: i18n.t('capabilities:ph'), component: <Ph /> },
-  doser: { label: i18n.t('capabilities:dosing_pumps'), component: <Doser /> },
-  macro: { label: i18n.t('capabilities:macros'), component: <Macro /> },
-  camera: { label: i18n.t('capabilities:camera'), component: <Camera /> },
-  manager: { label: i18n.t('capabilities:manager'), component: <Instances /> },
-  journal: { label: i18n.t('capabilities:journal'), component: <Journal /> },
-  configuration: { label: i18n.t('capabilities:configuration'), component: <Configuration /> },
-  log: { label: i18n.t('capabilities:log'), component: <Log /> }
+
+const routes = [
+  <Route key="dashboard" index element={<Dashboard />} label={i18n.t('capabilities:dashboard')} />,
+  <Route key="equipment" path="/equipment" element={<Equipment />} label={i18n.t('capabilities:equipment')} />,
+  <Route key="timers" path="/timers" element={<Timers />} label={i18n.t('capabilities:timers')} />,
+  <Route key="lighting" path="/lighting" element={<Lighting />} label={i18n.t('capabilities:lights')} />,
+  <Route key="temperature" path="/temperature" element={<Temperature />} label={i18n.t('capabilities:temperature')} />,
+  <Route key="ato" path="/ato" element={<Ato />} label={i18n.t('capabilities:ato')} />,
+  <Route key="ph" path="/ph" element={<Ph />} label={i18n.t('capabilities:ph')} />,
+  <Route key="doser" path="/doser" element={<Doser />} label={i18n.t('capabilities:dosing_pumps')} />,
+  <Route key="macro" path="/macro" element={<Macro />} label={i18n.t('capabilities:macros')} />,
+  <Route key="camera" path="/camera" element={<Camera />} label={i18n.t('capabilities:camera')} />,
+  <Route key="manager" path="/manager" element={<Instances />} label={i18n.t('capabilities:manager')} />,
+  <Route key="journal" path="/journal" element={<Journal />} label={i18n.t('capabilities:journal')} />,
+  <Route key="configuration" path="/configuration" element={<Configuration />} label={i18n.t('capabilities:configuration')} />,
+  <Route key="log" path="/log" element={<Log />} label={i18n.t('capabilities:log')} />
+]
+
+
+function CurrentPageHeader() {
+  const location = useLocation()
+  // TODO(#1842): this should really be using the component's title which is translated
+  // this just keeps parity with the old version, so if you go to "/log" it'll show "log"
+  const headingName = location.pathname.slice(1)
+  return <span>{headingName}</span>
 }
+
 
 class mainPanel extends React.Component {
   constructor (props) {
     super(props)
-    this.state = {
-      tab: 'dashboard'
-    }
     this.navs = this.navs.bind(this)
-    this.setTab = this.setTab.bind(this)
   }
 
   componentDidMount () {
     this.props.fetchUIData()
   }
 
-  setTab (k) {
-    return () => {
-      this.setState({ tab: k })
+  navs (currentCaps) {
+    const panels = []
+    for (const route of routes) {
+      const cap = route.key
+      if (currentCaps[cap] === undefined) {
+        continue
+      }
+      if (!currentCaps[cap]) {
+        continue
+      }
+      const label = route.props.label
+
+      panels.push(
+        <li className='nav-item' key={'li-tab-' + cap}>
+          <NavLink to={route.props.path || ''} id={'tab-' + cap} className="nav-link">
+            {label}
+          </NavLink>
+        </li>
+      )
     }
+    return (
+      <ul className='navbar-nav'>{panels}</ul>
+    )
   }
 
-  navs (tab) {
+  render () {
     const MandatoryTabs = {
       log: true
     }
     const currentCaps = Object.assign(this.props.capabilities, MandatoryTabs)
-    const panels = []
-    for (const prop in caps) {
-      if (currentCaps[prop] === undefined) {
-        continue
-      }
-      if (!currentCaps[prop]) {
-        continue
-      }
-      const cname = prop === tab ? 'nav-link active' : 'nav-link'
-      const label = caps[prop].label
-      panels.push(
-        <li className='nav-item' key={'li-tab-' + prop}>
-          <a href='#' id={'tab-' + prop} className={cname} onClick={this.setTab(prop)}>
-            {label}
-          </a>
-        </li>
-      )
-    }
-    return <ul className='navbar-nav'>{panels}</ul>
-  }
 
-  render () {
-    let tab = this.state.tab
-    if (!this.props.capabilities.dashboard && tab === 'dashboard') {
-      for (const k in this.props.capabilities) {
-        if (this.props.capabilities[k] && caps[k] !== undefined) {
-          tab = k
-          break
-        }
-      }
-    }
-    const body = caps[tab].component
     return (
-      <div id='content'>
-        <nav className='navbar navbar-dark navbar-reefpi navbar-expand-lg'>
-          <span className='navbar-brand mb-0 h1'>{this.props.info.name}</span>
-          <span className='navbar-brand mb-0 h1 navbar-toggler current-tab'>{tab}</span>
-          <button
-            className='navbar-toggler'
-            type='button'
-            data-toggle='collapse'
-            data-target='#navbarNav'
-            aria-controls='navbarNav'
-            aria-expanded='false'
-            aria-label='Toggle navigation'
-          >
-            <span className='navbar-toggler-icon' />
-          </button>
-          <div
-            className='collapse navbar-collapse navHeaderCollapse'
-            id='navbarNav'
-            data-toggle='collapse'
-            data-target='.navbar-collapse'
-          >
-            {this.navs(tab)}
-          </div>
-        </nav>
-        <div className='container-fluid'>
-          <FatalError />
-          <NotificationAlert />
-          <div className='row body-panel'>
-            <div className='col'>
-              <ErrorBoundary tab={this.state.tab}>{body}</ErrorBoundary>
+      <BrowserRouter>
+        <div id='content'>
+          <nav className='navbar navbar-dark navbar-reefpi navbar-expand-lg'>
+            <span className='navbar-brand mb-0 h1'>{this.props.info.name}</span>
+            <span className='navbar-brand mb-0 h1 navbar-toggler current-tab'><CurrentPageHeader /></span>
+            <button
+              className='navbar-toggler'
+              type='button'
+              data-toggle='collapse'
+              data-target='#navbarNav'
+              aria-controls='navbarNav'
+              aria-expanded='false'
+              aria-label='Toggle navigation'
+            >
+              <span className='navbar-toggler-icon' />
+            </button>
+            <div
+              className='collapse navbar-collapse navHeaderCollapse'
+              id='navbarNav'
+              data-toggle='collapse'
+              data-target='.navbar-collapse'
+            >
+              {this.navs(currentCaps)}
             </div>
-          </div>
-          <div className='row d-none d-lg-block'>
-            <div className='col'>
-              <Summary fetch={this.props.fetchInfo} info={this.props.info} errors={this.props.errors} />
+          </nav>
+          <div className='container-fluid'>
+            <FatalError />
+            <NotificationAlert />
+            <div className='row body-panel'>
+              <div className='col'>
+                <ErrorBoundary>
+                  <Routes>
+                    {routes}
+                  </Routes>
+                </ErrorBoundary>
+              </div>
+            </div>
+            <div className='row d-none d-lg-block'>
+              <div className='col'>
+                <Summary fetch={this.props.fetchInfo} info={this.props.info} errors={this.props.errors} />
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </BrowserRouter>
     )
   }
 }

--- a/front-end/src/summary.jsx
+++ b/front-end/src/summary.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import i18n from 'utils/i18n'
+import { Link } from 'react-router-dom'
 
 export default class Summary extends React.Component {
   constructor (props) {
@@ -26,7 +27,11 @@ export default class Summary extends React.Component {
           <li className='list-inline-item'>{i18n.t('since')} {this.props.info.uptime} | </li>
           <li className='list-inline-item'>IP {this.props.info.ip} | </li>
           <li className='list-inline-item'><a href='/assets/api.html'>API</a> | </li>
-          <li className='list-inline-item text-danger'>{i18n.t('errors')}({this.props.errors.length})</li>
+          <li className='list-inline-item'>
+            <a href="/configuration/errors" className="text-danger">
+              {i18n.t('errors')}({this.props.errors.length})
+            </a>
+          </li>
         </ul>
       </nav>
     )

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react-icons": "4.3.1",
     "react-images": "1.1.7",
     "react-redux": "^8.0.1",
+    "react-router-dom": "^6.3.0",
     "react-test-renderer": "16.14.0",
     "react-toggle-switch": "3.0.4",
     "recharts": "^2.1.9",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,7 +68,8 @@ var config = {
   },
   output: {
     path: BUILD_DIR,
-    filename: 'assets/js/[name].[contenthash].js'
+    filename: 'assets/js/[name].[contenthash].js',
+    publicPath: '/'
   },
   optimization: {
     splitChunks: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1104,6 +1104,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.7.6":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.0.tgz#6d77142a19cb6088f0af662af1ada37a604d34ae"
+  integrity sha512-YMQvx/6nKEaucl0MY56mwIG483xk8SDNdlUwb2Ts6FUpr7fm85DxEmsY18LXBNhcTz6tO6JwZV8w1W06v8UKeg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.16.0", "@babel/template@^7.16.7", "@babel/template@^7.3.3":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -5769,6 +5776,13 @@ highlight-es@^1.0.0:
     is-es2016-keyword "^1.0.0"
     js-tokens "^3.0.0"
 
+history@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
+  integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
+
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -9627,6 +9641,21 @@ react-resize-detector@^6.6.3:
     lodash.debounce "^4.0.8"
     lodash.throttle "^4.1.1"
     resize-observer-polyfill "^1.5.1"
+
+react-router-dom@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"
+  integrity sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==
+  dependencies:
+    history "^5.2.0"
+    react-router "6.3.0"
+
+react-router@6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
+  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
+  dependencies:
+    history "^5.2.0"
 
 react-smooth@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Link the Errors in footer to the Errors page

This is built on top of #1843. This doesn't combine the Log and Error screens,
but instead deep links to the error page.

I believe combining the Log and Errors screens will still be worthwhile, but
this is an easy improvement with the deep linking in place.

Tested just by pulling up the UI and seeing the link works.

Relates #1779

**Merge #1843 first**