### PR TITLE
fix: strip special characters from Adafruit.io feed names

### DIFF
--- a/controller/telemetry/telemetry.go
+++ b/controller/telemetry/telemetry.go
@@ -21,6 +21,13 @@ const DBKey = "telemetry"
 
 var sanitizePrometheusMetricRegex = regexp.MustCompile("[^a-zA-Z0-9_]")
 
+// adafruitIOFeedKeyRegex strips any character that is not a lowercase letter,
+// digit, or hyphen — the only characters accepted in Adafruit IO feed keys.
+var adafruitIOFeedKeyRegex = regexp.MustCompile("[^a-z0-9-]")
+
+// consecutiveDashRegex collapses multiple adjacent hyphens into one.
+var consecutiveDashRegex = regexp.MustCompile("-{2,}")
+
 type ErrorLogger func(string, string) error
 
 type Telemetry interface {
@@ -190,7 +197,15 @@ func (t *telemetry) Mail(subject, body string) (bool, error) {
 
 func SanitizeAdafruitIOFeedName(name string) string {
 	name = strings.ToLower(name)
-	return strings.Replace(name, " ", "-", -1)
+	// Replace spaces with dashes first, then strip all remaining characters
+	// that Adafruit IO does not allow in feed keys (only a-z, 0-9, hyphen).
+	name = strings.ReplaceAll(name, " ", "-")
+	name = adafruitIOFeedKeyRegex.ReplaceAllString(name, "")
+	// Collapse consecutive hyphens that result from stripping characters such
+	// as parentheses, colons, etc.  e.g. "foo-(bar)-baz" → "foo-bar-baz".
+	name = consecutiveDashRegex.ReplaceAllString(name, "-")
+	// Trim any leading/trailing hyphens.
+	return strings.Trim(name, "-")
 }
 func SanitizePrometheusMetricName(name string) string {
 	name = strings.ToLower(name)

--- a/controller/telemetry/telemetry_test.go
+++ b/controller/telemetry/telemetry_test.go
@@ -39,6 +39,33 @@ func TestEmitMetric(t *testing.T) {
 	}
 }
 
+// https://github.com/reef-pi/reef-pi/issues/1996
+func TestSanitizeAdafruitIOFeedName(t *testing.T) {
+	checks := []struct {
+		input  string
+		output string
+	}{
+		{input: "simple", output: "simple"},
+		{input: "with space", output: "with-space"},
+		// parentheses must be stripped (caused "invalid URL" on adafruit.io)
+		{input: "rpato-auto-fill-(ato)-state", output: "rpato-auto-fill-ato-state"},
+		// colon must be stripped
+		{input: "rpato-alarm:-water-high", output: "rpato-alarm-water-high"},
+		// consecutive dashes from stripped characters collapse to one
+		{input: "rpdaylight---sera-(30w)-led", output: "rpdaylight-sera-30w-led"},
+		// leading/trailing hyphens trimmed
+		{input: "(foo)", output: "foo"},
+		// uppercase is lowercased
+		{input: "MyFeed", output: "myfeed"},
+	}
+	for _, c := range checks {
+		out := SanitizeAdafruitIOFeedName(c.input)
+		if out != c.output {
+			t.Errorf("feed name not sanitized: input %q output %q expected %q", c.input, out, c.output)
+		}
+	}
+}
+
 func TestSanitizePrometheusMetricName(t *testing.T) {
 	checks := []struct {
 		input  string


### PR DESCRIPTION
## Summary

- `SanitizeAdafruitIOFeedName()` only replaced spaces with hyphens; it left characters like parentheses `()` and colons `:` in the feed name
- Adafruit.io rejects these as invalid URL characters, returning `{"error":"not found - that is an invalid URL"}` on every metric publish for any sensor/equipment whose name contains those characters
- Examples from the issue: `rpato-auto-fill-tapwater-(ato)-state`, `rpato-alarm:-water-level-sump-high-state`
- Fix: after lower-casing and replacing spaces, strip every character that is not `[a-z0-9-]`, collapse consecutive hyphens, and trim leading/trailing hyphens — matching the Adafruit.io feed key format exactly
- Previously valid feed names (only letters, digits, single hyphens) are unchanged

## Test plan

- [ ] Name equipment/ATO with parentheses or colons (e.g. `Auto Fill (ATO)`)
- [ ] Enable Adafruit.io telemetry and verify no "invalid URL" 404 errors in the log
- [ ] Verify metrics are published correctly to the sanitized feed name
- [ ] `go test ./controller/telemetry/... -run TestSanitize`

Fixes #1996

🤖 Generated with [Claude Code](https://claude.com/claude-code)