### PR TITLE
feat: periodic system health status reports via email

### DIFF
--- a/controller/settings/healthcheck.go
+++ b/controller/settings/healthcheck.go
@@ -1,7 +1,9 @@
 package settings
 
 type HealthCheckNotify struct {
-	Enable    bool    `json:"enable"`
-	MaxMemory float64 `json:"max_memory"`
-	MaxCPU    float64 `json:"max_cpu"`
+	Enable         bool    `json:"enable"`
+	MaxMemory      float64 `json:"max_memory"`
+	MaxCPU         float64 `json:"max_cpu"`
+	ReportEnable   bool    `json:"report_enable"`
+	ReportSchedule string  `json:"report_schedule"`
 }

--- a/controller/telemetry/health.go
+++ b/controller/telemetry/health.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	cron "github.com/robfig/cron/v3"
 	"github.com/shirou/gopsutil/load"
 	"github.com/shirou/gopsutil/v4/mem"
 
@@ -36,6 +37,8 @@ type hc struct {
 	store         storage.Store
 	statsMgr      StatsManager
 	isRaspberryPi bool
+	reporter      *cron.Cron
+	lastMetric    HealthMetric
 }
 
 type HealthMetric struct {
@@ -134,6 +137,7 @@ func (h *hc) Check() {
 	h.t.EmitMetric("system", "under-voltage", metric.UnderVoltage)
 	log.Println("health check: Used memory:", usedMemory, " Load5:", loadStat.Load5)
 	h.statsMgr.Update(HealthStatsKey, metric)
+	h.lastMetric = metric
 	h.NotifyIfNeeded(usedMemory, loadStat.Load5)
 }
 
@@ -154,8 +158,25 @@ func (h *hc) NotifyIfNeeded(memory, load float64) {
 	}
 }
 
+func (h *hc) sendReport() {
+	m := h.lastMetric
+	subject := fmt.Sprintf("[reef-pi] Status Report - %s", time.Now().Format("Jan 2 15:04"))
+	body := fmt.Sprintf(
+		"reef-pi Status Report\n\nCPU Load (5m avg): %.2f\nMemory used: %.2f%%\nUnder-voltage events: %.0f\nTime: %s",
+		m.Load5, m.UsedMemory, m.UnderVoltage, time.Now().Format(time.RFC1123),
+	)
+	if _, err := h.t.Mail(subject, body); err != nil {
+		log.Println("ERROR: health checker: failed to send status report:", err)
+	} else {
+		log.Println("health checker: status report sent")
+	}
+}
+
 func (h *hc) Stop() {
 	log.Println("Stopping health checker")
+	if h.reporter != nil {
+		h.reporter.Stop()
+	}
 	h.stopCh <- struct{}{}
 	if err := h.statsMgr.Save(HealthStatsKey); err != nil {
 		log.Println("ERROR: health checker. Failed to save usage. Error:", err)
@@ -177,6 +198,15 @@ func (h *hc) Start() {
 	}
 	if err := h.statsMgr.Load(HealthStatsKey, fn); err != nil {
 		log.Println("ERROR: health checker. Failed to load usage. Error:", err)
+	}
+	if h.Notify.ReportEnable && h.Notify.ReportSchedule != "" {
+		h.reporter = cron.New()
+		if _, err := h.reporter.AddFunc(h.Notify.ReportSchedule, h.sendReport); err != nil {
+			log.Println("ERROR: health checker: invalid report schedule:", h.Notify.ReportSchedule, err)
+		} else {
+			h.reporter.Start()
+			log.Println("Starting health report scheduler:", h.Notify.ReportSchedule)
+		}
 	}
 	log.Println("Starting health checker")
 	metric := HealthMetric{

--- a/front-end/assets/translations/de.csv
+++ b/front-end/assets/translations/de.csv
@@ -150,7 +150,7 @@ configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,Speicherbelegung MB größer
 configuration:settings:report_enable,Enable periodic status reports
 configuration:settings:report_schedule,Report schedule (cron)
-configuration:settings:report_schedule_help,Standard 5-field cron expression, e.g. "0 8 * * *" for daily at 8am
+configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:name,Netzwerkname
 configuration:settings:network_address_required,Eine Netzwerkadresse wird benötigt!
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)

--- a/front-end/assets/translations/de.csv
+++ b/front-end/assets/translations/de.csv
@@ -146,6 +146,9 @@ configuration:settings:display,Display
 configuration:settings:interface,Netzwerkinterface
 configuration:settings:max_cpu,CPU Nutzung % größer
 configuration:settings:max_memory,Speicherbelegung MB größer
+configuration:settings:report_enable,Enable periodic status reports
+configuration:settings:report_schedule,Report schedule (cron)
+configuration:settings:report_schedule_help,Standard 5-field cron expression, e.g. "0 8 * * *" for daily at 8am
 configuration:settings:name,Netzwerkname
 configuration:settings:network_address_required,Eine Netzwerkadresse wird benötigt!
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)

--- a/front-end/assets/translations/en.csv
+++ b/front-end/assets/translations/en.csv
@@ -146,6 +146,9 @@ configuration:settings:display,Display
 configuration:settings:interface,Interface
 configuration:settings:max_cpu,Max CPU
 configuration:settings:max_memory,Max memory
+configuration:settings:report_enable,Enable periodic status reports
+configuration:settings:report_schedule,Report schedule (cron)
+configuration:settings:report_schedule_help,Standard 5-field cron expression, e.g. "0 8 * * *" for daily at 8am
 configuration:settings:name,Name
 configuration:settings:network_address_required,Network address is required
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)

--- a/front-end/assets/translations/en.csv
+++ b/front-end/assets/translations/en.csv
@@ -150,7 +150,7 @@ configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,Max memory
 configuration:settings:report_enable,Enable periodic status reports
 configuration:settings:report_schedule,Report schedule (cron)
-configuration:settings:report_schedule_help,Standard 5-field cron expression, e.g. "0 8 * * *" for daily at 8am
+configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:name,Name
 configuration:settings:network_address_required,Network address is required
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)

--- a/front-end/assets/translations/es.csv
+++ b/front-end/assets/translations/es.csv
@@ -146,6 +146,9 @@ configuration:settings:display,Pantalla
 configuration:settings:interface,Interface
 configuration:settings:max_cpu,Procesador Maximo
 configuration:settings:max_memory,Memoria Maxima
+configuration:settings:report_enable,Enable periodic status reports
+configuration:settings:report_schedule,Report schedule (cron)
+configuration:settings:report_schedule_help,Standard 5-field cron expression, e.g. "0 8 * * *" for daily at 8am
 configuration:settings:name,Nombre
 configuration:settings:network_address_required,La direccion de red es requerida
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)

--- a/front-end/assets/translations/es.csv
+++ b/front-end/assets/translations/es.csv
@@ -150,7 +150,7 @@ configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,Memoria Maxima
 configuration:settings:report_enable,Enable periodic status reports
 configuration:settings:report_schedule,Report schedule (cron)
-configuration:settings:report_schedule_help,Standard 5-field cron expression, e.g. "0 8 * * *" for daily at 8am
+configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:name,Nombre
 configuration:settings:network_address_required,La direccion de red es requerida
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)

--- a/front-end/assets/translations/fa.csv
+++ b/front-end/assets/translations/fa.csv
@@ -150,7 +150,7 @@ configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,
 configuration:settings:report_enable,Enable periodic status reports
 configuration:settings:report_schedule,Report schedule (cron)
-configuration:settings:report_schedule_help,Standard 5-field cron expression, e.g. "0 8 * * *" for daily at 8am
+configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:name,
 configuration:settings:network_address_required,
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)

--- a/front-end/assets/translations/fa.csv
+++ b/front-end/assets/translations/fa.csv
@@ -146,6 +146,9 @@ configuration:settings:display,
 configuration:settings:interface,
 configuration:settings:max_cpu,
 configuration:settings:max_memory,
+configuration:settings:report_enable,Enable periodic status reports
+configuration:settings:report_schedule,Report schedule (cron)
+configuration:settings:report_schedule_help,Standard 5-field cron expression, e.g. "0 8 * * *" for daily at 8am
 configuration:settings:name,
 configuration:settings:network_address_required,
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)

--- a/front-end/assets/translations/fr.csv
+++ b/front-end/assets/translations/fr.csv
@@ -146,6 +146,9 @@ configuration:settings:display,Affichage
 configuration:settings:interface,Interface
 configuration:settings:max_cpu,CPU maximum
 configuration:settings:max_memory,Mémoire maximum
+configuration:settings:report_enable,Enable periodic status reports
+configuration:settings:report_schedule,Report schedule (cron)
+configuration:settings:report_schedule_help,Standard 5-field cron expression, e.g. "0 8 * * *" for daily at 8am
 configuration:settings:name,Nom
 configuration:settings:network_address_required,Adresse réseau requise
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)

--- a/front-end/assets/translations/fr.csv
+++ b/front-end/assets/translations/fr.csv
@@ -150,7 +150,7 @@ configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,Mémoire maximum
 configuration:settings:report_enable,Enable periodic status reports
 configuration:settings:report_schedule,Report schedule (cron)
-configuration:settings:report_schedule_help,Standard 5-field cron expression, e.g. "0 8 * * *" for daily at 8am
+configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:name,Nom
 configuration:settings:network_address_required,Adresse réseau requise
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)

--- a/front-end/assets/translations/hi.csv
+++ b/front-end/assets/translations/hi.csv
@@ -150,7 +150,7 @@ configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,
 configuration:settings:report_enable,Enable periodic status reports
 configuration:settings:report_schedule,Report schedule (cron)
-configuration:settings:report_schedule_help,Standard 5-field cron expression, e.g. "0 8 * * *" for daily at 8am
+configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:name,
 configuration:settings:network_address_required,
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)

--- a/front-end/assets/translations/hi.csv
+++ b/front-end/assets/translations/hi.csv
@@ -146,6 +146,9 @@ configuration:settings:display,
 configuration:settings:interface,
 configuration:settings:max_cpu,
 configuration:settings:max_memory,
+configuration:settings:report_enable,Enable periodic status reports
+configuration:settings:report_schedule,Report schedule (cron)
+configuration:settings:report_schedule_help,Standard 5-field cron expression, e.g. "0 8 * * *" for daily at 8am
 configuration:settings:name,
 configuration:settings:network_address_required,
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)

--- a/front-end/assets/translations/it.csv
+++ b/front-end/assets/translations/it.csv
@@ -150,7 +150,7 @@ configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,
 configuration:settings:report_enable,Enable periodic status reports
 configuration:settings:report_schedule,Report schedule (cron)
-configuration:settings:report_schedule_help,Standard 5-field cron expression, e.g. "0 8 * * *" for daily at 8am
+configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:name,
 configuration:settings:network_address_required,
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)

--- a/front-end/assets/translations/it.csv
+++ b/front-end/assets/translations/it.csv
@@ -146,6 +146,9 @@ configuration:settings:display,
 configuration:settings:interface,
 configuration:settings:max_cpu,
 configuration:settings:max_memory,
+configuration:settings:report_enable,Enable periodic status reports
+configuration:settings:report_schedule,Report schedule (cron)
+configuration:settings:report_schedule_help,Standard 5-field cron expression, e.g. "0 8 * * *" for daily at 8am
 configuration:settings:name,
 configuration:settings:network_address_required,
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)

--- a/front-end/assets/translations/nl.csv
+++ b/front-end/assets/translations/nl.csv
@@ -150,7 +150,7 @@ configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,Max Geheugen
 configuration:settings:report_enable,Enable periodic status reports
 configuration:settings:report_schedule,Report schedule (cron)
-configuration:settings:report_schedule_help,Standard 5-field cron expression, e.g. "0 8 * * *" for daily at 8am
+configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:name,Naam
 configuration:settings:network_address_required,Netwerkadres is nodig
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)

--- a/front-end/assets/translations/nl.csv
+++ b/front-end/assets/translations/nl.csv
@@ -146,6 +146,9 @@ configuration:settings:display,Display
 configuration:settings:interface,Interface
 configuration:settings:max_cpu,Max CPU
 configuration:settings:max_memory,Max Geheugen
+configuration:settings:report_enable,Enable periodic status reports
+configuration:settings:report_schedule,Report schedule (cron)
+configuration:settings:report_schedule_help,Standard 5-field cron expression, e.g. "0 8 * * *" for daily at 8am
 configuration:settings:name,Naam
 configuration:settings:network_address_required,Netwerkadres is nodig
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)

--- a/front-end/assets/translations/pt.csv
+++ b/front-end/assets/translations/pt.csv
@@ -150,7 +150,7 @@ configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,Maximo de Memoria
 configuration:settings:report_enable,Enable periodic status reports
 configuration:settings:report_schedule,Report schedule (cron)
-configuration:settings:report_schedule_help,Standard 5-field cron expression, e.g. "0 8 * * *" for daily at 8am
+configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:name,Nome
 configuration:settings:network_address_required,Endereço de rede é obrigatório
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)

--- a/front-end/assets/translations/pt.csv
+++ b/front-end/assets/translations/pt.csv
@@ -146,6 +146,9 @@ configuration:settings:display,Ecrã
 configuration:settings:interface,Interface
 configuration:settings:max_cpu,Maximo de CPU
 configuration:settings:max_memory,Maximo de Memoria
+configuration:settings:report_enable,Enable periodic status reports
+configuration:settings:report_schedule,Report schedule (cron)
+configuration:settings:report_schedule_help,Standard 5-field cron expression, e.g. "0 8 * * *" for daily at 8am
 configuration:settings:name,Nome
 configuration:settings:network_address_required,Endereço de rede é obrigatório
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)

--- a/front-end/assets/translations/zh.csv
+++ b/front-end/assets/translations/zh.csv
@@ -146,6 +146,9 @@ configuration:settings:display,显示
 configuration:settings:interface,接口
 configuration:settings:max_cpu,最大CPU
 configuration:settings:max_memory,最大内存
+configuration:settings:report_enable,Enable periodic status reports
+configuration:settings:report_schedule,Report schedule (cron)
+configuration:settings:report_schedule_help,Standard 5-field cron expression, e.g. "0 8 * * *" for daily at 8am
 configuration:settings:name,名字
 configuration:settings:network_address_required,必须填写网络地址
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)

--- a/front-end/assets/translations/zh.csv
+++ b/front-end/assets/translations/zh.csv
@@ -150,7 +150,7 @@ configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,最大内存
 configuration:settings:report_enable,Enable periodic status reports
 configuration:settings:report_schedule,Report schedule (cron)
-configuration:settings:report_schedule_help,Standard 5-field cron expression, e.g. "0 8 * * *" for daily at 8am
+configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:name,名字
 configuration:settings:network_address_required,必须填写网络地址
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)

--- a/front-end/src/configuration/health_notify.jsx
+++ b/front-end/src/configuration/health_notify.jsx
@@ -8,11 +8,14 @@ export default class HealthNotify extends React.Component {
       notify: {
         enable: props.state.enable,
         max_memory: props.state.max_memory,
-        max_cpu: props.state.max_cpu
+        max_cpu: props.state.max_cpu,
+        report_enable: props.state.report_enable,
+        report_schedule: props.state.report_schedule || ''
       }
     }
     this.update = this.update.bind(this)
     this.handleUpdateEnable = this.handleUpdateEnable.bind(this)
+    this.handleUpdateReportEnable = this.handleUpdateReportEnable.bind(this)
   }
 
   handleUpdateEnable (ev) {
@@ -22,10 +25,17 @@ export default class HealthNotify extends React.Component {
     this.props.update(h)
   }
 
+  handleUpdateReportEnable (ev) {
+    const h = this.state.notify
+    h.report_enable = ev.target.checked
+    this.setState({ notify: h })
+    this.props.update(h)
+  }
+
   update (key) {
     return function (ev) {
       const h = this.state.notify
-      h[key] = Number(ev.target.value)
+      h[key] = key === 'report_schedule' ? ev.target.value : Number(ev.target.value)
       this.setState({ notify: h })
       this.props.update(h)
     }.bind(this)
@@ -74,6 +84,38 @@ export default class HealthNotify extends React.Component {
         </div>
       )
     }
-    return ct
+    ct.push(
+      <div className='col-12' key='health_report_enable'>
+        <div className='form-check'>
+          <label className='form-check-label'>
+            <input
+              className='form-check-input'
+              type='checkbox'
+              id='health_report_enable'
+              defaultChecked={this.state.notify.report_enable}
+              onClick={this.handleUpdateReportEnable}
+            />
+            <b>{i18n.t('configuration:settings:report_enable')}</b>
+          </label>
+        </div>
+      </div>
+    )
+    if (this.state.notify.report_enable) {
+      ct.push(
+        <div className='form-group col-md-8 col-12' key='health_report_schedule'>
+          <label htmlFor='health_report_schedule'>{i18n.t('configuration:settings:report_schedule')}</label>
+          <input
+            type='text'
+            className='form-control'
+            id='health_report_schedule'
+            placeholder='0 8 * * *'
+            value={this.state.notify.report_schedule}
+            onChange={this.update('report_schedule')}
+          />
+          <small className='form-text text-muted'>{i18n.t('configuration:settings:report_schedule_help')}</small>
+        </div>
+      )
+    }
+    return <>{ct}</>
   }
 }


### PR DESCRIPTION
## Summary

- Adds `report_enable` and `report_schedule` fields to `HealthCheckNotify` settings
- When enabled, a `robfig/cron` job fires on the user-specified schedule and sends an email with the most recent health metrics (CPU load, memory %, under-voltage count)
- The schedule uses standard 5-field cron syntax — e.g. `0 8 * * *` for daily at 8am, `0 */6 * * *` for every 6 hours
- Settings form shows the report enable toggle and schedule input with a help text in the health check settings section
- The cron job starts alongside the health checker and stops cleanly when it stops

## Test plan

- [ ] Enable report with a short schedule (e.g. `* * * * *` = every minute) and verify an email is received
- [ ] Disable report and verify no further emails are sent after restart
- [ ] Invalid cron expression logs an error but does not crash the health checker
- [ ] Go tests: `go test ./controller/telemetry/...`
- [ ] Frontend tests: `npm test`

Fixes #1829

🤖 Generated with [Claude Code](https://claude.com/claude-code)