### PR TITLE
feat: add CPU temperature to health check

### DIFF
--- a/controller/settings/healthcheck.go
+++ b/controller/settings/healthcheck.go
@@ -1,7 +1,8 @@
 package settings
 
 type HealthCheckNotify struct {
-	Enable    bool    `json:"enable"`
-	MaxMemory float64 `json:"max_memory"`
-	MaxCPU    float64 `json:"max_cpu"`
+	Enable     bool    `json:"enable"`
+	MaxMemory  float64 `json:"max_memory"`
+	MaxCPU     float64 `json:"max_cpu"`
+	MaxCPUTemp float64 `json:"max_cpu_temp"`
 }

--- a/controller/telemetry/health.go
+++ b/controller/telemetry/health.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"math"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -41,10 +43,12 @@ type hc struct {
 type HealthMetric struct {
 	Load5        float64  `json:"cpu"`
 	UsedMemory   float64  `json:"memory"`
+	CPUTemp      float64  `json:"cpu_temp"`
 	Time         TeleTime `json:"time"`
 	len          int
 	loadSum      float64
 	memorySum    float64
+	cpuTempSum   float64
 	UnderVoltage float64 `json:"throttle"`
 }
 
@@ -55,16 +59,20 @@ func (m1 HealthMetric) Rollup(mx Metric) (Metric, bool) {
 			Time:         m1.Time,
 			Load5:        m1.Load5,
 			UsedMemory:   m1.UsedMemory,
+			CPUTemp:      m1.CPUTemp,
 			len:          m1.len,
 			loadSum:      m1.loadSum,
 			memorySum:    m1.memorySum,
+			cpuTempSum:   m1.cpuTempSum,
 			UnderVoltage: m2.UnderVoltage,
 		}
 		m.loadSum += m2.Load5
 		m.memorySum += m2.UsedMemory
+		m.cpuTempSum += m2.CPUTemp
 		m.len += 1
 		m.Load5 = utils.RoundToTwoDecimal(m.loadSum / float64(m.len))
 		m.UsedMemory = utils.RoundToTwoDecimal(m.memorySum / float64(m.len))
+		m.CPUTemp = utils.RoundToTwoDecimal(m.cpuTempSum / float64(m.len))
 		if m.UnderVoltage == 0 {
 			m.UnderVoltage = m2.UnderVoltage
 		}
@@ -94,6 +102,18 @@ func NewHealthChecker(b string, i time.Duration, notify settings.HealthCheckNoti
 	return h
 }
 
+func readCPUTemp() (float64, error) {
+	data, err := os.ReadFile("/sys/class/thermal/thermal_zone0/temp")
+	if err != nil {
+		return 0, err
+	}
+	millideg, err := strconv.ParseFloat(strings.TrimSpace(string(data)), 64)
+	if err != nil {
+		return 0, err
+	}
+	return utils.RoundToTwoDecimal(millideg / 1000.0), nil
+}
+
 func (h *hc) Check() {
 	loadStat, err := load.Avg()
 	if err != nil {
@@ -116,6 +136,16 @@ func (h *hc) Check() {
 		memorySum:  usedMemory,
 		Time:       TeleTime(time.Now()),
 	}
+
+	cpuTemp, err := readCPUTemp()
+	if err != nil {
+		log.Println("WARNING: Failed to read CPU temperature. Error:", err)
+	} else {
+		metric.CPUTemp = cpuTemp
+		metric.cpuTempSum = cpuTemp
+		h.t.EmitMetric("system", "cpu-temp", cpuTemp)
+	}
+
 	if h.isRaspberryPi {
 		throttles, err := VcgencmdGetThrottled()
 		if err != nil {
@@ -132,12 +162,12 @@ func (h *hc) Check() {
 
 	h.t.EmitMetric("system", "mem-used", usedMemory)
 	h.t.EmitMetric("system", "under-voltage", metric.UnderVoltage)
-	log.Println("health check: Used memory:", usedMemory, " Load5:", loadStat.Load5)
+	log.Println("health check: Used memory:", usedMemory, " Load5:", loadStat.Load5, " CPUTemp:", metric.CPUTemp)
 	h.statsMgr.Update(HealthStatsKey, metric)
-	h.NotifyIfNeeded(usedMemory, loadStat.Load5)
+	h.NotifyIfNeeded(usedMemory, loadStat.Load5, metric.CPUTemp)
 }
 
-func (h *hc) NotifyIfNeeded(memory, load float64) {
+func (h *hc) NotifyIfNeeded(memory, load, cpuTemp float64) {
 	if h.Notify.Enable {
 		if load >= h.Notify.MaxCPU {
 			subject := "CPU Load is high"
@@ -149,6 +179,12 @@ func (h *hc) NotifyIfNeeded(memory, load float64) {
 			subject := "Memory consumption is high"
 			format := "Current memory consumption %f is above threshold ( %f )"
 			body := fmt.Sprintf(format, memory, h.Notify.MaxMemory)
+			h.t.Alert(subject, body)
+		}
+		if h.Notify.MaxCPUTemp > 0 && cpuTemp >= h.Notify.MaxCPUTemp {
+			subject := "CPU temperature is high"
+			format := "Current CPU temperature %f°C is above threshold ( %f°C )"
+			body := fmt.Sprintf(format, cpuTemp, h.Notify.MaxCPUTemp)
 			h.t.Alert(subject, body)
 		}
 	}
@@ -166,6 +202,7 @@ func (h *hc) setup() {
 	h.t.CreateFeedIfNotExist("system-load5")
 	h.t.CreateFeedIfNotExist("system-mem-used")
 	h.t.CreateFeedIfNotExist("system-under-voltage")
+	h.t.CreateFeedIfNotExist("system-cpu-temp")
 }
 
 func (h *hc) Start() {

--- a/front-end/assets/translations/de.csv
+++ b/front-end/assets/translations/de.csv
@@ -145,6 +145,7 @@ configuration:settings:cors,cors
 configuration:settings:display,Display
 configuration:settings:interface,Netzwerkinterface
 configuration:settings:max_cpu,CPU Nutzung % größer
+configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,Speicherbelegung MB größer
 configuration:settings:name,Netzwerkname
 configuration:settings:network_address_required,Eine Netzwerkadresse wird benötigt!

--- a/front-end/assets/translations/en.csv
+++ b/front-end/assets/translations/en.csv
@@ -145,6 +145,7 @@ configuration:settings:cors,Enable cors
 configuration:settings:display,Display
 configuration:settings:interface,Interface
 configuration:settings:max_cpu,Max CPU
+configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,Max memory
 configuration:settings:name,Name
 configuration:settings:network_address_required,Network address is required

--- a/front-end/assets/translations/es.csv
+++ b/front-end/assets/translations/es.csv
@@ -145,6 +145,7 @@ configuration:settings:cors,Activar cors
 configuration:settings:display,Pantalla
 configuration:settings:interface,Interface
 configuration:settings:max_cpu,Procesador Maximo
+configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,Memoria Maxima
 configuration:settings:name,Nombre
 configuration:settings:network_address_required,La direccion de red es requerida

--- a/front-end/assets/translations/fa.csv
+++ b/front-end/assets/translations/fa.csv
@@ -145,6 +145,7 @@ configuration:settings:cors,
 configuration:settings:display,
 configuration:settings:interface,
 configuration:settings:max_cpu,
+configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,
 configuration:settings:name,
 configuration:settings:network_address_required,

--- a/front-end/assets/translations/fr.csv
+++ b/front-end/assets/translations/fr.csv
@@ -145,6 +145,7 @@ configuration:settings:cors,
 configuration:settings:display,Affichage
 configuration:settings:interface,Interface
 configuration:settings:max_cpu,CPU maximum
+configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,Mémoire maximum
 configuration:settings:name,Nom
 configuration:settings:network_address_required,Adresse réseau requise

--- a/front-end/assets/translations/hi.csv
+++ b/front-end/assets/translations/hi.csv
@@ -145,6 +145,7 @@ configuration:settings:cors,
 configuration:settings:display,
 configuration:settings:interface,
 configuration:settings:max_cpu,
+configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,
 configuration:settings:name,
 configuration:settings:network_address_required,

--- a/front-end/assets/translations/it.csv
+++ b/front-end/assets/translations/it.csv
@@ -145,6 +145,7 @@ configuration:settings:cors,
 configuration:settings:display,
 configuration:settings:interface,
 configuration:settings:max_cpu,
+configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,
 configuration:settings:name,
 configuration:settings:network_address_required,

--- a/front-end/assets/translations/nl.csv
+++ b/front-end/assets/translations/nl.csv
@@ -145,6 +145,7 @@ configuration:settings:cors,cors inschakelen
 configuration:settings:display,Display
 configuration:settings:interface,Interface
 configuration:settings:max_cpu,Max CPU
+configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,Max Geheugen
 configuration:settings:name,Naam
 configuration:settings:network_address_required,Netwerkadres is nodig

--- a/front-end/assets/translations/pt.csv
+++ b/front-end/assets/translations/pt.csv
@@ -145,6 +145,7 @@ configuration:settings:cors,Activar cors
 configuration:settings:display,Ecrã
 configuration:settings:interface,Interface
 configuration:settings:max_cpu,Maximo de CPU
+configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,Maximo de Memoria
 configuration:settings:name,Nome
 configuration:settings:network_address_required,Endereço de rede é obrigatório

--- a/front-end/assets/translations/zh.csv
+++ b/front-end/assets/translations/zh.csv
@@ -145,6 +145,7 @@ configuration:settings:cors,
 configuration:settings:display,显示
 configuration:settings:interface,接口
 configuration:settings:max_cpu,最大CPU
+configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,最大内存
 configuration:settings:name,名字
 configuration:settings:network_address_required,必须填写网络地址

--- a/front-end/src/configuration/health_notify.jsx
+++ b/front-end/src/configuration/health_notify.jsx
@@ -8,7 +8,8 @@ export default class HealthNotify extends React.Component {
       notify: {
         enable: props.state.enable,
         max_memory: props.state.max_memory,
-        max_cpu: props.state.max_cpu
+        max_cpu: props.state.max_cpu,
+        max_cpu_temp: props.state.max_cpu_temp
       }
     }
     this.update = this.update.bind(this)
@@ -70,6 +71,18 @@ export default class HealthNotify extends React.Component {
             id='health_max_cpu'
             value={this.state.notify.max_cpu}
             onChange={this.update('max_cpu')}
+          />
+        </div>
+      )
+      ct.push(
+        <div className='form-group col-md-6 col-12' key='health_notify_max_cpu_temp'>
+          <label htmlFor='health_max_cpu_temp'>{i18n.t('configuration:settings:max_cpu_temp')}</label>
+          <input
+            type='number'
+            className='form-control'
+            id='health_max_cpu_temp'
+            value={this.state.notify.max_cpu_temp}
+            onChange={this.update('max_cpu_temp')}
           />
         </div>
       )

--- a/front-end/src/health_chart.jsx
+++ b/front-end/src/health_chart.jsx
@@ -41,10 +41,12 @@ class healthChart extends React.Component {
           <LineChart data={healthStats}>
             <YAxis yAxisId='left' orientation='left' stroke='#00c851' />
             <YAxis yAxisId='right' orientation='right' stroke='#ffbb33' />
+            <YAxis yAxisId='temp' orientation='right' stroke='#ff4444' />
             <XAxis dataKey='time' />
             <Tooltip />
             <Line dot={false} type='linear' dataKey='cpu' stroke='#00c851' isAnimationActive={false} yAxisId='left' />
             <Line dot={false} type='linear' dataKey='memory' stroke='#ffbb33' isAnimationActive={false} yAxisId='right' />
+            <Line dot={false} type='linear' dataKey='cpu_temp' stroke='#ff4444' isAnimationActive={false} yAxisId='temp' />
           </LineChart>
         </ResponsiveContainer>
       </div>


### PR DESCRIPTION
## Summary

- Reads CPU temperature from `/sys/class/thermal/thermal_zone0/temp` (standard on Raspberry Pi and most Linux SBCs)
- Adds `cpu_temp` field to `HealthMetric` — included in rollup averaging and persisted to stats
- Emits `system/cpu-temp` telemetry metric (Prometheus, Adafruit IO, MQTT)
- Displays CPU temperature as a red line on the health chart alongside the existing CPU load (green) and memory (yellow) lines
- Adds optional `max_cpu_temp` alert threshold to the health check notification settings
- Temperature read failure is a non-fatal warning — other health metrics continue to be collected

## Test plan

- [ ] Deploy to a Raspberry Pi and verify the health chart shows a red CPU temp line
- [ ] Set a low `Max CPU Temp` threshold and confirm an alert email is sent
- [ ] Verify graceful degradation on systems without `/sys/class/thermal/thermal_zone0/temp` (only a WARNING log, no crash)
- [ ] Go tests: `go test ./controller/telemetry/...`
- [ ] Frontend tests: `npm test -- --testPathPattern=health`

Fixes #1956

🤖 Generated with [Claude Code](https://claude.com/claude-code)