### PR TITLE
feat: add sort control to equipment list

### DIFF
--- a/front-end/assets/translations/de.csv
+++ b/front-end/assets/translations/de.csv
@@ -199,6 +199,11 @@ doser:warn_delete,Wollen Sie die Dosierpumpe {{name}} wirklich löschen?
 doser:warn_reset,Wollen Sie den Verlauf von {{name}} wirklich löschen?
 equipment:chart:barchart,Geräte (Balken)
 equipment:chart:ctrlpanel,Geräte (Schalter)
+equipment:sort,Sort
+equipment:sort_name_az,Name (A→Z)
+equipment:sort_name_za,Name (Z→A)
+equipment:sort_on_first,On first
+equipment:sort_off_first,Off first
 equipment:title_delete,{{name}} löschen?
 equipment:warn_delete,Wollen Sie das Gerät {{name}} wirklich löschen?
 fatal_error:connection_lost,Verbindung verloren

--- a/front-end/assets/translations/en.csv
+++ b/front-end/assets/translations/en.csv
@@ -199,6 +199,11 @@ doser:warn_delete,This action will delete doser {{name}}
 doser:warn_reset,This action will reset usage data for doser {{name}}
 equipment:chart:barchart,Equipment(Bar Chart)
 equipment:chart:ctrlpanel,Equipment(Switch Panel)
+equipment:sort,Sort
+equipment:sort_name_az,Name (A→Z)
+equipment:sort_name_za,Name (Z→A)
+equipment:sort_on_first,On first
+equipment:sort_off_first,Off first
 equipment:title_delete,Delete {{name}} ?
 equipment:warn_delete,This action will delete equipment {{name}}
 fatal_error:connection_lost,Connection Lost

--- a/front-end/assets/translations/es.csv
+++ b/front-end/assets/translations/es.csv
@@ -199,6 +199,11 @@ doser:warn_delete,
 doser:warn_reset,
 equipment:chart:barchart,Equipo(Gráfica de Barras)
 equipment:chart:ctrlpanel,Equipo(Panel de Interruptores)
+equipment:sort,Sort
+equipment:sort_name_az,Name (A→Z)
+equipment:sort_name_za,Name (Z→A)
+equipment:sort_on_first,On first
+equipment:sort_off_first,Off first
 equipment:title_delete,
 equipment:warn_delete,
 fatal_error:connection_lost,Conexion Perdida

--- a/front-end/assets/translations/fa.csv
+++ b/front-end/assets/translations/fa.csv
@@ -199,6 +199,11 @@ doser:warn_delete,
 doser:warn_reset,
 equipment:chart:barchart,
 equipment:chart:ctrlpanel,
+equipment:sort,Sort
+equipment:sort_name_az,Name (A→Z)
+equipment:sort_name_za,Name (Z→A)
+equipment:sort_on_first,On first
+equipment:sort_off_first,Off first
 equipment:title_delete,
 equipment:warn_delete,
 fatal_error:connection_lost,

--- a/front-end/assets/translations/fr.csv
+++ b/front-end/assets/translations/fr.csv
@@ -199,6 +199,11 @@ doser:warn_delete,
 doser:warn_reset,
 equipment:chart:barchart,
 equipment:chart:ctrlpanel,
+equipment:sort,Sort
+equipment:sort_name_az,Name (A→Z)
+equipment:sort_name_za,Name (Z→A)
+equipment:sort_on_first,On first
+equipment:sort_off_first,Off first
 equipment:title_delete,
 equipment:warn_delete,
 fatal_error:connection_lost,

--- a/front-end/assets/translations/hi.csv
+++ b/front-end/assets/translations/hi.csv
@@ -199,6 +199,11 @@ doser:warn_delete,
 doser:warn_reset,
 equipment:chart:barchart,
 equipment:chart:ctrlpanel,
+equipment:sort,Sort
+equipment:sort_name_az,Name (A→Z)
+equipment:sort_name_za,Name (Z→A)
+equipment:sort_on_first,On first
+equipment:sort_off_first,Off first
 equipment:title_delete,
 equipment:warn_delete,
 fatal_error:connection_lost,

--- a/front-end/assets/translations/it.csv
+++ b/front-end/assets/translations/it.csv
@@ -199,6 +199,11 @@ doser:warn_delete,
 doser:warn_reset,
 equipment:chart:barchart,
 equipment:chart:ctrlpanel,
+equipment:sort,Sort
+equipment:sort_name_az,Name (A→Z)
+equipment:sort_name_za,Name (Z→A)
+equipment:sort_on_first,On first
+equipment:sort_off_first,Off first
 equipment:title_delete,
 equipment:warn_delete,
 fatal_error:connection_lost,

--- a/front-end/assets/translations/nl.csv
+++ b/front-end/assets/translations/nl.csv
@@ -199,6 +199,11 @@ doser:warn_delete,
 doser:warn_reset,
 equipment:chart:barchart,
 equipment:chart:ctrlpanel,
+equipment:sort,Sort
+equipment:sort_name_az,Name (A→Z)
+equipment:sort_name_za,Name (Z→A)
+equipment:sort_on_first,On first
+equipment:sort_off_first,Off first
 equipment:title_delete,
 equipment:warn_delete,
 fatal_error:connection_lost,Connectie verloren

--- a/front-end/assets/translations/pt.csv
+++ b/front-end/assets/translations/pt.csv
@@ -199,6 +199,11 @@ doser:warn_delete,Aviso Apagar
 doser:warn_reset,Aviso Reninciar
 equipment:chart:barchart,Grafico
 equipment:chart:ctrlpanel,Painel de Control
+equipment:sort,Sort
+equipment:sort_name_az,Name (A→Z)
+equipment:sort_name_za,Name (Z→A)
+equipment:sort_on_first,On first
+equipment:sort_off_first,Off first
 equipment:title_delete,Apagar
 equipment:warn_delete,Aviso Apagar
 fatal_error:connection_lost,Ligação Perdida

--- a/front-end/assets/translations/zh.csv
+++ b/front-end/assets/translations/zh.csv
@@ -199,6 +199,11 @@ doser:warn_delete,
 doser:warn_reset,
 equipment:chart:barchart,
 equipment:chart:ctrlpanel,
+equipment:sort,Sort
+equipment:sort_name_az,Name (A→Z)
+equipment:sort_name_za,Name (Z→A)
+equipment:sort_on_first,On first
+equipment:sort_off_first,Off first
 equipment:title_delete,
 equipment:warn_delete,
 fatal_error:connection_lost,连接丢失

--- a/front-end/src/equipment/main.jsx
+++ b/front-end/src/equipment/main.jsx
@@ -7,17 +7,38 @@ import EquipmentForm from './equipment_form'
 import { SortByName } from 'utils/sort_by_name'
 import i18next from 'i18next'
 
+const SORT_NAME_AZ = 'name_az'
+const SORT_NAME_ZA = 'name_za'
+const SORT_ON_FIRST = 'on_first'
+const SORT_OFF_FIRST = 'off_first'
+
+function sortEquipment (equipment, mode) {
+  const copy = [...equipment]
+  switch (mode) {
+    case SORT_NAME_ZA:
+      return copy.sort((a, b) => SortByName(b, a))
+    case SORT_ON_FIRST:
+      return copy.sort((a, b) => (b.on ? 1 : 0) - (a.on ? 1 : 0) || SortByName(a, b))
+    case SORT_OFF_FIRST:
+      return copy.sort((a, b) => (a.on ? 1 : 0) - (b.on ? 1 : 0) || SortByName(a, b))
+    default:
+      return copy.sort((a, b) => SortByName(a, b))
+  }
+}
+
 class main extends React.Component {
   constructor (props) {
     super(props)
 
     this.state = {
       selectedOutlet: undefined,
-      addEquipment: false
+      addEquipment: false,
+      sortMode: SORT_NAME_AZ
     }
 
     this.handleAddEquipment = this.handleAddEquipment.bind(this)
     this.handleToggleAddEquipmentDiv = this.handleToggleAddEquipmentDiv.bind(this)
+    this.handleSortChange = this.handleSortChange.bind(this)
   }
 
   componentDidMount () {
@@ -40,25 +61,49 @@ class main extends React.Component {
     })
   }
 
+  handleSortChange (ev) {
+    this.setState({ sortMode: ev.target.value })
+  }
+
   render () {
     let nEq = <div />
     if (this.state.addEquipment) {
       nEq = <EquipmentForm outlets={this.props.outlets} actionLabel={i18next.t('add')} onSubmit={this.handleAddEquipment} />
     }
+    const sorted = sortEquipment(this.props.equipment, this.state.sortMode)
     return (
       <ul className='list-group list-group-flush'>
-        {this.props.equipment.sort((a, b) => SortByName(a, b))
-          .map(item => {
-            return (
-              <Equipment
-                key={item.id}
-                equipment={item}
-                outlets={this.props.outlets}
-                update={this.props.update}
-                delete={this.props.delete}
-              />
-            )
-          })}
+        <li className='list-group-item'>
+          <div className='row align-items-center'>
+            <div className='col-auto'>
+              <label htmlFor='equipment-sort' className='col-form-label'>{i18next.t('equipment:sort')}</label>
+            </div>
+            <div className='col-auto'>
+              <select
+                id='equipment-sort'
+                className='form-control form-control-sm'
+                value={this.state.sortMode}
+                onChange={this.handleSortChange}
+              >
+                <option value={SORT_NAME_AZ}>{i18next.t('equipment:sort_name_az')}</option>
+                <option value={SORT_NAME_ZA}>{i18next.t('equipment:sort_name_za')}</option>
+                <option value={SORT_ON_FIRST}>{i18next.t('equipment:sort_on_first')}</option>
+                <option value={SORT_OFF_FIRST}>{i18next.t('equipment:sort_off_first')}</option>
+              </select>
+            </div>
+          </div>
+        </li>
+        {sorted.map(item => {
+          return (
+            <Equipment
+              key={item.id}
+              equipment={item}
+              outlets={this.props.outlets}
+              update={this.props.update}
+              delete={this.props.delete}
+            />
+          )
+        })}
         <li className='list-group-item add-equipment'>
           <div className='row'>
             <div className='col'>


### PR DESCRIPTION
## Summary

- Adds a sort dropdown at the top of the equipment list with four options:
  - **Name (A→Z)** — default, same as existing behavior
  - **Name (Z→A)** — reverse alphabetical
  - **On first** — powered-on equipment at top, then alphabetical within each group
  - **Off first** — powered-off equipment at top, then alphabetical within each group
- Sort preference is local to the component (no persistence needed — it resets naturally on navigation)
- All 10 translation files updated with English fallback strings

## Test plan

- [ ] Verify sort dropdown appears at the top of the equipment list
- [ ] Switch between each sort mode and confirm ordering is correct
- [ ] Verify sort persists while toggling equipment on/off (state updates re-sort the list)
- [ ] Frontend tests pass: `npm test -- --testPathPattern=equipment`

Fixes #1917

🤖 Generated with [Claude Code](https://claude.com/claude-code)