### PR TITLE
fix: ATOs set to Nothing operate correctly with one_shot

### DIFF
--- a/controller/modules/ato/ato.go
+++ b/controller/modules/ato/ato.go
@@ -214,14 +214,19 @@ func (c *Controller) Run(a ATO, quit chan struct{}) error {
 				if err != nil {
 					return err
 				}
-				if reading == 1 {
+				// With pump control: disable once tank is full (reading==1)
+				// Without pump control (Nothing): disable once low level detected (reading==0)
+				if (a.Control && reading == 1) || (!a.Control && reading == 0) {
 					a.Enable = false
 					return c.Update(a.ID, a)
 				}
 			}
 		case <-quit:
-			// always turn off pump befor quitting
-			return c.Control(a, 1)
+			// turn off pump on quit only when a pump is configured
+			if a.Control && a.Pump != "" {
+				return c.Control(a, 1)
+			}
+			return nil
 		}
 	}
 }


### PR DESCRIPTION
Fixes #2119

## Summary
- When an ATO has control set to "Nothing" (no pump), `one_shot` mode now disables the ATO after detecting a **LOW** reading (sensor triggered), rather than a HIGH reading
- This matches user expectation: in monitoring-only mode, "alert once when low, then stop"
- With pump control, `one_shot` continues to disable when the tank reads **HIGH** (full) — unchanged behavior
- On goroutine quit, `Control(a, 1)` is only called when a pump is actually configured, eliminating spurious "pump not set, skipping" log warnings

## Test plan
- [ ] Create an ATO with control=Nothing and one_shot=true; when sensor reads low, ATO should send alert and disable itself
- [ ] Create an ATO with control=equipment+pump and one_shot=true; pump runs until full (reading=1), then ATO disables — unchanged behavior
- [ ] All ATO tests pass: `go test ./controller/modules/ato/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)