### PR TITLE
feat: add ATO debounce delay

### DIFF
--- a/controller/modules/ato/ato.go
+++ b/controller/modules/ato/ato.go
@@ -21,6 +21,7 @@ type ATO struct {
 	Inlet          string        `json:"inlet"`
 	Pump           string        `json:"pump"`
 	Period         time.Duration `json:"period"`
+	Debounce       time.Duration `json:"debounce"`
 	Control        bool          `json:"control"`
 	Enable         bool          `json:"enable"`
 	Notify         Notify        `json:"notify"`
@@ -173,8 +174,27 @@ func (c *Controller) Check(a ATO) (int, error) {
 	c.c.Telemetry().EmitMetric("ato", a.Name+"-state", float64(reading))
 	log.Println("ato-subsystem: sensor:", a.Name, "state:", reading)
 	if a.Control {
-		if err := c.Control(a, reading); err != nil {
-			log.Println("ERROR: Failed to execute ato control logic. Error:", err)
+		shouldControl := true
+		if a.Debounce > 0 && reading == 0 {
+			c.mu.Lock()
+			ls, ok := c.lowSince[a.ID]
+			if !ok || ls == nil {
+				now := time.Now()
+				c.lowSince[a.ID] = &now
+				shouldControl = false
+			} else if time.Since(*ls) < a.Debounce*time.Second {
+				shouldControl = false
+			}
+			c.mu.Unlock()
+		} else if reading == 1 {
+			c.mu.Lock()
+			c.lowSince[a.ID] = nil
+			c.mu.Unlock()
+		}
+		if shouldControl {
+			if err := c.Control(a, reading); err != nil {
+				log.Println("ERROR: Failed to execute ato control logic. Error:", err)
+			}
 		}
 		usage.Pump = int(a.Period)
 		if reading == 1 {

--- a/controller/modules/ato/controlller.go
+++ b/controller/modules/ato/controlller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"sync"
+	"time"
 
 	"github.com/reef-pi/reef-pi/controller"
 	"github.com/reef-pi/reef-pi/controller/device_manager/connectors"
@@ -16,13 +17,14 @@ const Bucket = storage.ATOBucket
 const UsageBucket = storage.ATOUsageBucket
 
 type Controller struct {
-	statsMgr telemetry.StatsManager
-	devMode  bool
-	quitters map[string]chan struct{}
-	wg       sync.WaitGroup
-	mu       *sync.Mutex
-	inlets   *connectors.Inlets
-	c        controller.Controller
+	statsMgr   telemetry.StatsManager
+	devMode    bool
+	quitters   map[string]chan struct{}
+	wg         sync.WaitGroup
+	mu         *sync.Mutex
+	inlets     *connectors.Inlets
+	c          controller.Controller
+	lowSince   map[string]*time.Time
 }
 
 func New(devMode bool, c controller.Controller) (*Controller, error) {
@@ -33,6 +35,7 @@ func New(devMode bool, c controller.Controller) (*Controller, error) {
 		quitters: make(map[string]chan struct{}),
 		statsMgr: c.Telemetry().NewStatsManager(UsageBucket),
 		c:        c,
+		lowSince: make(map[string]*time.Time),
 	}
 	return con, nil
 }

--- a/front-end/assets/translations/de.csv
+++ b/front-end/assets/translations/de.csv
@@ -394,3 +394,4 @@ validation:name_required,Ein Name ist erforderlich!
 validation:number_required,Das muss eine Zahl sein!
 validation:selection_required,Eine Auswahl ist erforderlich!
 validation:time_required,Eine Zeit im Format HH:mm:ss ist erforderlich!
+ato:debounce,Debounce

--- a/front-end/assets/translations/en.csv
+++ b/front-end/assets/translations/en.csv
@@ -394,3 +394,4 @@ validation:name_required,Name is required
 validation:number_required,A number is required
 validation:selection_required,Select one entry
 validation:time_required,Enter a time as HH:mm:ss
+ato:debounce,Debounce

--- a/front-end/assets/translations/es.csv
+++ b/front-end/assets/translations/es.csv
@@ -394,3 +394,4 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
+ato:debounce,Debounce

--- a/front-end/assets/translations/fa.csv
+++ b/front-end/assets/translations/fa.csv
@@ -394,3 +394,4 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
+ato:debounce,Debounce

--- a/front-end/assets/translations/fr.csv
+++ b/front-end/assets/translations/fr.csv
@@ -394,3 +394,4 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
+ato:debounce,Debounce

--- a/front-end/assets/translations/hi.csv
+++ b/front-end/assets/translations/hi.csv
@@ -394,3 +394,4 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
+ato:debounce,Debounce

--- a/front-end/assets/translations/it.csv
+++ b/front-end/assets/translations/it.csv
@@ -394,3 +394,4 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
+ato:debounce,Debounce

--- a/front-end/assets/translations/nl.csv
+++ b/front-end/assets/translations/nl.csv
@@ -394,3 +394,4 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
+ato:debounce,Debounce

--- a/front-end/assets/translations/pt.csv
+++ b/front-end/assets/translations/pt.csv
@@ -394,3 +394,4 @@ validation:name_required,nome é obrigatório
 validation:number_required,numero é obrigatória
 validation:selection_required,Selecção é obrigatória
 validation:time_required,Tempo é obrigatória
+ato:debounce,Debounce

--- a/front-end/assets/translations/zh.csv
+++ b/front-end/assets/translations/zh.csv
@@ -394,3 +394,4 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
+ato:debounce,Debounce

--- a/front-end/src/ato/ato_form.jsx
+++ b/front-end/src/ato/ato_form.jsx
@@ -22,6 +22,7 @@ const AtoForm = withFormik({
       one_shot: data.one_shot || false,
       disable_on_alert: data.disable_on_alert || false,
       period: data.period || 60,
+      debounce: data.debounce || 0,
       pump: data.pump || '',
       notify: (data.notify && data.notify.enable) || false,
       maxAlert: (data.notify && data.notify.max) || 120

--- a/front-end/src/ato/edit_ato.jsx
+++ b/front-end/src/ato/edit_ato.jsx
@@ -133,6 +133,30 @@ const EditAto = ({
 
         <div className='col-12 col-sm-6 col-md-3'>
           <div className='form-group'>
+            <label htmlFor='debounce'>{i18next.t('ato:debounce')}</label>
+            <div className='input-group'>
+              <Field
+                name='debounce'
+                readOnly={readOnly}
+                type='number'
+                min='0'
+                className={classNames('form-control', {
+                  'is-invalid': ShowError('debounce', touched, errors)
+                })}
+              />
+              <div className='input-group-append'>
+                <span className='input-group-text d-none d-lg-flex'>
+                  {i18next.t('second_s')}
+                </span>
+                <span className='input-group-text d-flex d-lg-none'>sec</span>
+              </div>
+              <ErrorFor errors={errors} touched={touched} name='debounce' />
+            </div>
+          </div>
+        </div>
+
+        <div className='col-12 col-sm-6 col-md-3'>
+          <div className='form-group'>
             <label htmlFor='enable'>{i18next.t('status')}</label>
             <Field
               name='enable'

--- a/front-end/src/ato/main.jsx
+++ b/front-end/src/ato/main.jsx
@@ -35,6 +35,7 @@ class main extends React.Component {
       enable: values.enable,
       inlet: values.inlet,
       period: parseInt(values.period),
+      debounce: parseInt(values.debounce) || 0,
       control: (values.control === 'macro' || values.control === 'equipment'),
       pump: values.pump,
       disable_on_alert: values.disable_on_alert,


### PR DESCRIPTION
Fixes #1351

## Summary
- Added `Debounce time.Duration` field to the `ATO` struct (stored as seconds, defaults to 0 = disabled)
- Backend tracks per-ATO `lowSince` timestamp in the Controller; pump only activates after the sensor has been continuously low for at least `Debounce` seconds
- Added "Debounce" number input field to the ATO edit form
- Fully backwards compatible: `debounce: 0` is the default and behaves exactly as before

## Test plan
- [ ] Create/edit an ATO — a "Debounce" field (in seconds) should appear in the form
- [ ] Set debounce to 10 seconds; verify the pump does not activate immediately when sensor reads low — it waits 10s
- [ ] Set debounce to 0; verify original immediate behavior is preserved
- [ ] All ATO Go tests pass: `go test ./controller/modules/ato/...`
- [ ] All ATO JS tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)