### PR TITLE
fix: retry MQTT connection in background when initial connect fails at boot

### DIFF
--- a/controller/telemetry/mqtt.go
+++ b/controller/telemetry/mqtt.go
@@ -36,7 +36,11 @@ type MQTTClient struct {
 
 func NewMQTTClient(conf MQTTConfig) (*MQTTClient, error) {
 	mqtt.ERROR = log.New(os.Stdout, "", 0)
-	connOpts := mqtt.NewClientOptions().AddBroker(conf.Server).SetClientID(conf.ClientID).SetCleanSession(true)
+	connOpts := mqtt.NewClientOptions().
+		AddBroker(conf.Server).
+		SetClientID(conf.ClientID).
+		SetCleanSession(true).
+		SetAutoReconnect(true)
 	if conf.Username != "" {
 		connOpts.SetUsername(conf.Username)
 		if conf.Password != "" {

--- a/controller/telemetry/telemetry.go
+++ b/controller/telemetry/telemetry.go
@@ -124,11 +124,44 @@ func NewTelemetry(name, bucket string, store storage.Store, config TelemetryConf
 		mClient, err := NewMQTTClient(config.MQTT)
 		if err != nil {
 			lr("telemety-subsystem", "Failed to initialize mqtt client:"+err.Error())
+			// Network may not be ready at boot (DHCP/DNS still pending). Retry in background.
+			go t.mqttReconnectLoop()
 		} else {
 			t.mClient = mClient
 		}
 	}
 	return t
+}
+
+// mqttReconnectLoop retries the MQTT connection every 30 seconds until it
+// succeeds or MQTT is disabled. It is started as a goroutine when the initial
+// connection attempt at startup fails (common on Pi due to network not being
+// ready before reef-pi starts).
+func (t *telemetry) mqttReconnectLoop() {
+	for {
+		time.Sleep(30 * time.Second)
+		t.mu.Lock()
+		enabled := t.config.MQTT.Enable
+		already := t.mClient != nil
+		t.mu.Unlock()
+		if !enabled || already {
+			return
+		}
+		mClient, err := NewMQTTClient(t.config.MQTT)
+		if err != nil {
+			log.Println("WARNING: telemetry: mqtt reconnect failed:", err)
+			continue
+		}
+		t.mu.Lock()
+		if t.mClient == nil { // check again in case applyConfig ran concurrently
+			t.mClient = mClient
+			log.Println("INFO: telemetry: mqtt client reconnected successfully")
+		} else {
+			mClient.client.Disconnect(250) // applyConfig already set a new one
+		}
+		t.mu.Unlock()
+		return
+	}
 }
 
 func (t *telemetry) NewStatsManager(b string) StatsManager {
@@ -231,10 +264,13 @@ func (t *telemetry) EmitMetric(module, name string, v float64) {
 }
 
 func (t *telemetry) EmitMQTT(topic string, v float64) error {
-	if t.mClient == nil {
+	t.mu.Lock()
+	client := t.mClient
+	t.mu.Unlock()
+	if client == nil {
 		return errors.New("mqtt client is not initialized")
 	}
-	return t.mClient.Publish(topic, fmt.Sprintf("%f", v))
+	return client.Publish(topic, fmt.Sprintf("%f", v))
 }
 
 func (t *telemetry) EmitAIO(user, feed string, v float64) error {
@@ -284,11 +320,13 @@ func (t *telemetry) applyConfig(c TelemetryConfig) {
 			newMClient = mc
 		}
 	}
+	t.mu.Lock()
 	oldMClient := t.mClient
 	t.config = c
+	t.mClient = newMClient
+	t.mu.Unlock()
 	t.dispatcher = newDispatcher
 	t.aClient = newAClient
-	t.mClient = newMClient
 	if oldMClient != nil {
 		oldMClient.client.Disconnect(250)
 	}


### PR DESCRIPTION
## Summary

- On Raspberry Pi, reef-pi can start before the network stack is fully initialized (DHCP/DNS still pending), causing `NewMQTTClient()` to fail on the first attempt
- Previously `t.mClient` was set to `nil` and never retried, so every subsequent `EmitMQTT()` call returned "mqtt client is not initialized" even after the network came up — a permanent failure that requires a manual service restart to fix
- Added `SetAutoReconnect(true)` to the Paho client so connections lost after the initial handshake are restored automatically
- When `NewTelemetry()` fails the initial MQTT connect, it now starts a background goroutine (`mqttReconnectLoop`) that retries every 30 s until the broker becomes reachable or MQTT is disabled in settings
- Protected `t.mClient` reads/writes with `t.mu` to eliminate the data race between the reconnect goroutine, `applyConfig()`, and `EmitMQTT()`

## Test plan

- [ ] Enable MQTT with a remote broker hostname (`homeassistant.local`) before network is ready, start reef-pi — observe "Failed to initialize mqtt client" log but no permanent failure
- [ ] After 30 s (or however long until DNS resolves), verify reef-pi automatically connects and begins publishing metrics
- [ ] Verify re-saving MQTT settings via the UI disconnects the old client and connects the new one without issues
- [ ] `go test ./controller/telemetry/...`

Fixes #1932
Fixes #2009

🤖 Generated with [Claude Code](https://claude.com/claude-code)