### PR TITLE
(chore)remove cron syntax validation

### DIFF
--- a/front-end/src/timers/timer_schema.jsx
+++ b/front-end/src/timers/timer_schema.jsx
@@ -29,28 +29,17 @@ const TimerSchema = Yup.object().shape({
   type: Yup.string()
     .required(i18n.t('validation:selection_required')),
   month: Yup.string()
-    .required(i18n.t('validation:cron_required'))
-    // cron expression:
-    // either a joker '*'
-    // or a number (range depends on field, some accept slightly too much)
-    //    optionally followed by a single range '-' or increment '/', and same digits
-    //    or optionally followed by a comma separated list of same digits
-    .matches(/^(\*|[1]?\d([-/][1]?\d)?|[1]?\d(,[1]?\d)*)$/, i18n.t('validation:cron_required')),
+    .required(i18n.t('validation:cron_required')),
   week: Yup.string()
-    .required(i18n.t('validation:cron_required'))
-    .matches(/^(\*|[0-6]([-/][0-6])?|[0-6](,[0-6])*)$/, i18n.t('validation:cron_required')),
+    .required(i18n.t('validation:cron_required')),
   day: Yup.string()
-    .required(i18n.t('validation:cron_required'))
-    .matches(/^(\*|[123]?\d([-/][123]?\d)?|[123]?\d(,[123]?\d)*)$/, i18n.t('validation:cron_required')),
+    .required(i18n.t('validation:cron_required')),
   hour: Yup.string()
-    .required(i18n.t('validation:cron_required'))
-    .matches(/^(\*|[12]?\d([-/][12]?\d)?|[12]?\d(,[12]?\d)*)$/, i18n.t('validation:cron_required')),
+    .required(i18n.t('validation:cron_required')),
   minute: Yup.string()
-    .required(i18n.t('validation:cron_required'))
-    .matches(/^(\*|[1-5]?\d([-/][1-5]?\d)?|[1-5]?\d(,[1-5]?\d)*)$/, i18n.t('validation:cron_required')),
+    .required(i18n.t('validation:cron_required')),
   second: Yup.string()
-    .required(i18n.t('validation:cron_nojoker_required'))
-    .matches(/^([1-5]?\d([-/][1-5]?\d)?|[1-5]?\d(,[1-5]?\d)*)$/, i18n.t('validation:cron_nojoker_required')),
+    .required(i18n.t('validation:cron_nojoker_required')),
   target: Yup.object().when('type', (type, schema) => {
     switch (type) {
       case 'ato':


### PR DESCRIPTION
Remove cron specification validation on the UI. its incorrect and inhibits users from entering */2 like specs. We have backend based validation already so this does not significantly risk saving wrong specs. 