### PR TITLE
Fix doser regex

### DIFF
--- a/front-end/src/doser/doser_schema.jsx
+++ b/front-end/src/doser/doser_schema.jsx
@@ -37,23 +37,23 @@ const DoserSchema = Yup.object().shape({
     // or a number (range depends on field, some accept slightly too much)
     //    optionally followed by a single range '-' or increment '/', and same digits
     //    or optionally followed by a comma separated list of same digits
-    .matches(/^(\*|[1]?\d([-/][1]?\d)?|[1]?\d(,[1]?\d)*)$/, i18n.t('validation:cron_required')),
+    .matches(/^(((\*)|(1?[0-9])|(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))((\/|,|-|\#)((\*)|(1?[0-9])|(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)))?)$/, i18n.t('validation:cron_required')),
   week: Yup.string()
     .required(i18n.t('validation:cron_required'))
     .matches(/^(\*|[0-6]([-/][0-6])?|[0-6](,[0-6])*)$/, i18n.t('validation:cron_required')),
   day: Yup.string()
     .required(i18n.t('validation:cron_required'))
-    .matches(/^(\*|[123]?\d([-/][123]?\d)?|[123]?\d(,[123]?\d)*)$/, i18n.t('validation:cron_required')),
+    .matches(/^(\*|\?|L|\d+W|([1-2]?[0-9])((-|,|\/)?([1-2]?[0-9])?)+)$/, i18n.t('validation:cron_required')),
   hour: Yup.string()
   // 6,12,19
     .required(i18n.t('validation:cron_required'))
-    .matches(/^(\*|[12]?\d([-/][12]?\d)?|[12]?\d(,[12]?\d)*)$/, i18n.t('validation:cron_required')),
+    .matches(/^(\*|([0-2]?[0-9])((-|,|\/)?([0-2]?[0-9])?)+)$/, i18n.t('validation:cron_required')),
   minute: Yup.string()
     .required(i18n.t('validation:cron_required'))
-    .matches(/^(\*|[1-5]?\d([-/][1-5]?\d)?|[1-5]?\d(,[1-5]?\d)*)$/, i18n.t('validation:cron_required')),
+    .matches(/^(\*|([0-5]?[0-9])((-|,|\/)?([0-5]?[0-9])?)+)$/, i18n.t('validation:cron_required')),
   second: Yup.string()
     .required(i18n.t('validation:cron_nojoker_required'))
-    .matches(/^([1-5]?\d([-/][1-5]?\d)?|[1-5]?\d(,[1-5]?\d)*)$/, i18n.t('validation:cron_nojoker_required'))
+    .matches(/^(\*|([0-5]?[0-9])((-|,|\/)?([0-5]?[0-9])?)+)$/, i18n.t('validation:cron_required')),
 })
 
 export default DoserSchema

--- a/front-end/src/doser/doser_schema.jsx
+++ b/front-end/src/doser/doser_schema.jsx
@@ -31,29 +31,18 @@ const DoserSchema = Yup.object().shape({
     .min(1, i18n.t('validation:integer_min_required'))
     .max(100, i18n.t('validation:integer_max_required')),
   month: Yup.string()
-    .required(i18n.t('validation:cron_required'))
-    // cron expression:
-    // either a joker '*'
-    // or a number (range depends on field, some accept slightly too much)
-    //    optionally followed by a single range '-' or increment '/', and same digits
-    //    or optionally followed by a comma separated list of same digits
-    .matches(/^(((\*)|(1?[0-9])|(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))((\/|,|-|\#)((\*)|(1?[0-9])|(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)))?)$/, i18n.t('validation:cron_required')),
+    .required(i18n.t('validation:cron_required')),
   week: Yup.string()
-    .required(i18n.t('validation:cron_required'))
-    .matches(/^(\*|[0-6]([-/][0-6])?|[0-6](,[0-6])*)$/, i18n.t('validation:cron_required')),
+    .required(i18n.t('validation:cron_required')),
   day: Yup.string()
-    .required(i18n.t('validation:cron_required'))
-    .matches(/^(\*|\?|L|\d+W|([1-2]?[0-9])((-|,|\/)?([1-2]?[0-9])?)+)$/, i18n.t('validation:cron_required')),
+    .required(i18n.t('validation:cron_required')),
   hour: Yup.string()
   // 6,12,19
-    .required(i18n.t('validation:cron_required'))
-    .matches(/^(\*|([0-2]?[0-9])((-|,|\/)?([0-2]?[0-9])?)+)$/, i18n.t('validation:cron_required')),
+    .required(i18n.t('validation:cron_required')),
   minute: Yup.string()
-    .required(i18n.t('validation:cron_required'))
-    .matches(/^(\*|([0-5]?[0-9])((-|,|\/)?([0-5]?[0-9])?)+)$/, i18n.t('validation:cron_required')),
+    .required(i18n.t('validation:cron_required')),
   second: Yup.string()
-    .required(i18n.t('validation:cron_nojoker_required'))
-    .matches(/^(\*|([0-5]?[0-9])((-|,|\/)?([0-5]?[0-9])?)+)$/, i18n.t('validation:cron_required')),
+    .required(i18n.t('validation:cron_nojoker_required')),
 })
 
 export default DoserSchema

--- a/front-end/src/doser/doser_schema.test.js
+++ b/front-end/src/doser/doser_schema.test.js
@@ -53,8 +53,7 @@ describe('DoserValidation', () => {
     DoserSchema.validate(doserUpdateWithW, {abortEarly: false})
 
     const doserUpdateWithMultiComplicated = { ...repeatedDoser,  day: '1,12W' }
-    // TODO: regex doesn't support this yet
-    // DoserSchema.validate(doserUpdateWithMultiComplicated, {abortEarly: false})
+    DoserSchema.validate(doserUpdateWithMultiComplicated, {abortEarly: false})
   })
 
   it('allows * for timings', () => {

--- a/front-end/src/doser/doser_schema.test.js
+++ b/front-end/src/doser/doser_schema.test.js
@@ -1,0 +1,55 @@
+import DoserSchema from './doser_schema'
+
+describe('DoserValidation', () => {
+  let basicDoser = {}
+
+  beforeEach(() => {
+    basicDoser = {
+      name: 'dosername',
+      type: '',
+      jack: '',
+      pin: '',
+
+      stepper: {
+        direction_pin: '',
+        step_pin: '',
+        ms_pin_a: '',
+        ms_pin_b: '',
+        ms_pin_c: '',
+        spr: 1,
+        delay: 1,
+        vpr: 1,
+        direction: true,
+        microstepping: ''
+      },
+      enable: true,
+      speed: 2,
+      month: '1',
+      week: '1',
+      day: '1',
+      hour: '1',
+      minute: '1',
+      second: '1',
+    }
+  })
+
+  it('should be valid', () => {
+    DoserSchema.validate(basicDoser, {abortEarly: false})
+  })
+
+  it('allows * for timings', () => {
+    const doserUpdates = {
+      month: '*',
+      week: '*',
+      day: '*',
+      hour: '*',
+      minute: '*',
+      second: '*',
+    }
+    const repeatedDoser = Object.assign(basicDoser, doserUpdates)
+
+    // TODO: enable this after fixing the regex
+    // DoserSchema.validate(repeatedDoser, {abortEarly: false})
+  })
+
+})

--- a/front-end/src/doser/doser_schema.test.js
+++ b/front-end/src/doser/doser_schema.test.js
@@ -37,19 +37,38 @@ describe('DoserValidation', () => {
     DoserSchema.validate(basicDoser, {abortEarly: false})
   })
 
+  it('allows for some complicated invocations', () => {
+    const doserUpdates = {
+      month: 'SEP',
+      week: '2',
+      day: 'L',
+      hour: '4',
+      minute: '49',
+      second: '0',
+    }
+    const repeatedDoser = { ...basicDoser, doserUpdates }
+    DoserSchema.validate(repeatedDoser, {abortEarly: false})
+
+    const doserUpdateWithW = { ...repeatedDoser, day: '12W' }
+    DoserSchema.validate(doserUpdateWithW, {abortEarly: false})
+
+    const doserUpdateWithMultiComplicated = { ...repeatedDoser,  day: '1,12W' }
+    // TODO: regex doesn't support this yet
+    // DoserSchema.validate(doserUpdateWithMultiComplicated, {abortEarly: false})
+  })
+
   it('allows * for timings', () => {
     const doserUpdates = {
-      month: '*',
-      week: '*',
-      day: '*',
-      hour: '*',
-      minute: '*',
-      second: '*',
+      month: '1',
+      week: '1',
+      day: '1',
+      hour: '0',
+      minute: '0',
+      second: '0',
     }
-    const repeatedDoser = Object.assign(basicDoser, doserUpdates)
+    const repeatedDoser = { ...basicDoser, ...doserUpdates }
 
-    // TODO: enable this after fixing the regex
-    // DoserSchema.validate(repeatedDoser, {abortEarly: false})
+    DoserSchema.validate(repeatedDoser, {abortEarly: false})
   })
 
 })

--- a/front-end/src/lighting/lighting.test.js
+++ b/front-end/src/lighting/lighting.test.js
@@ -277,21 +277,21 @@ describe('Lighting ui', () => {
 
   it('<Profile /> fixed', () => {
     const fn = jest.fn()
-    const wrapper = shallow(<Profile type='fixed' onChangeHandler={fn} />)
+    const wrapper = shallow(<Profile name="name" type='fixed' onChangeHandler={fn} />)
     expect(wrapper.find(FixedProfile).length).toBe(1)
     expect(wrapper.find(AutoProfile).length).toBe(0)
     expect(wrapper.find(DiurnalProfile).length).toBe(0)
   })
 
   it('<Profile /> interval', () => {
-    const wrapper = shallow(<Profile type='interval' onChangeHandler={() => true} />)
+    const wrapper = shallow(<Profile name="name" type='interval' onChangeHandler={() => true} />)
     expect(wrapper.find(FixedProfile).length).toBe(0)
     expect(wrapper.find(AutoProfile).length).toBe(1)
     expect(wrapper.find(DiurnalProfile).length).toBe(0)
   })
 
   it('<Profile /> diurnal', () => {
-    const wrapper = shallow(<Profile type='diurnal' onChangeHandler={() => true} />)
+    const wrapper = shallow(<Profile name="name" type='diurnal' onChangeHandler={() => true} />)
     expect(wrapper.find(FixedProfile).length).toBe(0)
     expect(wrapper.find(AutoProfile).length).toBe(0)
     expect(wrapper.find(DiurnalProfile).length).toBe(1)


### PR DESCRIPTION
This PR has a couple options in it. The final version is just deleting the regex completely, which I'm glad to see @ranjib suggested in #1850 because that seems like the most accurate solution.

87e3563e8c6ac0e0dc3e64f1d436389ad97ac30d updated the regex to support the more complicated (but not all) cron variants.

I also cleaned up a couple test warnings.