### PR TITLE
fix: load and validate light channels on startup so PWM values are restored after reboot

### DIFF
--- a/controller/modules/lighting/controller.go
+++ b/controller/modules/lighting/controller.go
@@ -66,6 +66,10 @@ func (c *Controller) Start() {
 		if err := c.statsMgr.Load(l.ID, fn); err != nil {
 			log.Println("ERROR: lighting subsystem. Failed to load usage. Error:", err)
 		}
+		if err := c.validate(&l); err != nil {
+			log.Println("ERROR: lighting subsystem. Failed to validate light on startup:", l.Name, "Error:", err)
+			continue
+		}
 		quit := make(chan struct{})
 		c.quitters[l.ID] = quit
 		go c.Run(l, quit)


### PR DESCRIPTION
## Summary

- `Start()` now calls `validate(&l)` before launching each light's goroutine, ensuring profiles are loaded and all channels are populated before the first `syncLight()` call
- If validation fails (e.g. the referenced jack was deleted), the light is skipped with a clear log message instead of silently writing zeros to the hardware

## Root cause

`Start()` loaded `Light` structs directly from storage and passed them to `go c.Run(l, quit)`. Because `ch.profile` is an unexported interface field it is not serialized, so it was always `nil` on startup. The goroutine called `l.LoadChannels()` to recover, but on any error execution continued silently: `syncLight()` then called `ch.ValueAt()` which returned `0` for every profile-based channel, turning all lights off. The next retry was 30 s away (the ticker interval).

A secondary problem: if the jack backing a light had pins added after the light was created, `LoadChannels()` (unlike `validate()`) does not add entries for the new pins, so those channels were never synced.

`Update()` already calls `validate()` before starting a goroutine — `Start()` now does the same.

## Test plan

- [ ] `go test ./controller/modules/lighting/...` passes
- [ ] After reef-pi restart, lights configured with PWM profiles resume at the correct value immediately (not after the first 30 s tick)
- [ ] A light whose jack was deleted logs a clear error on startup and does not panic

Fixes #1316

🤖 Generated with [Claude Code](https://claude.com/claude-code)