### PR TITLE
feat: add min/max reference lines to pH chart

### DIFF
--- a/front-end/src/ph/chart.jsx
+++ b/front-end/src/ph/chart.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { ParseTimestamp, filterToday } from 'utils/timestamp'
-import { ResponsiveContainer, Tooltip, YAxis, XAxis, LineChart, Line } from 'recharts'
+import { ResponsiveContainer, Tooltip, YAxis, XAxis, LineChart, Line, ReferenceLine } from 'recharts'
 import { fetchProbeReadings } from 'redux/actions/phprobes'
 import { connect } from 'react-redux'
 import { TwoDecimalParse } from 'utils/two_decimal_parse'
@@ -41,6 +41,9 @@ class chart extends React.Component {
       }
     }
     const c = this.props.config.chart
+    const notify = this.props.config.notify
+    const showMin = notify && notify.enable && notify.min > 0
+    const showMax = notify && notify.enable && notify.max > 0
     return (
       <div className='container'>
         <span className='h6'>{this.props.config.name}({current})</span>
@@ -50,6 +53,22 @@ class chart extends React.Component {
             <XAxis dataKey='time' />
             <Tooltip formatter={(value, name) => [TwoDecimalParse(value), c.unit]} />
             <YAxis dataKey='value' domain={[c.ymin, c.ymax]} />
+            {showMin && (
+              <ReferenceLine
+                y={notify.min}
+                stroke='orange'
+                strokeDasharray='4 2'
+                label={{ value: `Min: ${notify.min}`, position: 'insideBottomRight', fontSize: 11, fill: 'orange' }}
+              />
+            )}
+            {showMax && (
+              <ReferenceLine
+                y={notify.max}
+                stroke='orange'
+                strokeDasharray='4 2'
+                label={{ value: `Max: ${notify.max}`, position: 'insideTopRight', fontSize: 11, fill: 'orange' }}
+              />
+            )}
           </LineChart>
         </ResponsiveContainer>
       </div>


### PR DESCRIPTION
## Summary

- Adds horizontal dashed orange reference lines at `notify.min` and `notify.max` on the pH chart
- Lines are only rendered when notifications are enabled (`notify.enable === true`) and the threshold is non-zero
- Uses Recharts `ReferenceLine` component (already in the dependency tree) with labels positioned inside the chart area

## Test plan

- [ ] Enable pH notifications with a min/max threshold configured
- [ ] Verify orange dashed lines appear at the correct Y positions on the pH chart
- [ ] Verify no lines appear when notifications are disabled
- [ ] Frontend unit tests pass: `npm test -- --testPathPattern=ph/`

Fixes #2165

🤖 Generated with [Claude Code](https://claude.com/claude-code)