### PR TITLE
Raspberry not in dev mode by default

### DIFF
--- a/controller/device_manager/drivers/factories.go
+++ b/controller/device_manager/drivers/factories.go
@@ -55,7 +55,7 @@ var piDriver = Driver{
 	Name:   "Raspberry Pi",
 	ID:     _rpi,
 	Type:   _rpi,
-	Config: []byte(`{"frequency": 150, "Dev Mode": true}`),
+	Config: []byte(`{"frequency": 150, "Dev Mode": false}`),
 }
 
 func (d *Drivers) loadRpi() error {


### PR DESCRIPTION
After https://github.com/reef-pi/reef-pi/pull/1976 Raspberry driver doesn't work because is loaded in devel model