### PR TITLE
Update reef-pi.service

### DIFF
--- a/build/reef-pi.service
+++ b/build/reef-pi.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=raspberry pi based reef tank controller
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 ExecStart=/usr/bin/reef-pi daemon -config /etc/reef-pi/config.yaml


### PR DESCRIPTION
Added WANT and AFTER network-online.target.  Prevents the service from attempting to bind before the network has started.  Absence was causing the service to fail to bind when a specific IP was specified in the config.