### PR TITLE
feat: add PWM step type to macros

### DIFF
--- a/controller/modules/macro/step.go
+++ b/controller/modules/macro/step.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/reef-pi/reef-pi/controller"
+	"github.com/reef-pi/reef-pi/controller/device_manager/connectors"
 	"github.com/reef-pi/reef-pi/controller/storage"
 )
 
@@ -21,6 +22,11 @@ type WaitStep struct {
 type AlertStep struct {
 	Title   string `json:"title"`
 	Message string `json:"message"`
+}
+
+type PWMStep struct {
+	ID    string  `json:"id"`
+	Value float64 `json:"value"`
 }
 
 type Step struct {
@@ -81,6 +87,21 @@ func (s *Step) Run(c controller.Controller, reverse bool) error {
 		log.Println("macro-subsystem: executing step: alert")
 		_, err := c.Telemetry().Mail(a.Title, a.Message)
 		return err
+	case "pwm":
+		var p PWMStep
+		if err := json.Unmarshal(s.Config, &p); err != nil {
+			return err
+		}
+		j, err := c.DM().Jacks().Get(p.ID)
+		if err != nil {
+			return err
+		}
+		values := connectors.PinValues{}
+		for _, pin := range j.Pins {
+			values[pin] = p.Value
+		}
+		log.Println("macro-subsystem: executing step: pwm jack:", j.Name, "value:", p.Value)
+		return c.DM().Jacks().Control(p.ID, values)
 	default:
 		return fmt.Errorf("Unknown step type:%s", s.Type)
 	}

--- a/front-end/assets/translations/de.csv
+++ b/front-end/assets/translations/de.csv
@@ -217,6 +217,7 @@ function:reminder,Email-Erinnerung
 function:subsystem,Funktionsgruppe
 function:temperature,Temperatur
 function:timers,Schaltuhr
+function:pwm,PWM
 function:wait,Pause
 health_chart:cpu_memory,CPU / Speicher
 health_chart:current,aktuell
@@ -272,6 +273,8 @@ macro:turn_off,Ausschalten
 macro:turn_on,Einschalten
 macro:wait:duration,Dauer
 macro:warn_delete,Wollen Sie das Makro {{name}} wirklich löschen?
+macro:pwm:jack,Jack
+macro:pwm:value,Value (%)
 ph:alert_above,obere Warnschwelle
 ph:alert_below,untere Warnschwelle
 ph:calibrate,Kalibrieren

--- a/front-end/assets/translations/en.csv
+++ b/front-end/assets/translations/en.csv
@@ -217,6 +217,7 @@ function:reminder,email reminder
 function:subsystem,subsystem
 function:temperature,temperature
 function:timers,timer
+function:pwm,PWM
 function:wait,wait
 health_chart:cpu_memory,CPU/Memory
 health_chart:current,current
@@ -272,6 +273,8 @@ macro:turn_off,Turn Off
 macro:turn_on,Turn On
 macro:wait:duration,Duration
 macro:warn_delete,This action will delete macro {{name}}
+macro:pwm:jack,Jack
+macro:pwm:value,Value (%)
 ph:alert_above,Alert Above
 ph:alert_below,Alert Below
 ph:calibrate,Calibrate

--- a/front-end/assets/translations/es.csv
+++ b/front-end/assets/translations/es.csv
@@ -217,6 +217,7 @@ function:reminder,
 function:subsystem,
 function:temperature,temperatura
 function:timers,cronómetro
+function:pwm,PWM
 function:wait,
 health_chart:cpu_memory,Procesador/Memoria
 health_chart:current,
@@ -272,6 +273,8 @@ macro:turn_off,Apagar
 macro:turn_on,Encender
 macro:wait:duration,
 macro:warn_delete,
+macro:pwm:jack,Jack
+macro:pwm:value,Value (%)
 ph:alert_above,Alerta Sobre
 ph:alert_below,Alerta Bajo
 ph:calibrate,Calibrar

--- a/front-end/assets/translations/fa.csv
+++ b/front-end/assets/translations/fa.csv
@@ -217,6 +217,7 @@ function:reminder,
 function:subsystem,
 function:temperature,
 function:timers,
+function:pwm,PWM
 function:wait,
 health_chart:cpu_memory,
 health_chart:current,
@@ -272,6 +273,8 @@ macro:turn_off,
 macro:turn_on,
 macro:wait:duration,
 macro:warn_delete,
+macro:pwm:jack,Jack
+macro:pwm:value,Value (%)
 ph:alert_above,
 ph:alert_below,
 ph:calibrate,

--- a/front-end/assets/translations/fr.csv
+++ b/front-end/assets/translations/fr.csv
@@ -217,6 +217,7 @@ function:reminder,
 function:subsystem,
 function:temperature,
 function:timers,
+function:pwm,PWM
 function:wait,
 health_chart:cpu_memory,
 health_chart:current,
@@ -272,6 +273,8 @@ macro:turn_off,
 macro:turn_on,
 macro:wait:duration,
 macro:warn_delete,
+macro:pwm:jack,Jack
+macro:pwm:value,Value (%)
 ph:alert_above,
 ph:alert_below,
 ph:calibrate,

--- a/front-end/assets/translations/hi.csv
+++ b/front-end/assets/translations/hi.csv
@@ -217,6 +217,7 @@ function:reminder,
 function:subsystem,
 function:temperature,
 function:timers,
+function:pwm,PWM
 function:wait,
 health_chart:cpu_memory,
 health_chart:current,
@@ -272,6 +273,8 @@ macro:turn_off,
 macro:turn_on,
 macro:wait:duration,
 macro:warn_delete,
+macro:pwm:jack,Jack
+macro:pwm:value,Value (%)
 ph:alert_above,
 ph:alert_below,
 ph:calibrate,

--- a/front-end/assets/translations/it.csv
+++ b/front-end/assets/translations/it.csv
@@ -217,6 +217,7 @@ function:reminder,
 function:subsystem,
 function:temperature,
 function:timers,
+function:pwm,PWM
 function:wait,
 health_chart:cpu_memory,
 health_chart:current,
@@ -272,6 +273,8 @@ macro:turn_off,
 macro:turn_on,
 macro:wait:duration,
 macro:warn_delete,
+macro:pwm:jack,Jack
+macro:pwm:value,Value (%)
 ph:alert_above,
 ph:alert_below,
 ph:calibrate,

--- a/front-end/assets/translations/nl.csv
+++ b/front-end/assets/translations/nl.csv
@@ -217,6 +217,7 @@ function:reminder,
 function:subsystem,
 function:temperature,
 function:timers,
+function:pwm,PWM
 function:wait,
 health_chart:cpu_memory,CPU/Geheugen
 health_chart:current,
@@ -272,6 +273,8 @@ macro:turn_off,Uitschakelen
 macro:turn_on,Inschakelen
 macro:wait:duration,
 macro:warn_delete,
+macro:pwm:jack,Jack
+macro:pwm:value,Value (%)
 ph:alert_above,Alarm boven
 ph:alert_below,Alarm onder
 ph:calibrate,Calibreren

--- a/front-end/assets/translations/pt.csv
+++ b/front-end/assets/translations/pt.csv
@@ -217,6 +217,7 @@ function:reminder,Lembretes
 function:subsystem,Subsistema
 function:temperature,Temperatura
 function:timers,Temporizadores
+function:pwm,PWM
 function:wait,Aguarda
 health_chart:cpu_memory,CPU/Memory
 health_chart:current,Atual
@@ -272,6 +273,8 @@ macro:turn_off,Desligar
 macro:turn_on,Ligar é Obrigatório
 macro:wait:duration,Duração
 macro:warn_delete,Apagar
+macro:pwm:jack,Jack
+macro:pwm:value,Value (%)
 ph:alert_above,Alerta superior de
 ph:alert_below,Alerta inferior de
 ph:calibrate,Calibrar

--- a/front-end/assets/translations/zh.csv
+++ b/front-end/assets/translations/zh.csv
@@ -217,6 +217,7 @@ function:reminder,
 function:subsystem,
 function:temperature,
 function:timers,
+function:pwm,PWM
 function:wait,
 health_chart:cpu_memory,CPU/内存
 health_chart:current,
@@ -272,6 +273,8 @@ macro:turn_off,关闭
 macro:turn_on,开启
 macro:wait:duration,
 macro:warn_delete,
+macro:pwm:jack,Jack
+macro:pwm:value,Value (%)
 ph:alert_above,告警上限
 ph:alert_below,告警下限
 ph:calibrate,校正

--- a/front-end/src/macro/pwm_step.jsx
+++ b/front-end/src/macro/pwm_step.jsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import PropTypes from 'prop-types'
+import { Field } from 'formik'
+import { ErrorFor, ShowError } from '../utils/validation_helper'
+import classNames from 'classnames'
+import i18n from 'utils/i18n'
+import { fetchJacks } from '../redux/actions/jacks'
+
+const PWMStep = ({ name, readOnly, touched, errors, jacks, fetch }) => {
+  React.useEffect(() => { fetch() }, [])
+
+  const jackOptions = () => {
+    return jacks.map((j) => (
+      <option key={j.id} value={j.id}>{j.name}</option>
+    ))
+  }
+
+  return (
+    <>
+      <div className='col-12 col-sm-4 col-md-3 form-group'>
+        <Field
+          name={`${name}.id`}
+          aria-label={i18n.t('macro:pwm:jack')}
+          title={i18n.t('macro:pwm:jack')}
+          component='select'
+          disabled={readOnly}
+          className={classNames('form-control custom-select', {
+            'is-invalid': ShowError(`${name}.id`, touched, errors)
+          })}
+        >
+          <option value='' className='d-none'>-- {i18n.t('select')} --</option>
+          {jackOptions()}
+        </Field>
+        <ErrorFor errors={errors} touched={touched} name={`${name}.id`} />
+      </div>
+      <div className='col-12 col-sm-4 col-md-3 form-group'>
+        <div className='input-group'>
+          <Field
+            name={`${name}.value`}
+            aria-label={i18n.t('macro:pwm:value')}
+            title={i18n.t('macro:pwm:value')}
+            type='number'
+            min='0'
+            max='100'
+            readOnly={readOnly}
+            placeholder={i18n.t('macro:pwm:value')}
+            className={classNames('form-control', {
+              'is-invalid': ShowError(`${name}.value`, touched, errors)
+            })}
+          />
+          <div className='input-group-append'>
+            <span className='input-group-text'>%</span>
+          </div>
+          <ErrorFor errors={errors} touched={touched} name={`${name}.value`} />
+        </div>
+      </div>
+    </>
+  )
+}
+
+PWMStep.propTypes = {
+  name: PropTypes.string,
+  touched: PropTypes.object,
+  errors: PropTypes.object,
+  readOnly: PropTypes.bool,
+  jacks: PropTypes.array,
+  fetch: PropTypes.func
+}
+
+const mapStateToProps = state => ({ jacks: state.jacks })
+const mapDispatchToProps = dispatch => ({ fetch: () => dispatch(fetchJacks()) })
+
+export default connect(mapStateToProps, mapDispatchToProps)(PWMStep)

--- a/front-end/src/macro/select_type.jsx
+++ b/front-end/src/macro/select_type.jsx
@@ -5,7 +5,7 @@ import i18n from 'utils/i18n'
 
 const SelectType = ({ name, className, readOnly }) => {
   const list = () => {
-    const validTypes = ['alert', 'wait', 'equipment', 'ato', 'temperature', 'lightings', 'doser', 'timers', 'phprobes', 'subsystem', 'macro']
+    const validTypes = ['alert', 'wait', 'equipment', 'ato', 'temperature', 'lightings', 'doser', 'timers', 'phprobes', 'subsystem', 'macro', 'pwm']
     // capabilities:..  are the subsytem names (plural or cathegory), correspinding to the tab pages, whereas
     // function:... are individual devices in these cathegories
     return validTypes.map((item) => {

--- a/front-end/src/macro/step_selector.jsx
+++ b/front-end/src/macro/step_selector.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import WaitStep from './wait_step'
 import AlertStep from './alert_step'
 import GenericStep from './generic_step'
+import PWMStep from './pwm_step'
 
 const StepSelector = ({
   type,
@@ -27,6 +28,15 @@ const StepSelector = ({
       case 'alert':
         return (
           <AlertStep
+            name={name}
+            errors={errors}
+            touched={touched}
+            readOnly={readOnly}
+          />
+        )
+      case 'pwm':
+        return (
+          <PWMStep
             name={name}
             errors={errors}
             touched={touched}


### PR DESCRIPTION
## Summary

- Adds a new `pwm` step type to the macro subsystem
- **Backend**: `PWMStep{ID, Value}` is resolved to a jack by ID; all pins of that jack are set to `Value` (0–100%) via `Jacks.Control()`
- **Frontend**: New `PWMStep` component with a jack selector and a percentage input (0–100); "PWM" appears in the step type dropdown

**Use cases from the issue:**
- Run a DC pump at minimum speed (e.g., 30%) during a feeding macro
- Set a cabinet fan to a specific speed based on a timer/condition

## Test plan

- [ ] Create a macro with a PWM step, select a jack, set a value, and run it — verify the PWM output changes
- [ ] Verify value clamping (0–100) is enforced both in the UI and at the jack level
- [ ] Go tests: `go test ./controller/modules/macro/...`
- [ ] Frontend tests: `npm test -- --testPathPattern=macro`

Fixes #1894

🤖 Generated with [Claude Code](https://claude.com/claude-code)