### PR TITLE
RFC: Allow saving telemetry without reentering creds

### DIFF
--- a/controller/storage/boltdb.go
+++ b/controller/storage/boltdb.go
@@ -42,12 +42,12 @@ func (s *store) bucket(tx *bolt.Tx, name string) (*bolt.Bucket, error) {
 	} else {
 		p := tx.Bucket([]byte(s.parent))
 		if p == nil {
-			return nil, fmt.Errorf("Parent bucket: '%s' does not exist.", s.parent)
+			return nil, &DoesNotExistError{fmt.Sprintf("Parent bucket: '%s' does not exist.", s.parent)}
 		}
 		b = p.Bucket([]byte(name))
 	}
 	if b == nil {
-		return nil, fmt.Errorf("Bucket: '%s' does not exist.", name)
+		return nil, &DoesNotExistError{fmt.Sprintf("Bucket: '%s' does not exist.", name)}
 	}
 	return b, nil
 }
@@ -68,7 +68,7 @@ func (s *store) RawGet(bucket, id string) ([]byte, error) {
 	err := s.db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(bucket))
 		if b == nil {
-			return fmt.Errorf("Bucket: '%s' does not exist.", bucket)
+			return &DoesNotExistError{fmt.Sprintf("Bucket: '%s' does not exist.", bucket)}
 		}
 		data = b.Get([]byte(id))
 		return nil
@@ -82,7 +82,7 @@ func (s *store) Get(bucket, id string, i interface{}) error {
 		return err
 	}
 	if data == nil || len(data) == 0 {
-		return fmt.Errorf("Item '%s' does not exist in bucket '%s'", id, bucket)
+		return &DoesNotExistError{fmt.Sprintf("Item '%s' does not exist in bucket '%s'", id, bucket)}
 	}
 	return json.Unmarshal(data, i)
 }
@@ -176,7 +176,7 @@ func (s *store) CreateSubBucket(parent, child string) error {
 	return s.db.Update(func(tx *bolt.Tx) error {
 		p := tx.Bucket([]byte(parent))
 		if p == nil {
-			return fmt.Errorf("Bucket: '%s' does not exist.", parent)
+			return &DoesNotExistError{fmt.Sprintf("Bucket: '%s' does not exist.", parent)}
 		}
 		_, err := p.CreateBucketIfNotExists([]byte(child))
 		return err

--- a/controller/storage/store.go
+++ b/controller/storage/store.go
@@ -49,3 +49,9 @@ type Store interface {
 	CreateBucket(string) error
 	Path() string
 }
+
+type DoesNotExistError struct { text string }
+
+func (e DoesNotExistError) Error() string {
+	return e.text
+}

--- a/controller/telemetry/api.go
+++ b/controller/telemetry/api.go
@@ -5,7 +5,15 @@ import (
 	"time"
 
 	"github.com/reef-pi/reef-pi/controller/utils"
+	"github.com/reef-pi/reef-pi/controller/storage"
 )
+
+// TODO: translate these
+// TODO: this is a bit of a hack in that it means someone can't have their
+// 			 actual token/password be the string "<stored>", but that seems rare
+//			 enough a reasonable trade-off for a quick fix to unsaveable form bugs
+const PasswordStoredPlaceholder = "<stored>"
+const AdafruitIOTokenStoredPlaceholder = "<stored>"
 
 func (t *telemetry) GetConfig(w http.ResponseWriter, req *http.Request) {
 	fn := func(_ string) (interface{}, error) {
@@ -13,8 +21,12 @@ func (t *telemetry) GetConfig(w http.ResponseWriter, req *http.Request) {
 		if err := t.store.Get(t.bucket, DBKey, &c); err != nil {
 			return nil, err
 		}
-		c.AdafruitIO.Token = ""
-		c.Mailer.Password = ""
+		if (c.AdafruitIO.Token != "") {
+			c.AdafruitIO.Token = AdafruitIOTokenStoredPlaceholder
+		}
+		if (c.Mailer.Password != "") {
+			c.Mailer.Password = PasswordStoredPlaceholder
+		}
 		return &c, nil
 	}
 	utils.JSONGetResponse(fn, w, req)
@@ -22,7 +34,28 @@ func (t *telemetry) GetConfig(w http.ResponseWriter, req *http.Request) {
 
 func (t *telemetry) UpdateConfig(w http.ResponseWriter, req *http.Request) {
 	var c TelemetryConfig
+
+	var existingConfig TelemetryConfig
+	var readErr = t.store.Get(t.bucket, DBKey, &existingConfig)
+	if readErr != nil {
+		switch readErr.(type) {
+			case storage.DoesNotExistError:
+				// no-op
+			default:
+				utils.ErrorResponse(http.StatusInternalServerError, "Failed to update. Error: "+readErr.Error(), w)
+				return
+		}
+	}
+
 	fn := func(_ string) error {
+		if readErr != nil {
+			if c.AdafruitIO.Token == AdafruitIOTokenStoredPlaceholder {
+				c.AdafruitIO.Token = existingConfig.AdafruitIO.Token;
+			}
+			if c.Mailer.Password == PasswordStoredPlaceholder {
+				c.Mailer.Password = existingConfig.Mailer.Password;
+			}
+		}
 		return t.store.Update(t.bucket, DBKey, c)
 	}
 	utils.JSONUpdateResponse(&c, fn, w, req)


### PR DESCRIPTION
After you have persisted telemetry settings, the UI no longer knows your creds.
This is good in that it avoids saved passwords getting returned out of the
backend, but it causes the UI to only allow updating telemetry if every time
you reenter in all the relevant passwords/tokens. That makes it very hard to
edit these later.

This is caused by the API blanking out those fields before returning them. That
is reasonable. However that leads to two issues. The first is the UI's
validation that token/password are filled in fails. The second is that if
you made the call to the backend, it'd then cause the database to be written
without those creds in it, losing them.

The current fix could be improved, as noted in the TODOs. However, given
right now the update flow has a major usability issue, I feel this is a
reasonable short-term solution. A future one likely would involve having the
API understand how to do an Upsert and ignore any fields that are not passed
through on the JSON. Then the UI would only pass these in if they changed,
or there'd be some sort of separate credentials form submitted separately.

Relates #1882

# This PR not yet tested, I'm sending for feedback/opinion

Before vetting this further, I want to get an opinion on this solution from @ranjib. I'll give it some testing locally on my side because this'll solve an issue I'm currently getting, but before cleaning anything up or going further I wanted to get a general  👍.