### PR TITLE
fix: remove mutex from ATO Control() to prevent deadlock stopping all ATOs

### DIFF
--- a/controller/modules/ato/controlller.go
+++ b/controller/modules/ato/controlller.go
@@ -96,8 +96,6 @@ func (c *Controller) Stop() {
 }
 
 func (c *Controller) Control(a ATO, reading int) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	if a.Pump == "" {
 		log.Println("ato-subsystem: control enabled but pump not set. Skipping")
 		return nil


### PR DESCRIPTION
## Summary

- `Control()` held `c.mu` while calling `sub.On()` (the equipment or macro subsystem)
- When an ATO uses a macro as its pump (`IsMacro=true`), the macro step can call back into `ato.On()` → `ato.Update()`, which tries to acquire `c.mu` → **deadlock**
- While this deadlock is active, every other ATO goroutine that tries to call `Control()` on its own tick is also blocked on `c.mu`, causing **all ATOs** to appear frozen until reef-pi is rebooted
- `Control()` does not access `c.quitters` or any other state guarded by `c.mu` — it operates entirely on the local `ATO` copy and makes thread-safe calls into other subsystems — so the lock was unnecessary and harmful
- Fix: remove `c.mu.Lock()` / `defer c.mu.Unlock()` from `Control()`

## Test plan

- [ ] Configure an ATO that uses a macro as its pump (`IsMacro=true`), where the macro has a step that enables/disables another ATO
- [ ] Trigger the ATO check cycle and verify no deadlock occurs
- [ ] Verify all ATOs continue running after a macro controlling an ATO is executed
- [ ] Run unit tests: `go test ./controller/modules/ato/...`

Fixes #2178

🤖 Generated with [Claude Code](https://claude.com/claude-code)