### PR TITLE
Add more data loading to config screens

### DIFF
--- a/front-end/src/configuration/capabilities.jsx
+++ b/front-end/src/configuration/capabilities.jsx
@@ -16,7 +16,7 @@ export default class Capabilities extends React.Component {
       const capabilities = this.state.capabilities
       capabilities[cap] = ev.target.checked
       this.setState({ capabilities: capabilities })
-      this.props.update(this.state.capabilities)
+      this.props.onChange(this.state.capabilities)
     }.bind(this)
   }
 
@@ -28,8 +28,8 @@ export default class Capabilities extends React.Component {
             className='form-check-input'
             type='checkbox'
             id={'update-' + label}
-            onClick={this.updateCapability(label)}
-            defaultChecked={this.state.capabilities[label]}
+            onChange={this.updateCapability(label)}
+            checked={!!this.state.capabilities[label]}
           />
           {i18n.t(`capabilities:${label}`)}
         </label>

--- a/front-end/src/configuration/capabilities.jsx
+++ b/front-end/src/configuration/capabilities.jsx
@@ -16,7 +16,7 @@ export default class Capabilities extends React.Component {
       const capabilities = this.state.capabilities
       capabilities[cap] = ev.target.checked
       this.setState({ capabilities: capabilities })
-      this.props.onChange(this.state.capabilities)
+      this.props.update(this.state.capabilities)
     }.bind(this)
   }
 

--- a/front-end/src/configuration/main.jsx
+++ b/front-end/src/configuration/main.jsx
@@ -11,14 +11,14 @@ import Errors from './errors'
 import i18n from 'utils/i18n'
 
 const configRoutes = [
-  <Route key="settings" index element={<Settings />} label={i18n.t(`configuration:tab:settings`)} />,
-  <Route key="connectors" path="connectors" element={<Connectors />} label={i18n.t(`configuration:tab:connectors`)} />,
-  <Route key="telemetry" path="telemetry" element={<Telemetry />} label={i18n.t(`configuration:tab:telemetry`)} />,
-  <Route key="authentication" path="authentication" element={<Auth />} label={i18n.t(`configuration:tab:authentication`)} />,
-  <Route key="drivers" path="drivers" element={<Drivers />} label={i18n.t(`configuration:tab:drivers`)} />,
-  <Route key="errors" path="errors" element={<Errors />} label={i18n.t(`configuration:tab:errors`)} />,
-  <Route key="admin" path="admin" element={<Admin />} label={i18n.t(`configuration:tab:admin`)} />,
-  <Route key="about" path="about" element={<About />} label={i18n.t(`configuration:tab:about`)} />
+  <Route key='settings' index element={<Settings />} label={i18n.t('configuration:tab:settings')} />,
+  <Route key='connectors' path='connectors' element={<Connectors />} label={i18n.t('configuration:tab:connectors')} />,
+  <Route key='telemetry' path='telemetry' element={<Telemetry />} label={i18n.t('configuration:tab:telemetry')} />,
+  <Route key='authentication' path='authentication' element={<Auth />} label={i18n.t('configuration:tab:authentication')} />,
+  <Route key='drivers' path='drivers' element={<Drivers />} label={i18n.t('configuration:tab:drivers')} />,
+  <Route key='errors' path='errors' element={<Errors />} label={i18n.t('configuration:tab:errors')} />,
+  <Route key='admin' path='admin' element={<Admin />} label={i18n.t('configuration:tab:admin')} />,
+  <Route key='about' path='about' element={<About />} label={i18n.t('configuration:tab:about')} />
 ]
 
 class Configuration extends React.Component {
@@ -50,4 +50,4 @@ class Configuration extends React.Component {
   }
 }
 
-export {Configuration as default, configRoutes as configRoutes }
+export { Configuration as default, configRoutes }

--- a/front-end/src/configuration/settings.jsx
+++ b/front-end/src/configuration/settings.jsx
@@ -151,7 +151,7 @@ class settings extends React.Component {
   }
 
   showCapabilities () {
-    return <Capabilities capabilities={this.state.capabilities} onChange={this.updateCapabilities} />
+    return <Capabilities capabilities={this.state.capabilities} update={this.updateCapabilities} />
   }
 
   updateCapabilities (capabilities) {
@@ -204,9 +204,9 @@ class settings extends React.Component {
   }
 
   render () {
-    if (this.state.settings == undefined ||
-          this.state.settings.capabilities == undefined ||
-          Object.keys(this.state.capabilities).length == 0) {
+    if (this.state.settings === undefined ||
+          this.state.settings.capabilities === undefined ||
+          Object.keys(this.state.capabilities).length === 0) {
       return (
         <div className='container'>
           {i18n.t('loading')}

--- a/front-end/src/configuration/settings.jsx
+++ b/front-end/src/configuration/settings.jsx
@@ -54,8 +54,8 @@ class settings extends React.Component {
           <input
             type='checkbox'
             id={attr}
-            onClick={this.updateCheckbox(attr)}
-            defaultChecked={this.state.settings[attr]}
+            onChange={this.updateCheckbox(attr)}
+            checked={!!this.state.settings[attr]}
             className='form-check-input'
           />
           {i18n.t('configuration:settings:' + attr)}
@@ -151,7 +151,7 @@ class settings extends React.Component {
   }
 
   showCapabilities () {
-    return <Capabilities capabilities={this.state.capabilities} update={this.updateCapabilities} />
+    return <Capabilities capabilities={this.state.capabilities} onChange={this.updateCapabilities} />
   }
 
   updateCapabilities (capabilities) {
@@ -204,6 +204,16 @@ class settings extends React.Component {
   }
 
   render () {
+    if (this.state.settings == undefined ||
+          this.state.settings.capabilities == undefined ||
+          Object.keys(this.state.capabilities).length == 0) {
+      return (
+        <div className='container'>
+          {i18n.t('loading')}
+        </div>
+      )
+    }
+
     let updateButtonClass = 'btn btn-outline-success col-xs-12 col-md-3 offset-md-9'
     if (this.state.updated) {
       updateButtonClass = 'btn btn-outline-danger col-xs-12 col-md-3 offset-md-9'

--- a/front-end/src/connectors/connectors.test.js
+++ b/front-end/src/connectors/connectors.test.js
@@ -34,7 +34,7 @@ jest.mock('utils/confirm', () => {
 })
 describe('Connectors', () => {
   it('<Main />', () => {
-    shallow(<Main />)
+    shallow(<Provider store={mockStore({})}><Main /></Provider>)
   })
 
   it('<InletSelector />', () => {

--- a/front-end/src/connectors/main.jsx
+++ b/front-end/src/connectors/main.jsx
@@ -3,9 +3,21 @@ import Outlets from './outlets'
 import Jacks from './jacks'
 import AnalogInputs from './analog_inputs'
 import Inlets from './inlets'
+import i18n from 'utils/i18n'
+import { connect } from 'react-redux'
+import { fetchDrivers } from 'redux/actions/jacks'
 
-export default class Connectors extends React.Component {
+class connectors extends React.Component {
   render () {
+    if (this.props.drivers === undefined ||
+          this.props.drivers.length === 0) {
+      return (
+        <div className='container'>
+          {i18n.t('loading')}
+        </div>
+      )
+    }
+
     return (
       <div className='container'>
         <div className='row inlets'>
@@ -28,3 +40,21 @@ export default class Connectors extends React.Component {
     )
   }
 }
+
+const mapStateToProps = state => {
+  return {
+    drivers: state.drivers
+  }
+}
+
+const mapDispatchToProps = dispatch => {
+  return {
+    fetchDrivers: () => dispatch(fetchDrivers())
+  }
+}
+
+const Connectors = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(connectors)
+export default Connectors

--- a/front-end/src/main_panel.jsx
+++ b/front-end/src/main_panel.jsx
@@ -89,10 +89,7 @@ class mainPanel extends React.Component {
   }
 
   render () {
-    const MandatoryTabs = {
-      log: true
-    }
-    const currentCaps = Object.assign(this.props.capabilities, MandatoryTabs)
+    const currentCaps = this.props.capabilities
 
     return (
       <BrowserRouter>

--- a/front-end/src/redux/actions/capabilities.js
+++ b/front-end/src/redux/actions/capabilities.js
@@ -1,9 +1,12 @@
 import { reduxGet } from '../../utils/ajax'
 
 export const capabilitiesLoaded = (capabilities) => {
+  const MandatoryCapabilities = {
+    log: true
+  }
   return ({
     type: 'CAPABILITIES_LOADED',
-    payload: capabilities
+    payload: Object.assign(capabilities, MandatoryCapabilities)
   })
 }
 

--- a/front-end/src/redux/actions/ui.test.js
+++ b/front-end/src/redux/actions/ui.test.js
@@ -39,6 +39,8 @@ describe('ui actions', () => {
     fetchMock.getOnce('/api/lights', [])
     fetchMock.getOnce('/api/inlets', [])
     fetchMock.getOnce('/api/jacks', [])
+    fetchMock.getOnce('/api/drivers', [])
+    fetchMock.getOnce('/api/analog_inputs', [])
     fetchMock.getOnce('/api/outlets', [])
     fetchMock.getOnce('/api/errors', [])
     const store = mockStore()

--- a/front-end/src/redux/store.js
+++ b/front-end/src/redux/store.js
@@ -18,7 +18,7 @@ const initialState = {
   macros: [],
   dosers: [],
   configuration: {},
-  capabilities: [],
+  capabilities: {},
   health_stats: {},
   inlets: [],
   jacks: [],


### PR DESCRIPTION
Two separate commits fixing separate aspects of the connection screen data loading. These are technically issues even if you went to `http://reefpi/` and then quickly navigated to the other pages, but being able to jump to `http://reefpi/configuration/*` exposed it.

Relate to #1846