### PR TITLE
fix: prevent stale on/off state in equipment bar chart

### DIFF
--- a/front-end/src/equipment/chart.jsx
+++ b/front-end/src/equipment/chart.jsx
@@ -35,15 +35,11 @@ class chart extends React.Component {
     if (this.props.equipment === undefined) {
       return <div />
     }
-    const equipment = []
-    this.props.equipment.forEach((eq, i) => {
-      if (eq.on) {
-        eq.onstate = 1
-      } else {
-        eq.offstate = 1
-      }
-      equipment.push(eq)
-    })
+    const equipment = this.props.equipment.map(eq => ({
+      ...eq,
+      onstate: eq.on ? 1 : undefined,
+      offstate: eq.on ? undefined : 1
+    }))
     return (
       <div className='container'>
         <span className='h6'>{i18next.t('capabilities:equipment')}</span>


### PR DESCRIPTION
## Summary

The equipment bar chart's `render()` method mutated the Redux store's equipment objects directly:

```js
if (eq.on) {
  eq.onstate = 1   // mutates Redux state object
} else {
  eq.offstate = 1  // mutates Redux state object
}
```

Because the same object references are reused across renders, a piece of equipment that was previously **off** (had `offstate=1`) and then switched **on** would accumulate **both** `onstate=1` and `offstate=1`. The stacked `BarChart` then rendered both the green and red bars simultaneously, producing a double-height bar that didn't reflect the actual on/off state.

Fix: use `Array.map` to produce fresh copies of each equipment object with `onstate`/`offstate` set exclusively based on the current `eq.on` value.

## Test plan

- [ ] Run frontend tests: `cd front-end && npm test`
- [ ] Add the Equipment Bar Chart to the dashboard
- [ ] Toggle a piece of equipment on and off a few times — confirm the bar shows only green (on) or red (off), never both stacked

Fixes #2071

🤖 Generated with [Claude Code](https://claude.com/claude-code)