### PR TITLE
fix: delay poweroff/reboot to close database cleanly before shutdown

### DIFF
--- a/controller/modules/system/api.go
+++ b/controller/modules/system/api.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"os"
+	"time"
 
 	"github.com/gorilla/mux"
 
@@ -165,11 +166,17 @@ func (t *Controller) GetSummary(w http.ResponseWriter, r *http.Request) {
 func (c *Controller) Poweroff(w http.ResponseWriter, r *http.Request) {
 	fn := func(string) (interface{}, error) {
 		log.Println("Shutting down reef-pi controller")
-		out, err := utils.Command("/bin/systemctl", "poweroff").WithDevMode(c.config.DevMode).CombinedOutput()
-		if err != nil {
-			return "", fmt.Errorf("failed to power off reef-pi. Output: %s. Error: %w", string(out), err)
-		}
-		return out, nil
+		devMode := c.config.DevMode
+		go func() {
+			// Delay so the HTTP response is sent before the shutdown sequence
+			// begins. systemd will then send SIGTERM to reef-pi, giving it time
+			// to flush and close the database cleanly before the power-off.
+			time.Sleep(2 * time.Second)
+			if out, err := utils.Command("/bin/systemctl", "poweroff").WithDevMode(devMode).CombinedOutput(); err != nil {
+				log.Println("ERROR: Failed to power off reef-pi. Output:", string(out), "Error:", err)
+			}
+		}()
+		return "shutting down", nil
 	}
 	utils.JSONGetResponse(fn, w, r)
 }
@@ -177,11 +184,17 @@ func (c *Controller) Poweroff(w http.ResponseWriter, r *http.Request) {
 func (c *Controller) Reboot(w http.ResponseWriter, r *http.Request) {
 	fn := func(string) (interface{}, error) {
 		log.Println("Rebooting reef-pi controller")
-		out, err := utils.Command("/bin/systemctl", "reboot").WithDevMode(c.config.DevMode).CombinedOutput()
-		if err != nil {
-			return "", fmt.Errorf("failed to reboot reef-pi. Output: %s. Error: %w", string(out), err)
-		}
-		return out, nil
+		devMode := c.config.DevMode
+		go func() {
+			// Delay so the HTTP response is sent before the reboot sequence
+			// begins. systemd will then send SIGTERM to reef-pi, giving it time
+			// to flush and close the database cleanly before the reboot.
+			time.Sleep(2 * time.Second)
+			if out, err := utils.Command("/bin/systemctl", "reboot").WithDevMode(devMode).CombinedOutput(); err != nil {
+				log.Println("ERROR: Failed to reboot reef-pi. Output:", string(out), "Error:", err)
+			}
+		}()
+		return "rebooting", nil
 	}
 	utils.JSONGetResponse(fn, w, r)
 }


### PR DESCRIPTION
## Summary

- `Poweroff()` and `Reboot()` previously called `systemctl poweroff/reboot` synchronously before the HTTP response was sent
- After systemd received the poweroff signal, it would send SIGTERM to reef-pi, but there was a race between the database flush (via `c.Stop()`) and systemd's kill timeout
- On Raspberry Pi 0 in particular, this race could leave BoltDB in a dirty state, corrupting the filesystem and preventing subsequent boots
- Fix: fire the `systemctl` command in a goroutine with a 2-second delay so the HTTP response is delivered first, giving reef-pi time to receive SIGTERM and cleanly close the database via its signal handler

## Test plan

- [ ] Click Shutdown in the reef-pi admin UI
- [ ] Verify the UI receives a response immediately ("shutting down")
- [ ] Wait ~2 seconds for the Pi to begin shutdown
- [ ] Confirm the Pi powers off and reboots cleanly
- [ ] Verify reef-pi starts successfully on next boot (no database corruption)

Fixes #2168

🤖 Generated with [Claude Code](https://claude.com/claude-code)