### PR TITLE
feat: show alerts as distinct entries in the error log

### DIFF
--- a/controller/telemetry/telemetry.go
+++ b/controller/telemetry/telemetry.go
@@ -170,7 +170,7 @@ func (t *telemetry) LogError(a, b string) error {
 
 func (t *telemetry) Alert(subject, body string) (bool, error) {
 	prefix := "[" + t.name + ":Alert]"
-	t.logError(prefix, subject)
+	t.logError("alert:"+subject, subject)
 	return t.Mail(prefix+subject, body)
 }
 

--- a/front-end/assets/translations/de.csv
+++ b/front-end/assets/translations/de.csv
@@ -123,6 +123,7 @@ configuration:about:status,Status
 configuration:about:uptime,Letzter Neustart
 configuration:about:version,Version
 configuration:about:website,Web Site
+configuration:errors:alert,Alert
 configuration:admin:db_export,DB Exportieren
 configuration:admin:db_import,DB Importieren
 configuration:admin:poweroff,Ausschalten

--- a/front-end/assets/translations/en.csv
+++ b/front-end/assets/translations/en.csv
@@ -123,6 +123,7 @@ configuration:about:status,Status
 configuration:about:uptime,Uptime
 configuration:about:version,Version
 configuration:about:website,Website
+configuration:errors:alert,Alert
 configuration:admin:db_export,Download current database
 configuration:admin:db_import,Import database
 configuration:admin:poweroff,Power Off

--- a/front-end/assets/translations/es.csv
+++ b/front-end/assets/translations/es.csv
@@ -123,6 +123,7 @@ configuration:about:status,Status
 configuration:about:uptime,Uptime
 configuration:about:version,Version
 configuration:about:website,Website
+configuration:errors:alert,Alert
 configuration:admin:db_export,Descargue Base de Datos
 configuration:admin:db_import,Importar una Base de Datos
 configuration:admin:poweroff,Apagar

--- a/front-end/assets/translations/fa.csv
+++ b/front-end/assets/translations/fa.csv
@@ -123,6 +123,7 @@ configuration:about:status,پیکربندی:در باره: وضعیت
 configuration:about:uptime,پیکربندی:در باره: زمان فعلی
 configuration:about:version,پیکربندی:در باره: نسخه
 configuration:about:website,پیکربندی:در باره: سایت اینترنتی
+configuration:errors:alert,Alert
 configuration:admin:db_export,
 configuration:admin:db_import,
 configuration:admin:poweroff,پیکربندی:مدیر: خاموش

--- a/front-end/assets/translations/fr.csv
+++ b/front-end/assets/translations/fr.csv
@@ -123,6 +123,7 @@ configuration:about:status,Statut
 configuration:about:uptime,Durée de fonctionnement
 configuration:about:version,Version
 configuration:about:website,Site Web
+configuration:errors:alert,Alert
 configuration:admin:db_export,
 configuration:admin:db_import,
 configuration:admin:poweroff,Arrêt

--- a/front-end/assets/translations/hi.csv
+++ b/front-end/assets/translations/hi.csv
@@ -123,6 +123,7 @@ configuration:about:status,
 configuration:about:uptime,
 configuration:about:version,
 configuration:about:website,
+configuration:errors:alert,Alert
 configuration:admin:db_export,
 configuration:admin:db_import,
 configuration:admin:poweroff,

--- a/front-end/assets/translations/it.csv
+++ b/front-end/assets/translations/it.csv
@@ -123,6 +123,7 @@ configuration:about:status,
 configuration:about:uptime,
 configuration:about:version,
 configuration:about:website,
+configuration:errors:alert,Alert
 configuration:admin:db_export,
 configuration:admin:db_import,
 configuration:admin:poweroff,

--- a/front-end/assets/translations/nl.csv
+++ b/front-end/assets/translations/nl.csv
@@ -123,6 +123,7 @@ configuration:about:status,Status
 configuration:about:uptime,Uptime
 configuration:about:version,Versie
 configuration:about:website,Website
+configuration:errors:alert,Alert
 configuration:admin:db_export,
 configuration:admin:db_import,
 configuration:admin:poweroff,Uitschakelen

--- a/front-end/assets/translations/pt.csv
+++ b/front-end/assets/translations/pt.csv
@@ -123,6 +123,7 @@ configuration:about:status,Estado
 configuration:about:uptime,Uptime
 configuration:about:version,Versão
 configuration:about:website,Site
+configuration:errors:alert,Alert
 configuration:admin:db_export,Exportar DB
 configuration:admin:db_import,Importar DB
 configuration:admin:poweroff,Desligar

--- a/front-end/assets/translations/zh.csv
+++ b/front-end/assets/translations/zh.csv
@@ -123,6 +123,7 @@ configuration:about:status,状态
 configuration:about:uptime,运行时间
 configuration:about:version,版本
 configuration:about:website,网站
+configuration:errors:alert,Alert
 configuration:admin:db_export,
 configuration:admin:db_import,
 configuration:admin:poweroff,关机

--- a/front-end/src/configuration/errors.jsx
+++ b/front-end/src/configuration/errors.jsx
@@ -20,10 +20,15 @@ class errors extends React.Component {
   render () {
     const items = []
     this.props.errors.forEach(el => {
+      const isAlert = el.id && el.id.startsWith('alert:')
       items.push(
-        <div className='row' key={'error-' + el.id}>
+        <div className='row align-items-center' key={'error-' + el.id}>
           <div className='col-lg-2'>{el.time}</div>
-          <div className='col-lg-8'>{el.message}</div>
+          <div className='col-lg-8'>
+            {isAlert && <span className='badge badge-warning mr-1'>{i18n.t('configuration:errors:alert')}</span>}
+            {el.message}
+            {el.count > 1 && <span className='badge badge-secondary ml-1'>{el.count}x</span>}
+          </div>
           <div className='col-lg-1'>
             <input
               className='btn btn-sm btn-outline-secondary'


### PR DESCRIPTION
## Summary

**Root cause:** All calls to `Alert()` used the same error ID `"[reef-pi:Alert]"` as the BoltDB key, causing every alert to overwrite the previous one. Users could only ever see the last alert.

**Fix:**
- `Alert()` now stores each distinct alert subject under its own key `"alert:<subject>"`, so multiple concurrent alerts each get their own entry with an independent repeat count
- The errors UI badges alert entries with an orange **Alert** pill and appends a grey count badge (e.g. `5x`) when the alert has fired more than once

**Before:** ATO disabled + pH high → only one entry, the last one to fire.

**After:** Both appear as separate rows, each with a count showing how many times they triggered.

## Test plan

- [ ] Trigger two different alert types (e.g. pH min/max threshold + temperature threshold)
- [ ] Verify both appear as separate rows in the Errors log with the orange "Alert" badge
- [ ] Trigger the same alert multiple times; verify the count badge increments
- [ ] Go tests: `go test ./controller/telemetry/...`
- [ ] Frontend tests: `npm test`

Fixes #2083

🤖 Generated with [Claude Code](https://claude.com/claude-code)