### PR TITLE
(ci) Release Workflow

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -1,8 +1,21 @@
 name: deb
-on: [push, pull_request]
+on:
+  workflow_call:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 jobs:
-  builds:
+  build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - x86
+          - pi0
+          - pi3
     steps:
       - uses: actions/checkout@v4.2.2
       - uses: ruby/setup-ruby@v1
@@ -14,23 +27,36 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - uses: actions/cache@v4.2.0
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node_modules-
+          cache: 'yarn'
       - name: Install
         run: yarn
-      - name: go
-        run: make go
-      - name: pi
-        run: make pi
+      - name: x86
+        if: matrix.target == 'x86'
+        run: make x86
       - name: pi-zero
+        if: matrix.target == 'pi0'
         run: make pi-zero
+      - name: pi
+        if: matrix.target == 'pi3'
+        run: make pi
       - name: bundler
         run: gem install bundler -v 2.4 --no-document
       - name: fpm
         run: bundle install
-      - name: deb
+      - name: pi_deb
+        if: matrix.target != 'x86'
         run: make pi_deb
+      - name: x86_deb
+        if: matrix.target == 'x86'
+        run: make x86_deb
+      - name: Rename deb package
+        run: |
+          VERSION=$(git describe --always --tags)
+          mv reef-pi-${VERSION}.deb reef-pi-${VERSION}-${{ matrix.target }}.deb
+      - name: "Upload ${{ matrix.target }} deb package"
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}-debian-package
+          path: 'reef-pi-*.deb'
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+on:
+  release:
+    types:
+      - created
+jobs:
+  build:
+    uses: ./.github/workflows/deb.yml
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: x86-debian-package
+      - uses: actions/download-artifact@v4
+        with:
+          name: pi0-debian-package
+      - uses: actions/download-artifact@v4
+        with:
+          name: pi3-debian-package
+      - name: Upload deb package
+        uses: AButler/upload-release-assets@v3.0
+        with:
+          files: "reef-pi-*.deb"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a release workflow to automate the generation of release artifacts

This workflow is tested in my fork
- https://github.com/hectorespert/planted-pi/actions/runs/13224885524
- https://github.com/hectorespert/planted-pi/releases/tag/2025.1.1