### PR TITLE
fix: deduplicate pH calibration points to prevent hal.CalibratorFactory error

### DIFF
--- a/controller/modules/ph/probe.go
+++ b/controller/modules/ph/probe.go
@@ -302,6 +302,16 @@ func (c *Controller) CalibratePoint(id string, point CalibrationPoint) error {
 		if err := c.c.Store().Get(CalibrationBucket, p.ID, &calibration); err != nil {
 			log.Println("ph-subsystem. No calibration data found for probe:", p.Name)
 		}
+		// Remove any existing point with the same expected value so re-calibrating
+		// a single point does not accumulate duplicates that would push the slice
+		// past the two-point limit accepted by hal.CalibratorFactory.
+		filtered := calibration[:0]
+		for _, m := range calibration {
+			if m.Expected != point.Expected {
+				filtered = append(filtered, m)
+			}
+		}
+		calibration = filtered
 	}
 	c.Lock()
 	defer c.Unlock()


### PR DESCRIPTION
## Summary

- `hal.CalibratorFactory` only accepts 0, 1, or 2 measurement points; 3+ causes it to return an error
- `CalibratePoint()` always appended the new point to the existing calibration slice, without deduplication
- If a user re-calibrated the second (or high/low) point without first resetting via the mid-point, the existing calibration slice was loaded (already containing 2 points) and a third was appended, causing `CalibratorFactory` to fail and the UI to show "something went wrong"
- Fix: before appending, remove any existing measurement whose `Expected` value matches the incoming point, so repeated calibrations on the same reference value replace the old entry rather than accumulate

## Test plan

- [ ] Configure a pH probe (disabled)
- [ ] Calibrate mid point (7.0)
- [ ] Calibrate second point (10.0) — verify succeeds
- [ ] Calibrate second point (10.0) **again** without resetting mid — verify it succeeds instead of erroring
- [ ] Confirm readings are correctly calibrated after each step
- [ ] Run unit tests: `go test ./controller/modules/ph/...`

Fixes #1395

🤖 Generated with [Claude Code](https://claude.com/claude-code)