### PR TITLE
feat: add fail-safe mode to auto-disable heater on sensor failure

### DIFF
--- a/controller/modules/temperature/control.go
+++ b/controller/modules/temperature/control.go
@@ -20,6 +20,15 @@ func (c *Controller) Check(tc *TC) (float64, error) {
 		c.c.LogError("tc-"+tc.ID, "temperature sub-system. Failed to read  sensor "+tc.Name+". Error:"+err.Error())
 		subject := fmt.Sprintf("Temperature sensor '%s' failed", tc.Name)
 		c.c.Telemetry().Alert(subject, "Error:"+err.Error())
+		if tc.FailSafe && tc.Control && tc.Heater != "" {
+			if sub, sErr := c.c.Subsystem("equipment"); sErr == nil {
+				if oErr := sub.On(tc.Heater, false); oErr != nil {
+					log.Println("ERROR: temperature sub-system: failsafe: failed to turn off heater:", oErr)
+				} else {
+					log.Println("temperature sub-system: failsafe: turned off heater due to sensor read failure:", tc.Name)
+				}
+			}
+		}
 		return reading, err
 	}
 

--- a/controller/modules/temperature/tc.go
+++ b/controller/modules/temperature/tc.go
@@ -38,6 +38,7 @@ type TC struct {
 	Period       time.Duration `json:"period"`
 	Control      bool          `json:"control"`
 	Enable       bool          `json:"enable"`
+	FailSafe     bool          `json:"fail_safe"`
 	Notify       Notify        `json:"notify"`
 	Sensor       string        `json:"sensor"`
 	Fahrenheit   bool          `json:"fahrenheit"`

--- a/front-end/assets/translations/de.csv
+++ b/front-end/assets/translations/de.csv
@@ -335,6 +335,7 @@ temperature:controlequipment,Gerät schalten
 temperature:controlmacro,Makro ausführen
 temperature:controlnothing,-keine Steuerung-
 temperature:current_reading,Messwert
+temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:fahrenheit,Fahrenheit
 temperature:heater_cooler,Heizung/Kühler
 temperature:hysteresis,Hysterese

--- a/front-end/assets/translations/en.csv
+++ b/front-end/assets/translations/en.csv
@@ -335,6 +335,7 @@ temperature:controlequipment, Equipment
 temperature:controlmacro, Macro
 temperature:controlnothing, Nothing
 temperature:current_reading, Current Reading
+temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:fahrenheit,Fahrenheit
 temperature:heater_cooler,Heater/Cooler
 temperature:hysteresis,Hysteresis

--- a/front-end/assets/translations/es.csv
+++ b/front-end/assets/translations/es.csv
@@ -335,6 +335,7 @@ temperature:controlequipment,Equipo
 temperature:controlmacro,Macro
 temperature:controlnothing,Nada
 temperature:current_reading,Lectura Actual
+temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:fahrenheit,Fahrenheit
 temperature:heater_cooler,Calentador/Enfriador
 temperature:hysteresis,Histéresis

--- a/front-end/assets/translations/fa.csv
+++ b/front-end/assets/translations/fa.csv
@@ -335,6 +335,7 @@ temperature:controlequipment,
 temperature:controlmacro,
 temperature:controlnothing,
 temperature:current_reading,
+temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:fahrenheit,
 temperature:heater_cooler,
 temperature:hysteresis,

--- a/front-end/assets/translations/fr.csv
+++ b/front-end/assets/translations/fr.csv
@@ -335,6 +335,7 @@ temperature:controlequipment,
 temperature:controlmacro,
 temperature:controlnothing,
 temperature:current_reading,
+temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:fahrenheit,
 temperature:heater_cooler,
 temperature:hysteresis,

--- a/front-end/assets/translations/hi.csv
+++ b/front-end/assets/translations/hi.csv
@@ -335,6 +335,7 @@ temperature:controlequipment,
 temperature:controlmacro,
 temperature:controlnothing,
 temperature:current_reading,
+temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:fahrenheit,
 temperature:heater_cooler,
 temperature:hysteresis,

--- a/front-end/assets/translations/it.csv
+++ b/front-end/assets/translations/it.csv
@@ -335,6 +335,7 @@ temperature:controlequipment,
 temperature:controlmacro,
 temperature:controlnothing,
 temperature:current_reading,
+temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:fahrenheit,
 temperature:heater_cooler,
 temperature:hysteresis,

--- a/front-end/assets/translations/nl.csv
+++ b/front-end/assets/translations/nl.csv
@@ -335,6 +335,7 @@ temperature:controlequipment,Apparatuur
 temperature:controlmacro,Macro
 temperature:controlnothing,Niets
 temperature:current_reading,Huidige uitlezing
+temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:fahrenheit,Fahrenheit
 temperature:heater_cooler,Verwarming/Koeling
 temperature:hysteresis,Hysteresis

--- a/front-end/assets/translations/pt.csv
+++ b/front-end/assets/translations/pt.csv
@@ -335,6 +335,7 @@ temperature:controlequipment,controlar equipamento
 temperature:controlmacro,controlar macro
 temperature:controlnothing,não controlar
 temperature:current_reading,Leitura atual
+temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:fahrenheit,Fahrenheit
 temperature:heater_cooler,Aquecedor/refrigeração
 temperature:hysteresis,hysteresis

--- a/front-end/assets/translations/zh.csv
+++ b/front-end/assets/translations/zh.csv
@@ -335,6 +335,7 @@ temperature:controlequipment,设备
 temperature:controlmacro,宏
 temperature:controlnothing,
 temperature:current_reading,当前读数
+temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:fahrenheit,华氏的
 temperature:heater_cooler,加热器/冷水机
 temperature:hysteresis,

--- a/front-end/src/temperature/edit_temperature.jsx
+++ b/front-end/src/temperature/edit_temperature.jsx
@@ -215,6 +215,24 @@ const EditTemperature = ({
               <ErrorFor errors={errors} touched={touched} name='one_shot' />
             </div>
           </div>
+
+          <div className='col-12 col-sm-6 col-md-3'>
+            <div className='form-group'>
+              <label htmlFor='fail_safe'>{i18next.t('temperature:fail_safe')}</label>
+              <Field
+                name='fail_safe'
+                component={BooleanSelect}
+                disabled={readOnly}
+                className={classNames('custom-select', {
+                  'is-invalid': ShowError('fail_safe', touched, errors)
+                })}
+              >
+                <option value='true'>{i18next.t('enabled')}</option>
+                <option value='false'>{i18next.t('disabled')}</option>
+              </Field>
+              <ErrorFor errors={errors} touched={touched} name='fail_safe' />
+            </div>
+          </div>
         </div>
 
         <div className='row'>

--- a/front-end/src/temperature/main.jsx
+++ b/front-end/src/temperature/main.jsx
@@ -52,6 +52,7 @@ class main extends React.Component {
       control: (values.control === 'macro' || values.control === 'equipment'),
       is_macro: (values.control === 'macro'),
       one_shot: values.one_shot,
+      fail_safe: values.fail_safe,
       heater: values.heater,
       cooler: values.cooler,
       min: parseFloat(values.min),

--- a/front-end/src/temperature/temperature_form.jsx
+++ b/front-end/src/temperature/temperature_form.jsx
@@ -26,6 +26,7 @@ const TemperatureForm = withFormik({
       alerts: (tc.notify && tc.notify.enable) || false,
       minAlert: (tc.notify && tc.notify.min) || '77',
       maxAlert: (tc.notify && tc.notify.max) || '81',
+      fail_safe: tc.fail_safe || false,
       heater: tc.heater || '',
       min: tc.min || '',
       hysteresis: tc.hysteresis || 0,


### PR DESCRIPTION
## Summary

- Adds a `fail_safe` boolean field to `TC` (temperature controller)
- When `fail_safe` is enabled and the sensor returns a read error, `Check()` immediately calls `equipment.On(heater, false)` to turn off the heater
- Logs a clear message: `"temperature sub-system: failsafe: turned off heater due to sensor read failure"`
- Frontend adds a "Fail safe" dropdown in the temperature form (alongside One Shot)
- All 10 language files updated with English fallback string

**Scenario this prevents:** DS18B20 probe fails → returns error → heater stays ON indefinitely → tank overheats/crashes. With fail-safe enabled: probe fails → heater turns off immediately → alert fired → user investigates.

## Test plan

- [ ] Enable fail-safe on a temperature controller with a heater configured
- [ ] Simulate sensor failure (unplug probe, or use a devmode override)
- [ ] Verify heater is turned OFF and a log message appears
- [ ] Disable fail-safe — verify heater state is left unchanged on sensor error (existing behavior)
- [ ] Go tests: `go test ./controller/modules/temperature/...`
- [ ] Frontend tests: `npm test`

Fixes #1576

🤖 Generated with [Claude Code](https://claude.com/claude-code)