### PR TITLE
feat: allow updating jack for existing lights

### DIFF
--- a/front-end/assets/translations/de.csv
+++ b/front-end/assets/translations/de.csv
@@ -383,3 +383,4 @@ validation:name_required,Ein Name ist erforderlich!
 validation:number_required,Das muss eine Zahl sein!
 validation:selection_required,Eine Auswahl ist erforderlich!
 validation:time_required,Eine Zeit im Format HH:mm:ss ist erforderlich!
+lighting:jack,Jack

--- a/front-end/assets/translations/en.csv
+++ b/front-end/assets/translations/en.csv
@@ -383,3 +383,4 @@ validation:name_required,Name is required
 validation:number_required,A number is required
 validation:selection_required,Select one entry
 validation:time_required,Enter a time as HH:mm:ss
+lighting:jack,Jack

--- a/front-end/assets/translations/es.csv
+++ b/front-end/assets/translations/es.csv
@@ -383,3 +383,4 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
+lighting:jack,Jack

--- a/front-end/assets/translations/fa.csv
+++ b/front-end/assets/translations/fa.csv
@@ -383,3 +383,4 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
+lighting:jack,Jack

--- a/front-end/assets/translations/fr.csv
+++ b/front-end/assets/translations/fr.csv
@@ -383,3 +383,4 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
+lighting:jack,Jack

--- a/front-end/assets/translations/hi.csv
+++ b/front-end/assets/translations/hi.csv
@@ -383,3 +383,4 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
+lighting:jack,Jack

--- a/front-end/assets/translations/it.csv
+++ b/front-end/assets/translations/it.csv
@@ -383,3 +383,4 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
+lighting:jack,Jack

--- a/front-end/assets/translations/nl.csv
+++ b/front-end/assets/translations/nl.csv
@@ -383,3 +383,4 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
+lighting:jack,Jack

--- a/front-end/assets/translations/pt.csv
+++ b/front-end/assets/translations/pt.csv
@@ -383,3 +383,4 @@ validation:name_required,nome é obrigatório
 validation:number_required,numero é obrigatória
 validation:selection_required,Selecção é obrigatória
 validation:time_required,Tempo é obrigatória
+lighting:jack,Jack

--- a/front-end/assets/translations/zh.csv
+++ b/front-end/assets/translations/zh.csv
@@ -383,3 +383,4 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
+lighting:jack,Jack

--- a/front-end/src/lighting/light.jsx
+++ b/front-end/src/lighting/light.jsx
@@ -18,6 +18,7 @@ const EditLight = ({
   handleChange,
   dirty,
   readOnly,
+  jacks,
   ...props
 }) => {
   const handleFormSubmit = event => {
@@ -82,6 +83,27 @@ const EditLight = ({
         </div>
       </div>
 
+      <div className={classNames('row', { 'd-none': readOnly })}>
+        <div className='col col-sm-6 col-md-3'>
+          <div className='form-group'>
+            <label htmlFor='config.jack'>{i18next.t('lighting:jack')}</label>
+            <Field
+              name='config.jack'
+              component='select'
+              disabled={readOnly}
+              className={classNames('custom-select', {
+                'is-invalid': ShowError('config.jack', touched, errors)
+              })}
+            >
+              {(jacks || []).map(j => (
+                <option key={j.id} value={String(j.id)}>{j.name}</option>
+              ))}
+            </Field>
+            <ErrorFor errors={errors} touched={touched} name='config.jack' />
+          </div>
+        </div>
+      </div>
+
       {channels()}
       <div className={classNames('row', { 'd-none': readOnly })}>
         <div className='col-12'>
@@ -108,7 +130,8 @@ EditLight.propTypes = {
   dirty: PropTypes.bool,
   readOnly: PropTypes.bool,
   touched: PropTypes.object,
-  errors: PropTypes.object
+  errors: PropTypes.object,
+  jacks: PropTypes.array
 }
 
 export default EditLight

--- a/front-end/src/lighting/main.jsx
+++ b/front-end/src/lighting/main.jsx
@@ -145,6 +145,7 @@ class main extends React.Component {
           let panelContent = (
             <Light
               config={light}
+              jacks={this.props.jacks}
               onSubmit={this.handleUpdateLight}
               remove={this.props.deleteLight}
             />


### PR DESCRIPTION
Fixes #1394

## Summary
- Added a jack selector dropdown to the light edit form in `light.jsx`
- Pass `jacks` prop from `main.jsx` through `LightForm` to `EditLight`
- The backend `validate()` already handles jack changes (remaps channels to new jack's pins); this wires up the missing frontend UI
- Added `lighting:jack` translation key to all 10 locale CSV files

## Test plan
- [ ] Open an existing light's edit form — a "Jack" dropdown should now appear showing available jacks
- [ ] Select a different jack and save — the light should remapped to the new jack's pins
- [ ] All existing lighting tests pass (`npm test -- --testPathPattern=lighting`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)