### PR TITLE
Rest api doser

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,9 @@
+name: Manual Trigger Workflow
+
+# Configure Manual Trigger
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,9 +1,0 @@
-name: Manual Trigger Workflow
-
-# Configure Manual Trigger
-on:
-  workflow_dispatch:
-
-jobs:
-  build:
-    runs-on: ubuntu-latest

--- a/controller/modules/doser/pump.go
+++ b/controller/modules/doser/pump.go
@@ -132,7 +132,7 @@ func (c *Controller) Calibrate(id string, cal CalibrationDetails) error {
 	if p.Type == "stepper" && p.Stepper != nil {
 		go p.Stepper.Dose(c.c.DM().Outlets(), cal.Volume)
 	} else if p.Type == "restdoser" && p.Restdoser != nil {
-	    go r.RESTDose(p.Restdoser.Url, p.Regiment.Volume, cal.Duration, cal.Speed)
+	    go r.RESTDose(p.Restdoser.CalUrl, p.Regiment.Volume, cal.Duration, cal.Speed)
 	} else {
 		go r.PWMDose(cal.Speed, cal.Duration)
 	}

--- a/controller/modules/doser/pump.go
+++ b/controller/modules/doser/pump.go
@@ -20,6 +20,10 @@ type DosingRegiment struct {
 	Volume   float64  `json:"volume"`
 }
 
+type Restdoser struct {
+	url      string   `json:"url"`
+}
+
 // swagger:model pump
 type Pump struct {
 	ID       string         `json:"id"`
@@ -28,6 +32,7 @@ type Pump struct {
 	Pin      int            `json:"pin"`
 	Regiment DosingRegiment `json:"regiment"`
 	Stepper  *DRV8825       `json:"stepper"`
+	Restdoser Restdoser     `json:"url"`
 	Type     string         `json:"type"`
 }
 
@@ -35,8 +40,12 @@ func (p *Pump) IsValid() error {
 	if p.Name == "" {
 		return fmt.Errorf("name can not be empty")
 	}
+	log.Println("Type Case ", p)
+
 	switch p.Type {
 	case "stepper":
+	    log.Println("Adding as Stepper ", p)
+
 		if p.Regiment.Volume <= 0 {
 			return fmt.Errorf("dosing volume must be positive")
 		}
@@ -45,6 +54,20 @@ func (p *Pump) IsValid() error {
 		}
 		if err := p.Stepper.IsValid(); err != nil {
 			return err
+		}
+	case "restdoser":
+	    log.Println("Adding as Restdoser ", p)
+	    log.Println("URL ", p.restdoser.url)
+	    log.Println("Volume",p.Volume)
+	    log.Println("Duration",p.Duration)
+	    log.Println("Speed",p.Speed)
+
+
+		if p.Regiment.Volume <= 0 {
+			return fmt.Errorf("dosing volume must be positive")
+		}
+		if p.Regiment.Duration <= 0 {
+			return fmt.Errorf("dosing duration must be positive")
 		}
 	default:
 		if p.Jack == "" {

--- a/controller/modules/doser/pump.go
+++ b/controller/modules/doser/pump.go
@@ -20,10 +20,6 @@ type DosingRegiment struct {
 	Volume   float64  `json:"volume"`
 }
 
-type Restdoser struct {
-	url      string   `json:"url"`
-}
-
 // swagger:model pump
 type Pump struct {
 	ID       string         `json:"id"`
@@ -32,7 +28,7 @@ type Pump struct {
 	Pin      int            `json:"pin"`
 	Regiment DosingRegiment `json:"regiment"`
 	Stepper  *DRV8825       `json:"stepper"`
-	Restdoser Restdoser     `json:"url"`
+	Restdoser *Restdoser    `json:"restdoser"`
 	Type     string         `json:"type"`
 }
 
@@ -57,10 +53,10 @@ func (p *Pump) IsValid() error {
 		}
 	case "restdoser":
 	    log.Println("Adding as Restdoser ", p)
-	    log.Println("URL ", p.restdoser.url)
-	    log.Println("Volume",p.Volume)
-	    log.Println("Duration",p.Duration)
-	    log.Println("Speed",p.Speed)
+	    log.Println("URL ",  p.Restdoser.Url)
+	    log.Println("Volume", p.Regiment.Volume)
+	    log.Println("Duration", p.Regiment.Duration)
+	    log.Println("Speed", p.Regiment.Speed)
 
 
 		if p.Regiment.Volume <= 0 {
@@ -135,6 +131,8 @@ func (c *Controller) Calibrate(id string, cal CalibrationDetails) error {
 	log.Println("doser subsystem: calibration run for:", p.Name)
 	if p.Type == "stepper" && p.Stepper != nil {
 		go p.Stepper.Dose(c.c.DM().Outlets(), cal.Volume)
+	} else if p.Type == "restdoser" && p.Restdoser != nil {
+	    go r.RESTDose(p.Restdoser.Url, p.Regiment.Volume, cal.Duration, cal.Speed)
 	} else {
 		go r.PWMDose(cal.Speed, cal.Duration)
 	}

--- a/controller/modules/doser/runner.go
+++ b/controller/modules/doser/runner.go
@@ -39,7 +39,7 @@ func (r *Runner) Run() {
 	    log.Println(r.pump.Restdoser.Url)
 		log.Println("doser sub system: running doser(REST Doser)", r.pump.Name, "for", r.pump.Regiment.Volume, "(ml)",  r.pump.Regiment.Duration, "(s)")
 	    if err := r.RESTDose(r.pump.Restdoser.Url, r.pump.Regiment.Volume, r.pump.Regiment.Duration, r.pump.Regiment.Speed); err != nil {
-	        log.Printf("ERROR: dosing sub-system. Failed to control REST pump. Error:", err)
+	        log.Println("ERROR: dosing sub-system. Failed to control REST pump. Error:", err)
 	    }
 		usage.Pump = int(r.pump.Regiment.Duration)
 	} else {

--- a/controller/modules/doser/runner.go
+++ b/controller/modules/doser/runner.go
@@ -8,6 +8,7 @@ import (
     "text/template"
 	"github.com/reef-pi/reef-pi/controller/device_manager"
 	"github.com/reef-pi/reef-pi/controller/telemetry"
+	"net/http"
 )
 
 type Runner struct {
@@ -19,6 +20,7 @@ type Runner struct {
 
 type Restdoser struct {
 	Url      string   `json:"url"`
+	CalUrl   string   `json:"calUrl"`
 }
 
 func (r *Runner) Run() {
@@ -98,14 +100,16 @@ func (r *Runner) RESTDose(urlTemplate string, volume float64, duration float64, 
     // Now use the generated URL to make the GET request
     log.Printf("Send REST command to Doser %s", url)
 
-    // Here, you would make the GET request using the generated URL
-    // For example:
-    // resp, err := http.Get(url)
-    // if err != nil {
-    //     return fmt.Errorf("error making GET request: %v", err)
-    // }
-    // defer resp.Body.Close()
-    // (Handle response as needed)
+    resp, err := http.Get(url)
+    if err != nil {
+        return fmt.Errorf("error making GET request: %v", err)
+    }
+    defer resp.Body.Close()
+
+    // Check the response status code
+    if resp.StatusCode != http.StatusOK {
+        return fmt.Errorf("unexpected status code: %v", resp.StatusCode)
+    }
 
     return nil
 }

--- a/front-end/assets/translations/de.csv
+++ b/front-end/assets/translations/de.csv
@@ -170,6 +170,7 @@ cron:second,Sekunde
 cron:week,Wochentag (0=So - 6=Sa)
 dashboard:back_to_dashboard,zurück zur Übersicht
 dashboard:blank_panel,-leer-
+doser:calUrl,Kalibrierungs-URL
 doser:calibrate,Kalibrieren
 doser:calibration:run,Start
 doser:delay,

--- a/front-end/assets/translations/en.csv
+++ b/front-end/assets/translations/en.csv
@@ -17,6 +17,7 @@ delete,Delete
 devmode_warning,In DevMode
 disabled,Disabled
 documentation,Documentation
+doser:calUrl,Calibration URL
 done,Done
 doser,Doser
 driver,Driver
@@ -186,7 +187,7 @@ doser:microstep:full,Full
 doser:microstepping,Microstepping
 doser:ms_pin_a,MicroStepping Pin A
 doser:ms_pin_b,MicroStepping Pin B
-doser:ms_pin_c,MicroStepping Pin C 
+doser:ms_pin_c,MicroStepping Pin C
 doser:speed,Speed
 doser:spr,Steps Per Rotation
 doser:step_pin,Step Pin

--- a/front-end/assets/translations/es.csv
+++ b/front-end/assets/translations/es.csv
@@ -18,6 +18,7 @@ devmode_warning,
 disabled,Desactivar
 documentation,Documentación
 done,Listo
+doser:calUrl,URL de calibración
 doser,Dosificador
 driver,Controlador
 edit,Editar

--- a/front-end/assets/translations/fa.csv
+++ b/front-end/assets/translations/fa.csv
@@ -19,6 +19,7 @@ disabled,غیرفعال شده
 documentation,مستندات
 done,انجام شده
 doser,
+doser:calUrl,URL کالیبراسیون
 driver,
 edit,ویرایش کنید
 enabled,فعال شده

--- a/front-end/assets/translations/fr.csv
+++ b/front-end/assets/translations/fr.csv
@@ -170,6 +170,7 @@ cron:second,
 cron:week,
 dashboard:back_to_dashboard,Retour au Tableau de bord
 dashboard:blank_panel,
+doser:calUrl,URL d'étalonnage
 doser:calibrate,
 doser:calibration:run,
 doser:delay,

--- a/front-end/assets/translations/hi.csv
+++ b/front-end/assets/translations/hi.csv
@@ -170,6 +170,7 @@ cron:second,
 cron:week,
 dashboard:back_to_dashboard,
 dashboard:blank_panel,
+doser:calUrl,अंशांकन यूआरएल
 doser:calibrate,
 doser:calibration:run,
 doser:delay,

--- a/front-end/assets/translations/it.csv
+++ b/front-end/assets/translations/it.csv
@@ -170,6 +170,7 @@ cron:second,
 cron:week,
 dashboard:back_to_dashboard,
 dashboard:blank_panel,
+doser:calUrl,URL di calibrazione
 doser:calibrate,
 doser:calibration:run,
 doser:delay,

--- a/front-end/assets/translations/nl.csv
+++ b/front-end/assets/translations/nl.csv
@@ -170,6 +170,7 @@ cron:second,Seconde
 cron:week,Week
 dashboard:back_to_dashboard,Terug naar dashboard
 dashboard:blank_panel,
+doser:calUrl,Kalibratie-URl
 doser:calibrate,
 doser:calibration:run,
 doser:delay,

--- a/front-end/assets/translations/pt.csv
+++ b/front-end/assets/translations/pt.csv
@@ -170,6 +170,7 @@ cron:second,Segundos
 cron:week,Semana
 dashboard:back_to_dashboard,Voltas ao  Painel Inicial
 dashboard:blank_panel,Painel em branco
+doser:calUrl,Kalibracja URl
 doser:calibrate,calibrar
 doser:calibration:run,correr calibração
 doser:delay,espera
@@ -288,7 +289,7 @@ ph:controlmacro,Macro
 ph:controlnothing,Nada
 ph:current_reading,Leitura Atual
 ph:hysteresis,hysteresis
-ph:hysteresis_less_than, hysteresis Menos de 
+ph:hysteresis_less_than, hysteresis Menos de
 ph:lower_function,Função em baixo
 ph:lower_threshold,Função na zona
 ph:midpoint,Ponto médio
@@ -325,7 +326,7 @@ temperature:chart:down,Refrigeração
 temperature:chart:historical,histórico
 temperature:chart:up,Aquecedor
 temperature:chart_color,cor
-temperature:chart_ymax,y maximo 
+temperature:chart_ymax,y maximo
 temperature:chart_ymin,y minimo
 temperature:check_frequency,Verificar a frequência
 temperature:control,controlo
@@ -336,7 +337,7 @@ temperature:current_reading,Leitura atual
 temperature:fahrenheit,Fahrenheit
 temperature:heater_cooler,Aquecedor/refrigeração
 temperature:hysteresis,hysteresis
-temperature:hysteresis_less_than,hysteresis menos de 
+temperature:hysteresis_less_than,hysteresis menos de
 temperature:lower_function,função caso seja menor
 temperature:lower_threshold,Abaixo do desejado
 temperature:sensor,Sensor

--- a/front-end/assets/translations/zh.csv
+++ b/front-end/assets/translations/zh.csv
@@ -170,6 +170,7 @@ cron:second,秒
 cron:week,周
 dashboard:back_to_dashboard,回到面板
 dashboard:blank_panel,
+doser:calUrl,校准 URL
 doser:calibrate,
 doser:calibration:run,
 doser:delay,

--- a/front-end/src/doser/doser_form.jsx
+++ b/front-end/src/doser/doser_form.jsx
@@ -31,7 +31,8 @@ const DoserForm = withFormik({
       minute: data.regiment.schedule.minute || '0',
       second: data.regiment.schedule.second || '0',
       type: data.type || '',
-      stepper: data.stepper || {}
+      stepper: data.stepper || {},
+      restdoser: data.restdoser || {}
     }
   },
   validationSchema: DoserSchema,

--- a/front-end/src/doser/doser_schema.jsx
+++ b/front-end/src/doser/doser_schema.jsx
@@ -15,7 +15,8 @@ const Stepperchema = Yup.object().shape({
 })
 
 const Restdoserchema = Yup.object().shape({
-  url: Yup.string()
+  url: Yup.string(),
+  calUrl: Yup.string()
 })
 
 const DoserSchema = Yup.object().shape({

--- a/front-end/src/doser/doser_schema.jsx
+++ b/front-end/src/doser/doser_schema.jsx
@@ -14,6 +14,10 @@ const Stepperchema = Yup.object().shape({
   microstepping: Yup.string()
 })
 
+const Restdoserchema = Yup.object().shape({
+  url: Yup.string()
+})
+
 const DoserSchema = Yup.object().shape({
   name: Yup.string()
     .required(i18n.t('validation:name_required')),
@@ -21,6 +25,7 @@ const DoserSchema = Yup.object().shape({
   jack: Yup.string(),
   pin: Yup.string(),
   stepper: Stepperchema,
+  restdoser: Restdoserchema,
   enable: Yup.bool()
     .required(i18n.t('validation:selection_required')),
   duration: Yup.number()

--- a/front-end/src/doser/edit_doser.jsx
+++ b/front-end/src/doser/edit_doser.jsx
@@ -52,14 +52,14 @@ const EditDoser = ({
           dirty={dirty}
         />
       )
-    } else if (values.type === 'dcpump') {
+    } else if (values.type === 'restdoser') {
       return (
-        <EditDcPump
+        <EditRestDoser
           values={values}
           readOnly={readOnly}
           errors={errors}
           touched={touched}
-          jacks={jacks}
+          outlets={outlets}
           isValid={isValid}
           onBlur={onBlur}
           handleChange={handleChange}
@@ -69,12 +69,12 @@ const EditDoser = ({
       )
     } else {
       return (
-        <EditRestDoser
+        <EditDcPump
           values={values}
           readOnly={readOnly}
           errors={errors}
           touched={touched}
-          outlets={outlets}
+          jacks={jacks}
           isValid={isValid}
           onBlur={onBlur}
           handleChange={handleChange}
@@ -124,6 +124,7 @@ const EditDoser = ({
             <Field
               name='type'
               component='select'
+              defaultValue='dcpump'
               disabled={readOnly}
               className={classNames('custom-select', {
                 'is-invalid': ShowError('type', touched, errors)

--- a/front-end/src/doser/edit_doser.jsx
+++ b/front-end/src/doser/edit_doser.jsx
@@ -8,6 +8,7 @@ import { Field } from 'formik'
 import Cron from '../ui_components/cron'
 import EditStepper from './edit_stepper'
 import EditDcPump from './edit_dcpump'
+import EditRestDoser from './edit_restdoser'
 
 const EditDoser = ({
   values,
@@ -51,7 +52,7 @@ const EditDoser = ({
           dirty={dirty}
         />
       )
-    } else {
+    } else if (values.type === 'dcpump') {
       return (
         <EditDcPump
           values={values}
@@ -59,6 +60,21 @@ const EditDoser = ({
           errors={errors}
           touched={touched}
           jacks={jacks}
+          isValid={isValid}
+          onBlur={onBlur}
+          handleChange={handleChange}
+          setFieldValue={setFieldValue}
+          dirty={dirty}
+        />
+      )
+    } else {
+      return (
+        <EditRestDoser
+          values={values}
+          readOnly={readOnly}
+          errors={errors}
+          touched={touched}
+          outlets={outlets}
           isValid={isValid}
           onBlur={onBlur}
           handleChange={handleChange}
@@ -115,6 +131,7 @@ const EditDoser = ({
             >
               <option value='dcpump' key='dcpump'> DC motor </option>
               <option value='stepper' key='stepper'> Stepper</option>
+              <option value='restdoser' key='restdoser'> REST API</option>
             </Field>
             <ErrorFor errors={errors} touched={touched} name='type' />
           </div>

--- a/front-end/src/doser/edit_restdoser.jsx
+++ b/front-end/src/doser/edit_restdoser.jsx
@@ -4,6 +4,8 @@ import { Field } from 'formik'
 import i18n from 'utils/i18n'
 import classNames from 'classnames'
 import BooleanSelect from '../ui_components/boolean_select'
+import i18next from 'i18next'
+import Percent from '../ui_components/percent'
 
 const EditRestDoser = ({
   values,
@@ -18,192 +20,67 @@ const EditRestDoser = ({
   dirty,
   readOnly
 }) => {
-  const outletOptions = () => {
-    return outlets.map(item => {
-      return (
-        <option key={item.id} value={item.id}>
-          {item.name}
-        </option>
-      )
-    })
-  }
   return (
     <div className='row'>
-      <div className='col'>
+      <div className='col-12 col-sm-6 col-md-3'>
         <div className='form-group'>
-          <label htmlFor='step_pin'>{i18n.t('doser:step_pin')}</label>
+          <label htmlFor='URL'>{i18next.t('doser:url')}</label>
           <Field
-            name='stepper.step_pin'
+            name='restdoser.url'
             disabled={readOnly}
-            component='select'
-            className={classNames('custom-select', {
-              'is-invalid': ShowError('stepper.step_pin', touched, errors)
-            })}
-          >
-            <option value='' className='d-none'>-- {i18n.t('select')} --</option>
-            {outletOptions()}
-          </Field>
-          <ErrorFor errors={errors} touched={touched} name='stepper.step_pin' />
-        </div>
-      </div>
-
-      <div className='col'>
-        <div className='form-group'>
-          <label htmlFor='direction_pin'>{i18n.t('doser:direction_pin')}</label>
-          <Field
-            name='stepper.direction_pin'
-            disabled={readOnly}
-            component='select'
-            className={classNames('custom-select', {
-              'is-invalid': ShowError('stepper.direction_pin', touched, errors)
-            })}
-          >
-            <option value='' className='d-none'>-- {i18n.t('select')} --</option>
-            {outletOptions()}
-          </Field>
-          <ErrorFor errors={errors} touched={touched} name='stepper.direction_pin' />
-        </div>
-      </div>
-
-      <div className='col'>
-        <div className='form-group'>
-          <label htmlFor='ms_pin_a'>{i18n.t('doser:ms_pin_a')}</label>
-          <Field
-            name='stepper.ms_pin_a'
-            disabled={readOnly}
-            component='select'
-            className={classNames('custom-select', {
-              'is-invalid': ShowError('stepper.ms_pin_a', touched, errors)
-            })}
-          >
-            <option value='' className='d-none'>-- {i18n.t('select')} --</option>
-            {outletOptions()}
-          </Field>
-          <ErrorFor errors={errors} touched={touched} name='stepper.ms_pin_a' />
-        </div>
-      </div>
-
-      <div className='col'>
-        <div className='form-group'>
-          <label htmlFor='ms_pin_b'>{i18n.t('doser:ms_pin_b')}</label>
-          <Field
-            name='stepper.ms_pin_b'
-            disabled={readOnly}
-            component='select'
-            className={classNames('custom-select', {
-              'is-invalid': ShowError('stepper.ms_pin_b', touched, errors)
-            })}
-          >
-            <option value='' className='d-none'>-- {i18n.t('select')} --</option>
-            {outletOptions()}
-          </Field>
-          <ErrorFor errors={errors} touched={touched} name='stepper.ms_pin_b' />
-        </div>
-      </div>
-
-      <div className='col'>
-        <div className='form-group'>
-          <label htmlFor='ms_pin_c'>{i18n.t('doser:ms_pin_c')}</label>
-          <Field
-            name='stepper.ms_pin_c'
-            disabled={readOnly}
-            component='select'
-            className={classNames('custom-select', {
-              'is-invalid': ShowError('stepper.ms_pin_c', touched, errors)
-            })}
-          >
-            <option value='' className='d-none'>-- {i18n.t('select')} --</option>
-            {outletOptions()}
-          </Field>
-          <ErrorFor errors={errors} touched={touched} name='stepper.ms_pin_c' />
-        </div>
-      </div>
-
-      <div className='col'>
-        <div className='form-group'>
-          <label htmlFor='spr'>{i18n.t('doser:spr')}</label>
-          <Field
-            name='stepper.spr'
-            disabled={readOnly}
-            type='number'
             className={classNames('form-control', {
-              'is-invalid': ShowError('stepper.spr', touched, errors)
+              'is-invalid': ShowError('restdoser.url', touched, errors)
             })}
           />
-          <ErrorFor errors={errors} touched={touched} name='stepper.spr' />
+          <ErrorFor errors={errors} touched={touched} name='restdoser.url' />
         </div>
       </div>
-
-      <div className='col'>
+      <div className='col-12 col-sm-6 col-md-3'>
         <div className='form-group'>
-          <label htmlFor='vpr'>{i18n.t('doser:vpr')}</label>
-          <Field
-            name='stepper.vpr'
-            disabled={readOnly}
-            type='number'
-            className={classNames('form-control', {
-              'is-invalid': ShowError('stepper.vpr', touched, errors)
-            })}
-          />
-          <ErrorFor errors={errors} touched={touched} name='stepper.vpr' />
+          <label htmlFor='duration'>{i18n.t('doser:duration')}</label>
+          <div className='input-group'>
+            <Field
+              name='duration'
+              readOnly={readOnly}
+              type='number'
+              className={classNames('form-control', {
+                'is-invalid': ShowError('duration', touched, errors)
+              })}
+            />
+            <div className='input-group-append'>
+              <span className='input-group-text d-none d-lg-flex'>
+                {i18n.t('second_s')}
+              </span>
+              <span className='input-group-text d-flex d-lg-none'>sec</span>
+            </div>
+            <ErrorFor errors={errors} touched={touched} name='duration' />
+          </div>
         </div>
       </div>
-
-      <div className='col'>
+      <div className='col col-sm-6 col-md-3'>
         <div className='form-group'>
-          <label htmlFor='delay'>{i18n.t('doser:delay')}</label>
-          <Field
-            name='stepper.delay'
-            disabled={readOnly}
-            type='number'
-            className={classNames('form-control', {
-              'is-invalid': ShowError('stepper.delay', touched, errors)
-            })}
-          />
-          <ErrorFor errors={errors} touched={touched} name='stepper.vpr' />
+          <label htmlFor='speed'>{i18n.t('doser:speed')}</label>
+          <div className='input-group'>
+            <Percent
+              type='number'
+              className={classNames('form-control', {
+                'is-invalid': ShowError('speed', touched, errors)
+              })}
+              name='speed'
+              onBlur={onBlur}
+              readOnly={readOnly}
+              onChange={handleChange}
+              value={values.speed}
+            />
+            <div className='input-group-append'>
+              <span className='input-group-text'>
+                %
+              </span>
+            </div>
+            <ErrorFor errors={errors} touched={touched} name='speed' />
+          </div>
         </div>
       </div>
-
-      <div className='col'>
-        <div className='form-group'>
-          <label htmlFor='direction'>{i18n.t('doser:direction')}</label>
-          <Field
-            name='stepper.direction'
-            disabled={readOnly}
-            component={BooleanSelect}
-            className={classNames('custom-select', {
-              'is-invalid': ShowError('stepper.direction', touched, errors)
-            })}
-          >
-            <option value='true'>{i18n.t('forward')}</option>
-            <option value='false'>{i18n.t('reverse')}</option>
-          </Field>
-          <ErrorFor errors={errors} touched={touched} name='stepper.direction' />
-        </div>
-      </div>
-
-      <div className='col'>
-        <div className='form-group'>
-          <label htmlFor='microstepping'>{i18n.t('doser:microstepping')}</label>
-          <Field
-            name='stepper.microstepping'
-            disabled={readOnly}
-            component='select'
-            className={classNames('custom-select', {
-              'is-invalid': ShowError('stepper.microstepping', touched, errors)
-            })}
-          >
-            <option value='Full'>{i18n.t('doser:microstep:full')}</option>
-            <option value='Half'>{i18n.t('doser:microstep:1/2')}</option>
-            <option value='1/4'>{i18n.t('doser:microstep:1/4')}</option>
-            <option value='1/8'>{i18n.t('doser:microstep:1/8')}</option>
-            <option value='1/16'>{i18n.t('doser:microstep:1/16')}</option>
-            <option value='1/32'>{i18n.t('doser:microstep:1/32')}</option>
-          </Field>
-          <ErrorFor errors={errors} touched={touched} name='stepper.microstepping' />
-        </div>
-      </div>
-
     </div>
   )
 }

--- a/front-end/src/doser/edit_restdoser.jsx
+++ b/front-end/src/doser/edit_restdoser.jsx
@@ -1,0 +1,210 @@
+import React from 'react'
+import { ErrorFor, ShowError } from '../utils/validation_helper'
+import { Field } from 'formik'
+import i18n from 'utils/i18n'
+import classNames from 'classnames'
+import BooleanSelect from '../ui_components/boolean_select'
+
+const EditRestDoser = ({
+  values,
+  errors,
+  touched,
+  outlets,
+  isValid,
+  onBlur,
+  handleChange,
+  setFieldValue,
+  submitForm,
+  dirty,
+  readOnly
+}) => {
+  const outletOptions = () => {
+    return outlets.map(item => {
+      return (
+        <option key={item.id} value={item.id}>
+          {item.name}
+        </option>
+      )
+    })
+  }
+  return (
+    <div className='row'>
+      <div className='col'>
+        <div className='form-group'>
+          <label htmlFor='step_pin'>{i18n.t('doser:step_pin')}</label>
+          <Field
+            name='stepper.step_pin'
+            disabled={readOnly}
+            component='select'
+            className={classNames('custom-select', {
+              'is-invalid': ShowError('stepper.step_pin', touched, errors)
+            })}
+          >
+            <option value='' className='d-none'>-- {i18n.t('select')} --</option>
+            {outletOptions()}
+          </Field>
+          <ErrorFor errors={errors} touched={touched} name='stepper.step_pin' />
+        </div>
+      </div>
+
+      <div className='col'>
+        <div className='form-group'>
+          <label htmlFor='direction_pin'>{i18n.t('doser:direction_pin')}</label>
+          <Field
+            name='stepper.direction_pin'
+            disabled={readOnly}
+            component='select'
+            className={classNames('custom-select', {
+              'is-invalid': ShowError('stepper.direction_pin', touched, errors)
+            })}
+          >
+            <option value='' className='d-none'>-- {i18n.t('select')} --</option>
+            {outletOptions()}
+          </Field>
+          <ErrorFor errors={errors} touched={touched} name='stepper.direction_pin' />
+        </div>
+      </div>
+
+      <div className='col'>
+        <div className='form-group'>
+          <label htmlFor='ms_pin_a'>{i18n.t('doser:ms_pin_a')}</label>
+          <Field
+            name='stepper.ms_pin_a'
+            disabled={readOnly}
+            component='select'
+            className={classNames('custom-select', {
+              'is-invalid': ShowError('stepper.ms_pin_a', touched, errors)
+            })}
+          >
+            <option value='' className='d-none'>-- {i18n.t('select')} --</option>
+            {outletOptions()}
+          </Field>
+          <ErrorFor errors={errors} touched={touched} name='stepper.ms_pin_a' />
+        </div>
+      </div>
+
+      <div className='col'>
+        <div className='form-group'>
+          <label htmlFor='ms_pin_b'>{i18n.t('doser:ms_pin_b')}</label>
+          <Field
+            name='stepper.ms_pin_b'
+            disabled={readOnly}
+            component='select'
+            className={classNames('custom-select', {
+              'is-invalid': ShowError('stepper.ms_pin_b', touched, errors)
+            })}
+          >
+            <option value='' className='d-none'>-- {i18n.t('select')} --</option>
+            {outletOptions()}
+          </Field>
+          <ErrorFor errors={errors} touched={touched} name='stepper.ms_pin_b' />
+        </div>
+      </div>
+
+      <div className='col'>
+        <div className='form-group'>
+          <label htmlFor='ms_pin_c'>{i18n.t('doser:ms_pin_c')}</label>
+          <Field
+            name='stepper.ms_pin_c'
+            disabled={readOnly}
+            component='select'
+            className={classNames('custom-select', {
+              'is-invalid': ShowError('stepper.ms_pin_c', touched, errors)
+            })}
+          >
+            <option value='' className='d-none'>-- {i18n.t('select')} --</option>
+            {outletOptions()}
+          </Field>
+          <ErrorFor errors={errors} touched={touched} name='stepper.ms_pin_c' />
+        </div>
+      </div>
+
+      <div className='col'>
+        <div className='form-group'>
+          <label htmlFor='spr'>{i18n.t('doser:spr')}</label>
+          <Field
+            name='stepper.spr'
+            disabled={readOnly}
+            type='number'
+            className={classNames('form-control', {
+              'is-invalid': ShowError('stepper.spr', touched, errors)
+            })}
+          />
+          <ErrorFor errors={errors} touched={touched} name='stepper.spr' />
+        </div>
+      </div>
+
+      <div className='col'>
+        <div className='form-group'>
+          <label htmlFor='vpr'>{i18n.t('doser:vpr')}</label>
+          <Field
+            name='stepper.vpr'
+            disabled={readOnly}
+            type='number'
+            className={classNames('form-control', {
+              'is-invalid': ShowError('stepper.vpr', touched, errors)
+            })}
+          />
+          <ErrorFor errors={errors} touched={touched} name='stepper.vpr' />
+        </div>
+      </div>
+
+      <div className='col'>
+        <div className='form-group'>
+          <label htmlFor='delay'>{i18n.t('doser:delay')}</label>
+          <Field
+            name='stepper.delay'
+            disabled={readOnly}
+            type='number'
+            className={classNames('form-control', {
+              'is-invalid': ShowError('stepper.delay', touched, errors)
+            })}
+          />
+          <ErrorFor errors={errors} touched={touched} name='stepper.vpr' />
+        </div>
+      </div>
+
+      <div className='col'>
+        <div className='form-group'>
+          <label htmlFor='direction'>{i18n.t('doser:direction')}</label>
+          <Field
+            name='stepper.direction'
+            disabled={readOnly}
+            component={BooleanSelect}
+            className={classNames('custom-select', {
+              'is-invalid': ShowError('stepper.direction', touched, errors)
+            })}
+          >
+            <option value='true'>{i18n.t('forward')}</option>
+            <option value='false'>{i18n.t('reverse')}</option>
+          </Field>
+          <ErrorFor errors={errors} touched={touched} name='stepper.direction' />
+        </div>
+      </div>
+
+      <div className='col'>
+        <div className='form-group'>
+          <label htmlFor='microstepping'>{i18n.t('doser:microstepping')}</label>
+          <Field
+            name='stepper.microstepping'
+            disabled={readOnly}
+            component='select'
+            className={classNames('custom-select', {
+              'is-invalid': ShowError('stepper.microstepping', touched, errors)
+            })}
+          >
+            <option value='Full'>{i18n.t('doser:microstep:full')}</option>
+            <option value='Half'>{i18n.t('doser:microstep:1/2')}</option>
+            <option value='1/4'>{i18n.t('doser:microstep:1/4')}</option>
+            <option value='1/8'>{i18n.t('doser:microstep:1/8')}</option>
+            <option value='1/16'>{i18n.t('doser:microstep:1/16')}</option>
+            <option value='1/32'>{i18n.t('doser:microstep:1/32')}</option>
+          </Field>
+          <ErrorFor errors={errors} touched={touched} name='stepper.microstepping' />
+        </div>
+      </div>
+
+    </div>
+  )
+}
+export default EditRestDoser

--- a/front-end/src/doser/edit_restdoser.jsx
+++ b/front-end/src/doser/edit_restdoser.jsx
@@ -24,7 +24,7 @@ const EditRestDoser = ({
     <div className='row'>
       <div className='col-12 col-sm-6 col-md-3'>
         <div className='form-group'>
-          <label htmlFor='URL'>{i18next.t('doser:url')}</label>
+          <label htmlFor='restdoser.url'>URL</label>
           <Field
             name='restdoser.url'
             disabled={readOnly}
@@ -33,6 +33,19 @@ const EditRestDoser = ({
             })}
           />
           <ErrorFor errors={errors} touched={touched} name='restdoser.url' />
+        </div>
+      </div>
+      <div className='col-12 col-sm-6 col-md-3'>
+        <div className='form-group'>
+          <label htmlFor='restdoser.calUrl'>{i18next.t('doser:calibrate')} URL</label>
+          <Field
+            name='restdoser.calUrl'
+            disabled={readOnly}
+            className={classNames('form-control', {
+              'is-invalid': ShowError('restdoser.calUrl', touched, errors)
+            })}
+          />
+          <ErrorFor errors={errors} touched={touched} name='restdoser.calUrl' />
         </div>
       </div>
       <div className='col-12 col-sm-6 col-md-3'>

--- a/front-end/src/doser/main.jsx
+++ b/front-end/src/doser/main.jsx
@@ -76,6 +76,7 @@ class doser extends React.Component {
       jack: values.jack,
       pin: parseInt(values.pin),
       stepper: values.stepper,
+      restdoser: values.restdoser,
       type: values.type,
       regiment: {
         volume: parseFloat(values.volume),


### PR DESCRIPTION
This pull request introduces enhancements to the Doser UI by integrating support for the REST API. The changes aim to provide users with the ability to interact with the Doser subsystem via RESTful endpoints, enabling flexible control and management of dosing operations:

1. Added REST API Integration: Implemented support for REST API endpoints to facilitate communication with the Doser subsystem.
2. Localization for new Parameters

Dependencies - standard build-in go libraries:
"bytes"
"fmt"
"text/template"
"net/http"

Testing:
1.  Tested locally to ensure the proper functioning of REST API endpoints.
3.  Verified the user interface changes across different browsers and screen sizes.
4.  Conducted unit tests to validate the behavior of the integrated features.

How it's works:
1)In UI was added new type of Doser "REST API"
2)New Doser is totally network-based and do not require any Jack/Outlet sockets
3)In UI Added two URL with different functions:
 - URL - link that used for dosing by schedule. 
 - Calibration URL - link used for Calibration window.
 
Both links are working as universal template for the REST API URL where placeholders like {{ volume }} and {{ duration }} are replaced with actual values, utilizing Go's text/template package. 

Currently templates support parameters:
- Volume
- Duration
- Speed

Examples of URL for UI:
http://192.168.254.146/dose?volume={{.Volume}}&time={{.Duration}}
http://192.168.254.146/calibration?direction=1&rpm={{.Speed}}&time={{.Duration}}

![Screenshot 2024-03-23 at 23 26 53](https://github.com/reef-pi/reef-pi/assets/26632086/6c3cbd61-14ca-436b-85f9-68a5b7026a57)
![Screenshot 2024-03-23 at 23 26 11](https://github.com/reef-pi/reef-pi/assets/26632086/69f429d8-2406-4aa6-8a13-9e98188e7dcf)
