### PR TITLE
fix: interval lighting profile returns 0 at end boundary due to +1s lookahead

### DIFF
--- a/controller/pwm_profile/interval.go
+++ b/controller/pwm_profile/interval.go
@@ -18,7 +18,7 @@ func (i *interval) Name() string {
 }
 
 func (i *interval) Get(t time.Time) float64 {
-	if i.IsOutside(t.Add(time.Second)) {
+	if i.IsOutside(t) {
 		return 0
 	}
 	past := i.PastSeconds(t)

--- a/controller/pwm_profile/interval_test.go
+++ b/controller/pwm_profile/interval_test.go
@@ -49,6 +49,40 @@ func TestInterval(t *testing.T) {
 	}
 }
 
+// https://github.com/reef-pi/reef-pi/issues/1117
+// At exactly the end time the profile should return the last configured value,
+// not 0. Previously Get() checked IsOutside(t+1s), causing a premature
+// zero at the exact boundary second.
+func TestIntervalAtEndBoundary(t *testing.T) {
+	// 08:00 to 22:00 = 50400 s; 50400/7200 + 1 = 8 values required
+	conf := `
+{
+	"start":"08:00:00",
+	"end":"22:00:00",
+	"interval":7200,
+	"values":[0,10,20,30,40,50,60,40]
+}
+`
+	i, err := Interval([]byte(conf), 0, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Exactly at end time the profile must return the last configured value.
+	endTime, err := time.Parse(tFormat, "22:00:00")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := i.Get(endTime)
+	if v == 0 {
+		t.Errorf("Expected non-zero value at end time, got 0 — interval profile terminated 1 second early")
+	}
+	// One second AFTER end the profile should return 0.
+	after := endTime.Add(time.Second)
+	if i.Get(after) != 0 {
+		t.Errorf("Expected 0 one second past end time, got %f", i.Get(after))
+	}
+}
+
 // https://github.com/reef-pi/reef-pi/issues/960
 // start: 00:00:00
 // end: 23:59:59


### PR DESCRIPTION
## Summary

- `interval.Get()` called `i.IsOutside(t.Add(time.Second))` instead of `i.IsOutside(t)`
- At exactly the end time (e.g. 22:00:00), this checked whether `22:00:01` was outside the range — which it is — so the profile returned 0 instead of the configured value
- Result: lights shut off at the configured end time and stayed off until midnight (next cycle start), exactly as reported
- All other profile types (`diurnal`, `fixed`, `sine`, `random`) already use `IsOutside(t)` without the one-second offset — this was an inconsistency unique to `interval`
- Fix: remove the `t.Add(time.Second)` offset; the boundary is now `[start, end]` inclusive, consistent with the other profiles
- Added a regression test that asserts a non-zero value at the exact end-time second and zero one second after

## Test plan

- [ ] Configure an interval lighting channel with `end = 22:00:00`
- [ ] Verify the light holds its configured value at exactly 22:00 instead of going dark
- [ ] Verify the light goes to 0 at 22:00:01
- [ ] `go test ./controller/pwm_profile/...`

Fixes #1117

🤖 Generated with [Claude Code](https://claude.com/claude-code)