### PR TITLE
Don't require a heater or cooler temp when they're disabled

### DIFF
--- a/front-end/src/temperature/temperature_schema.jsx
+++ b/front-end/src/temperature/temperature_schema.jsx
@@ -103,6 +103,8 @@ const TemperatureSchema = Yup.object().shape({
           .typeError(i18n.t('validation:number_required'))
           .test('lessThan', i18n.t('temperature:hysteresis_less_than'), function (hyst) {
             if (this.parent.heater === undefined || this.parent.heater === '') { return true }
+            if (this.parent.cooler === undefined || this.parent.cooler === '') { return true }
+            if (this.parent.min === undefined || this.parent.max === undefined) { return true }
             return hyst < (this.parent.max - this.parent.min)
           })
       } else { return schema }

--- a/front-end/src/temperature/temperature_schema.test.js
+++ b/front-end/src/temperature/temperature_schema.test.js
@@ -50,6 +50,28 @@ describe('Validation', () => {
     )
   })
 
+  it('should be valid when cooler < heater and either is disabled', () => {
+    tc.control = 'macro'
+    tc.heater = '2'
+    tc.cooler = '4'
+    tc.min = 77
+    tc.max = 50
+
+    expect.assertions(2)
+
+    const tc1 = Object.assign(tc, { heater: '' })
+    const valid1 = TemperatureSchema.isValid(tc1).then(
+      valid => expect(valid).toBe(true)
+    )
+
+    const tc2 = Object.assign(tc, { cooler: '' })
+    const valid2 = TemperatureSchema.isValid(tc2).then(
+      valid => expect(valid).toBe(true)
+    )
+
+    return Promise.all([valid1, valid2])
+  })
+
   it('should be invalid when heater and cooler are the same', () => {
     tc.control = 'macro'
     tc.heater = '2'


### PR DESCRIPTION
Fixes #1836

TBH I'm not sure exactly what the behavior of hysteresis is, so I'm not
sure if there's cases where this validation is erroneous. However, this
fixes the bug where right now if you try and create a new temperature
with just a heater, it will fail validation without telling you why. Currently
it's requiring you to setup a cooler regardless, as outlined in #1836