### PR TITLE
feat: auto-provision connectors when a driver is added

### DIFF
--- a/controller/device_manager/device_manager.go
+++ b/controller/device_manager/device_manager.go
@@ -1,10 +1,12 @@
 package device_manager
 
 import (
+	"fmt"
 	"log"
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/reef-pi/hal"
 	"github.com/reef-pi/rpi/i2c"
 
 	"github.com/shirou/gopsutil/v4/host"
@@ -14,6 +16,8 @@ import (
 	"github.com/reef-pi/reef-pi/controller/settings"
 	"github.com/reef-pi/reef-pi/controller/storage"
 	"github.com/reef-pi/reef-pi/controller/telemetry"
+	"github.com/reef-pi/reef-pi/controller/utils"
+	"net/http"
 )
 
 type DeviceManager struct {
@@ -53,7 +57,7 @@ func New(s settings.Settings, store storage.Store, t telemetry.Telemetry) *Devic
 	}
 	log.Println("device-manager subsystem initialized with", drvrs.Size(), "drivers")
 
-	return &DeviceManager{
+	dm := &DeviceManager{
 		bus:       bus,
 		drivers:   drvrs,
 		jacks:     connectors.NewJacks(drvrs, store),
@@ -62,6 +66,12 @@ func New(s settings.Settings, store storage.Store, t telemetry.Telemetry) *Devic
 		ais:       connectors.NewAnalogInputs(drvrs, store),
 		telemetry: t,
 	}
+	drvrs.OnCreate = func(id string) {
+		if err := dm.Provision(id); err != nil {
+			log.Println("device-manager: auto-provision failed for driver", id, ":", err)
+		}
+	}
+	return dm
 }
 
 func (dm *DeviceManager) Setup() error {
@@ -98,12 +108,84 @@ func (dm *DeviceManager) Drivers() *drivers.Drivers {
 	return dm.drivers
 }
 
+// Provision auto-creates connectors for all pins exposed by the driver with the given ID.
+// Outlets are created for DigitalOutput pins, Inlets for DigitalInput pins,
+// Jacks for PWM pins, and AnalogInputs for AnalogInput pins.
+// Errors for individual connectors are logged but do not abort provisioning.
+func (dm *DeviceManager) Provision(driverID string) error {
+	dr, err := dm.drivers.Get(driverID)
+	if err != nil {
+		return fmt.Errorf("provision: driver %s not found: %w", driverID, err)
+	}
+	driverName := dr.Name
+
+	for capStr, pins := range dr.PinMap {
+		switch capStr {
+		case hal.DigitalOutput.String():
+			for _, pin := range pins {
+				o := connectors.Outlet{
+					Name:   fmt.Sprintf("%s-%d", driverName, pin),
+					Driver: driverID,
+					Pin:    pin,
+				}
+				if err := dm.outlets.Create(o); err != nil {
+					log.Printf("device-manager: provision outlet pin %d for driver %s: %v", pin, driverName, err)
+				}
+			}
+		case hal.DigitalInput.String():
+			for _, pin := range pins {
+				i := connectors.Inlet{
+					Name:   fmt.Sprintf("%s-%d", driverName, pin),
+					Driver: driverID,
+					Pin:    pin,
+				}
+				if err := dm.inlets.Create(i); err != nil {
+					log.Printf("device-manager: provision inlet pin %d for driver %s: %v", pin, driverName, err)
+				}
+			}
+		case hal.PWM.String():
+			for _, pin := range pins {
+				j := connectors.Jack{
+					Name:   fmt.Sprintf("%s-%d", driverName, pin),
+					Driver: driverID,
+					Pins:   []int{pin},
+				}
+				if err := dm.jacks.Create(j); err != nil {
+					log.Printf("device-manager: provision jack pin %d for driver %s: %v", pin, driverName, err)
+				}
+			}
+		case hal.AnalogInput.String():
+			for _, pin := range pins {
+				ai := connectors.AnalogInput{
+					Name:   fmt.Sprintf("%s-%d", driverName, pin),
+					Driver: driverID,
+					Pin:    pin,
+				}
+				if err := dm.ais.Create(ai); err != nil {
+					log.Printf("device-manager: provision analog input pin %d for driver %s: %v", pin, driverName, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
 func (dm *DeviceManager) LoadAPI(r *mux.Router) {
 	dm.outlets.LoadAPI(r)
 	dm.inlets.LoadAPI(r)
 	dm.jacks.LoadAPI(r)
 	dm.ais.LoadAPI(r)
 	dm.drivers.LoadAPI(r)
+	r.HandleFunc("/api/drivers/{id}/provision", dm.provisionHandler).Methods("POST")
+}
+
+func (dm *DeviceManager) provisionHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id := vars["id"]
+	if err := dm.Provision(id); err != nil {
+		utils.ErrorResponse(http.StatusInternalServerError, "Failed to provision. Error: "+err.Error(), w)
+		return
+	}
 }
 
 func (dm *DeviceManager) Close() error {

--- a/controller/device_manager/drivers/drivers.go
+++ b/controller/device_manager/drivers/drivers.go
@@ -24,6 +24,7 @@ type Drivers struct {
 	bus           i2c.Bus
 	t             telemetry.Telemetry
 	isRaspberryPi bool
+	OnCreate      func(id string)
 }
 
 func NewDrivers(s settings.Settings, bus i2c.Bus, store storage.Store, t telemetry.Telemetry) (*Drivers, error) {
@@ -156,6 +157,9 @@ func (d *Drivers) Create(d1 Driver) error {
 		// Registration has failed, we need to de-allocate the DB entry
 		_ = d.store.Delete(DriverBucket, d1.ID)
 		return err
+	}
+	if d.OnCreate != nil {
+		d.OnCreate(d1.ID)
 	}
 	return nil
 }

--- a/front-end/assets/translations/de.csv
+++ b/front-end/assets/translations/de.csv
@@ -80,6 +80,7 @@ ato:control_target,Steuerung durch
 ato:controlequipment,Gerät schalten
 ato:controlmacro,Makro ausführen
 ato:controlnothing,-keine Steuerung-
+ato:debounce,Debounce
 ato:disable_on_alert,ATO nach Alarm ausschalten
 ato:reset_usage,Verlauf löschen
 ato:title_delete,{{name}} löschen?
@@ -123,7 +124,6 @@ configuration:about:status,Status
 configuration:about:uptime,Letzter Neustart
 configuration:about:version,Version
 configuration:about:website,Web Site
-configuration:errors:alert,Alert
 configuration:admin:db_export,DB Exportieren
 configuration:admin:db_import,DB Importieren
 configuration:admin:poweroff,Ausschalten
@@ -135,9 +135,12 @@ configuration:authentication:error_pass,falsches Passwort
 configuration:authentication:error_user,falscher Benutzername
 configuration:connectors:title_delete,{{name}} löschen?
 configuration:connectors:warn_delete,Wollen Sie den Anschluss {{name}} wirklich löschen?
+configuration:drivers:provision,
+configuration:drivers:provision_title,
 configuration:drivers:title_delete,{{name}} entfernen?
 configuration:drivers:type,Typ
 configuration:drivers:warn_delete,Wollen Sie den Treiber für {{name}} wirklich entfernen?
+configuration:errors:alert,Alert
 configuration:settings:address,Protokoll / IP-Adresse und Port
 configuration:settings:alert_health_check,Überlastwarnung
 configuration:settings:brightness,Brightness
@@ -148,16 +151,16 @@ configuration:settings:interface,Netzwerkinterface
 configuration:settings:max_cpu,CPU Nutzung % größer
 configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,Speicherbelegung MB größer
-configuration:settings:report_enable,Enable periodic status reports
-configuration:settings:report_schedule,Report schedule (cron)
-configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:name,Netzwerkname
-configuration:settings:network_address_required,Eine Netzwerkadresse wird benötigt!
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)
+configuration:settings:network_address_required,Eine Netzwerkadresse wird benötigt!
 configuration:settings:network_interface_required,Eine Netzwerk-Schnittstelle wird benötigt!
 configuration:settings:notification,Email-Benachrichtigung
 configuration:settings:pprof,Profiling
 configuration:settings:prometheus,Prometheus
+configuration:settings:report_enable,Enable periodic status reports
+configuration:settings:report_schedule,Report schedule (cron)
+configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:rpi_pwm_freq,PWM Fequenz (RPi)
 configuration:settings:use_https,Verwende HTTPS
 configuration:tab:about,Über ...
@@ -207,8 +210,8 @@ equipment:chart:ctrlpanel,Geräte (Schalter)
 equipment:sort,Sort
 equipment:sort_name_az,Name (A→Z)
 equipment:sort_name_za,Name (Z→A)
-equipment:sort_on_first,On first
 equipment:sort_off_first,Off first
+equipment:sort_on_first,On first
 equipment:title_delete,{{name}} löschen?
 equipment:warn_delete,Wollen Sie das Gerät {{name}} wirklich löschen?
 fatal_error:connection_lost,Verbindung verloren
@@ -223,11 +226,11 @@ function:equipment,Gerät
 function:lightings,Lampe
 function:macro,Makro
 function:phprobes,pH Sonde
+function:pwm,PWM
 function:reminder,Email-Erinnerung
 function:subsystem,Funktionsgruppe
 function:temperature,Temperatur
 function:timers,Schaltuhr
-function:pwm,PWM
 function:wait,Pause
 health_chart:cpu_memory,CPU / Speicher
 health_chart:current,aktuell
@@ -256,6 +259,7 @@ lighting:add_point,Neuer Punkt
 lighting:change_mode,Modus ändern
 lighting:channel_name,Kanalname
 lighting:chart_color,Diagrammfarbe
+lighting:jack,Jack
 lighting:mode_auto,Auto
 lighting:mode_manual,Manuell
 lighting:mode_mixed,Mix
@@ -271,6 +275,8 @@ macro:action,Aktion
 macro:alert:message,Nachricht
 macro:alert:title,Titel
 macro:one_step_required,Mindestens ein Schritt ist erforderlich!
+macro:pwm:jack,Jack
+macro:pwm:value,Value (%)
 macro:reversible,Umkehrbar
 macro:revert,Umgekehrt
 macro:reverting,Umkehr
@@ -283,8 +289,6 @@ macro:turn_off,Ausschalten
 macro:turn_on,Einschalten
 macro:wait:duration,Dauer
 macro:warn_delete,Wollen Sie das Makro {{name}} wirklich löschen?
-macro:pwm:jack,Jack
-macro:pwm:value,Value (%)
 ph:alert_above,obere Warnschwelle
 ph:alert_below,untere Warnschwelle
 ph:calibrate,Kalibrieren
@@ -348,8 +352,8 @@ temperature:controlequipment,Gerät schalten
 temperature:controlmacro,Makro ausführen
 temperature:controlnothing,-keine Steuerung-
 temperature:current_reading,Messwert
-temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:fahrenheit,Fahrenheit
+temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:heater_cooler,Heizung/Kühler
 temperature:hysteresis,Hysterese
 temperature:hysteresis_less_than,Die Hysterese muss kleiner als der Abstand der Schwellwerte sein!
@@ -368,7 +372,9 @@ timers:and_then,... danach
 timers:duration,Dauer
 timers:function,Funktion
 timers:message,Nachricht
+timers:reverse,
 timers:revert,Umgekehrt
+timers:run,
 timers:sec,s
 timers:stay_off,aus lassen
 timers:stay_on,an lassen
@@ -378,8 +384,6 @@ timers:turn_back_off,wieder ausschalten
 timers:turn_back_on,wieder einschalten
 timers:turn_off,Ausschalten
 timers:turn_on,Einschalten
-timers:run,
-timers:reverse,
 timers:warn_delete,Wollen Sie die Schaltuhr {{name}} wirklich löschen?
 validation:a_must_be_greater_than_b,{{a}} muss größer als {{b}} sein!
 validation:a_must_be_less_than_b,{{a}} muss kleiner als {{b}} sein!
@@ -397,5 +401,3 @@ validation:name_required,Ein Name ist erforderlich!
 validation:number_required,Das muss eine Zahl sein!
 validation:selection_required,Eine Auswahl ist erforderlich!
 validation:time_required,Eine Zeit im Format HH:mm:ss ist erforderlich!
-ato:debounce,Debounce
-lighting:jack,Jack

--- a/front-end/assets/translations/en.csv
+++ b/front-end/assets/translations/en.csv
@@ -135,6 +135,8 @@ configuration:authentication:error_pass,You Must Provide a password
 configuration:authentication:error_user,You Must Provide a username
 configuration:connectors:title_delete,Delete {{name}} ?
 configuration:connectors:warn_delete,This action will delete connector {{name}}
+configuration:drivers:provision,Provision
+configuration:drivers:provision_title,Auto-create outlets/inlets/jacks for all pins of this driver
 configuration:drivers:title_delete,Remove driver {{name}}?
 configuration:drivers:type,Type
 configuration:drivers:warn_delete,This action will remove the driver for {{name}}

--- a/front-end/assets/translations/en.csv
+++ b/front-end/assets/translations/en.csv
@@ -80,6 +80,7 @@ ato:control_target,Target
 ato:controlequipment,Equipment
 ato:controlmacro,Macro
 ato:controlnothing,Nothing
+ato:debounce,Debounce
 ato:disable_on_alert,Disable on alert
 ato:reset_usage,Reset
 ato:title_delete,Delete {{name}} ?
@@ -123,7 +124,6 @@ configuration:about:status,Status
 configuration:about:uptime,Uptime
 configuration:about:version,Version
 configuration:about:website,Website
-configuration:errors:alert,Alert
 configuration:admin:db_export,Download current database
 configuration:admin:db_import,Import database
 configuration:admin:poweroff,Power Off
@@ -140,6 +140,7 @@ configuration:drivers:provision_title,Auto-create outlets/inlets/jacks for all p
 configuration:drivers:title_delete,Remove driver {{name}}?
 configuration:drivers:type,Type
 configuration:drivers:warn_delete,This action will remove the driver for {{name}}
+configuration:errors:alert,Alert
 configuration:settings:address,Address
 configuration:settings:alert_health_check,Alert on health check
 configuration:settings:brightness,Brightness
@@ -150,16 +151,16 @@ configuration:settings:interface,Interface
 configuration:settings:max_cpu,Max CPU
 configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,Max memory
-configuration:settings:report_enable,Enable periodic status reports
-configuration:settings:report_schedule,Report schedule (cron)
-configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:name,Name
-configuration:settings:network_address_required,Network address is required
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)
+configuration:settings:network_address_required,Network address is required
 configuration:settings:network_interface_required,Network Interface is required
 configuration:settings:notification,Notification
 configuration:settings:pprof,Enable profiling
 configuration:settings:prometheus,Enable Prometheus
+configuration:settings:report_enable,Enable periodic status reports
+configuration:settings:report_schedule,Report schedule (cron)
+configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:rpi_pwm_freq,Rpi Pwm Frequency
 configuration:settings:use_https,Use HTTPS
 configuration:tab:about,About
@@ -209,8 +210,8 @@ equipment:chart:ctrlpanel,Equipment(Switch Panel)
 equipment:sort,Sort
 equipment:sort_name_az,Name (A→Z)
 equipment:sort_name_za,Name (Z→A)
-equipment:sort_on_first,On first
 equipment:sort_off_first,Off first
+equipment:sort_on_first,On first
 equipment:title_delete,Delete {{name}} ?
 equipment:warn_delete,This action will delete equipment {{name}}
 fatal_error:connection_lost,Connection Lost
@@ -225,11 +226,11 @@ function:equipment,equipment
 function:lightings,light
 function:macro,macro
 function:phprobes,pH probe
+function:pwm,PWM
 function:reminder,email reminder
 function:subsystem,subsystem
 function:temperature,temperature
 function:timers,timer
-function:pwm,PWM
 function:wait,wait
 health_chart:cpu_memory,CPU/Memory
 health_chart:current,current
@@ -258,6 +259,7 @@ lighting:add_point,Add point
 lighting:change_mode,Change Mode
 lighting:channel_name,Channel Name
 lighting:chart_color,Color
+lighting:jack,Jack
 lighting:mode_auto,Auto
 lighting:mode_manual,Manual
 lighting:mode_mixed,Mixed
@@ -273,6 +275,8 @@ macro:action,Action
 macro:alert:message,message
 macro:alert:title,title
 macro:one_step_required,At least one step is required!
+macro:pwm:jack,Jack
+macro:pwm:value,Value (%)
 macro:reversible,Reversible
 macro:revert,Revert
 macro:reverting,Reverting
@@ -285,8 +289,6 @@ macro:turn_off,Turn Off
 macro:turn_on,Turn On
 macro:wait:duration,Duration
 macro:warn_delete,This action will delete macro {{name}}
-macro:pwm:jack,Jack
-macro:pwm:value,Value (%)
 ph:alert_above,Alert Above
 ph:alert_below,Alert Below
 ph:calibrate,Calibrate
@@ -350,8 +352,8 @@ temperature:controlequipment, Equipment
 temperature:controlmacro, Macro
 temperature:controlnothing, Nothing
 temperature:current_reading, Current Reading
-temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:fahrenheit,Fahrenheit
+temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:heater_cooler,Heater/Cooler
 temperature:hysteresis,Hysteresis
 temperature:hysteresis_less_than, Hysteresis is less than acceptable threshold
@@ -370,7 +372,9 @@ timers:and_then,And Then
 timers:duration,Duration
 timers:function,Function
 timers:message,Message
+timers:reverse,Reverse
 timers:revert,Revert
+timers:run,Run
 timers:sec,sec
 timers:stay_off,Stay off
 timers:stay_on,Stay on
@@ -380,8 +384,6 @@ timers:turn_back_off,Turn back off
 timers:turn_back_on,Turn back on
 timers:turn_off,Turn Off
 timers:turn_on,Turn On
-timers:run,Run
-timers:reverse,Reverse
 timers:warn_delete,This action will delete timer {{name}}
 validation:a_must_be_greater_than_b,{{a}} must be greater than {{b}}
 validation:a_must_be_less_than_b,{{a}} must be less than {{b}}
@@ -399,5 +401,3 @@ validation:name_required,Name is required
 validation:number_required,A number is required
 validation:selection_required,Select one entry
 validation:time_required,Enter a time as HH:mm:ss
-ato:debounce,Debounce
-lighting:jack,Jack

--- a/front-end/assets/translations/es.csv
+++ b/front-end/assets/translations/es.csv
@@ -80,6 +80,7 @@ ato:control_target,Objetivo
 ato:controlequipment,Equipo
 ato:controlmacro,Macro
 ato:controlnothing,Nada
+ato:debounce,Debounce
 ato:disable_on_alert,Desactivar si ocurre la alerta
 ato:reset_usage,
 ato:title_delete,
@@ -123,7 +124,6 @@ configuration:about:status,Status
 configuration:about:uptime,Uptime
 configuration:about:version,Version
 configuration:about:website,Website
-configuration:errors:alert,Alert
 configuration:admin:db_export,Descargue Base de Datos
 configuration:admin:db_import,Importar una Base de Datos
 configuration:admin:poweroff,Apagar
@@ -135,9 +135,12 @@ configuration:authentication:error_pass,Proporcione una contraseña
 configuration:authentication:error_user,Proporcione un nombre de usuario
 configuration:connectors:title_delete,
 configuration:connectors:warn_delete,
+configuration:drivers:provision,
+configuration:drivers:provision_title,
 configuration:drivers:title_delete,
 configuration:drivers:type,
 configuration:drivers:warn_delete,
+configuration:errors:alert,Alert
 configuration:settings:address,Direccion
 configuration:settings:alert_health_check,Alerta de estado
 configuration:settings:brightness,
@@ -148,16 +151,16 @@ configuration:settings:interface,Interface
 configuration:settings:max_cpu,Procesador Maximo
 configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,Memoria Maxima
-configuration:settings:report_enable,Enable periodic status reports
-configuration:settings:report_schedule,Report schedule (cron)
-configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:name,Nombre
-configuration:settings:network_address_required,La direccion de red es requerida
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)
+configuration:settings:network_address_required,La direccion de red es requerida
 configuration:settings:network_interface_required,La interfaz de red es requerida
 configuration:settings:notification,Notificacion
 configuration:settings:pprof,Activar perfilado
 configuration:settings:prometheus,Activar prometheus
+configuration:settings:report_enable,Enable periodic status reports
+configuration:settings:report_schedule,Report schedule (cron)
+configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:rpi_pwm_freq,Rpi Pwm Frecuencia
 configuration:settings:use_https,Usar HTTPS
 configuration:tab:about,Acerca De
@@ -207,8 +210,8 @@ equipment:chart:ctrlpanel,Equipo(Panel de Interruptores)
 equipment:sort,Sort
 equipment:sort_name_az,Name (A→Z)
 equipment:sort_name_za,Name (Z→A)
-equipment:sort_on_first,On first
 equipment:sort_off_first,Off first
+equipment:sort_on_first,On first
 equipment:title_delete,
 equipment:warn_delete,
 fatal_error:connection_lost,Conexion Perdida
@@ -223,11 +226,11 @@ function:equipment,equipo
 function:lightings,luz
 function:macro,macro
 function:phprobes,pH
+function:pwm,PWM
 function:reminder,
 function:subsystem,
 function:temperature,temperatura
 function:timers,cronómetro
-function:pwm,PWM
 function:wait,
 health_chart:cpu_memory,Procesador/Memoria
 health_chart:current,
@@ -256,6 +259,7 @@ lighting:add_point,
 lighting:change_mode,
 lighting:channel_name,Nombre del Canal
 lighting:chart_color,Color
+lighting:jack,Jack
 lighting:mode_auto,
 lighting:mode_manual,
 lighting:mode_mixed,
@@ -271,6 +275,8 @@ macro:action,
 macro:alert:message,
 macro:alert:title,
 macro:one_step_required,
+macro:pwm:jack,Jack
+macro:pwm:value,Value (%)
 macro:reversible,
 macro:revert,
 macro:reverting,
@@ -283,8 +289,6 @@ macro:turn_off,Apagar
 macro:turn_on,Encender
 macro:wait:duration,
 macro:warn_delete,
-macro:pwm:jack,Jack
-macro:pwm:value,Value (%)
 ph:alert_above,Alerta Sobre
 ph:alert_below,Alerta Bajo
 ph:calibrate,Calibrar
@@ -348,8 +352,8 @@ temperature:controlequipment,Equipo
 temperature:controlmacro,Macro
 temperature:controlnothing,Nada
 temperature:current_reading,Lectura Actual
-temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:fahrenheit,Fahrenheit
+temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:heater_cooler,Calentador/Enfriador
 temperature:hysteresis,Histéresis
 temperature:hysteresis_less_than,Histéresis es menor que límite aceptable
@@ -368,7 +372,9 @@ timers:and_then,Luego
 timers:duration,
 timers:function,Funcion
 timers:message,Mensaje
+timers:reverse,
 timers:revert,
+timers:run,
 timers:sec,seg
 timers:stay_off,Mantener Apagado
 timers:stay_on,Mantener Encendido
@@ -378,8 +384,6 @@ timers:turn_back_off,Regresar a Apagado
 timers:turn_back_on,Regresar a Encendido
 timers:turn_off,Apagar
 timers:turn_on,Encender
-timers:run,
-timers:reverse,
 timers:warn_delete,
 validation:a_must_be_greater_than_b,
 validation:a_must_be_less_than_b,
@@ -397,5 +401,3 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
-ato:debounce,Debounce
-lighting:jack,Jack

--- a/front-end/assets/translations/fa.csv
+++ b/front-end/assets/translations/fa.csv
@@ -80,6 +80,7 @@ ato:control_target,
 ato:controlequipment,
 ato:controlmacro,
 ato:controlnothing,
+ato:debounce,Debounce
 ato:disable_on_alert,
 ato:reset_usage,
 ato:title_delete,
@@ -123,7 +124,6 @@ configuration:about:status,پیکربندی:در باره: وضعیت
 configuration:about:uptime,پیکربندی:در باره: زمان فعلی
 configuration:about:version,پیکربندی:در باره: نسخه
 configuration:about:website,پیکربندی:در باره: سایت اینترنتی
-configuration:errors:alert,Alert
 configuration:admin:db_export,
 configuration:admin:db_import,
 configuration:admin:poweroff,پیکربندی:مدیر: خاموش
@@ -135,9 +135,12 @@ configuration:authentication:error_pass,پیکربندی: احراز هویت:خ
 configuration:authentication:error_user,پیکربندی: احراز هویت :خطای کاربر
 configuration:connectors:title_delete,
 configuration:connectors:warn_delete,
+configuration:drivers:provision,
+configuration:drivers:provision_title,
 configuration:drivers:title_delete,
 configuration:drivers:type,
 configuration:drivers:warn_delete,
+configuration:errors:alert,Alert
 configuration:settings:address,
 configuration:settings:alert_health_check,
 configuration:settings:brightness,
@@ -148,16 +151,16 @@ configuration:settings:interface,
 configuration:settings:max_cpu,
 configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,
-configuration:settings:report_enable,Enable periodic status reports
-configuration:settings:report_schedule,Report schedule (cron)
-configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:name,
-configuration:settings:network_address_required,
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)
+configuration:settings:network_address_required,
 configuration:settings:network_interface_required,
 configuration:settings:notification,
 configuration:settings:pprof,
 configuration:settings:prometheus,
+configuration:settings:report_enable,Enable periodic status reports
+configuration:settings:report_schedule,Report schedule (cron)
+configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:rpi_pwm_freq,
 configuration:settings:use_https,
 configuration:tab:about,پیکربندی:برگه: در باره
@@ -207,8 +210,8 @@ equipment:chart:ctrlpanel,
 equipment:sort,Sort
 equipment:sort_name_az,Name (A→Z)
 equipment:sort_name_za,Name (Z→A)
-equipment:sort_on_first,On first
 equipment:sort_off_first,Off first
+equipment:sort_on_first,On first
 equipment:title_delete,
 equipment:warn_delete,
 fatal_error:connection_lost,
@@ -223,11 +226,11 @@ function:equipment,
 function:lightings,
 function:macro,
 function:phprobes,
+function:pwm,PWM
 function:reminder,
 function:subsystem,
 function:temperature,
 function:timers,
-function:pwm,PWM
 function:wait,
 health_chart:cpu_memory,
 health_chart:current,
@@ -256,6 +259,7 @@ lighting:add_point,
 lighting:change_mode,
 lighting:channel_name,
 lighting:chart_color,
+lighting:jack,Jack
 lighting:mode_auto,
 lighting:mode_manual,
 lighting:mode_mixed,
@@ -271,6 +275,8 @@ macro:action,
 macro:alert:message,
 macro:alert:title,
 macro:one_step_required,
+macro:pwm:jack,Jack
+macro:pwm:value,Value (%)
 macro:reversible,
 macro:revert,
 macro:reverting,
@@ -283,8 +289,6 @@ macro:turn_off,
 macro:turn_on,
 macro:wait:duration,
 macro:warn_delete,
-macro:pwm:jack,Jack
-macro:pwm:value,Value (%)
 ph:alert_above,
 ph:alert_below,
 ph:calibrate,
@@ -348,8 +352,8 @@ temperature:controlequipment,
 temperature:controlmacro,
 temperature:controlnothing,
 temperature:current_reading,
-temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:fahrenheit,
+temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:heater_cooler,
 temperature:hysteresis,
 temperature:hysteresis_less_than,
@@ -368,7 +372,9 @@ timers:and_then,
 timers:duration,
 timers:function,
 timers:message,
+timers:reverse,
 timers:revert,
+timers:run,
 timers:sec,
 timers:stay_off,
 timers:stay_on,
@@ -378,8 +384,6 @@ timers:turn_back_off,
 timers:turn_back_on,
 timers:turn_off,
 timers:turn_on,
-timers:run,
-timers:reverse,
 timers:warn_delete,
 validation:a_must_be_greater_than_b,
 validation:a_must_be_less_than_b,
@@ -397,5 +401,3 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
-ato:debounce,Debounce
-lighting:jack,Jack

--- a/front-end/assets/translations/fr.csv
+++ b/front-end/assets/translations/fr.csv
@@ -80,6 +80,7 @@ ato:control_target,
 ato:controlequipment,
 ato:controlmacro,
 ato:controlnothing,
+ato:debounce,Debounce
 ato:disable_on_alert,
 ato:reset_usage,
 ato:title_delete,
@@ -123,7 +124,6 @@ configuration:about:status,Statut
 configuration:about:uptime,Durée de fonctionnement
 configuration:about:version,Version
 configuration:about:website,Site Web
-configuration:errors:alert,Alert
 configuration:admin:db_export,
 configuration:admin:db_import,
 configuration:admin:poweroff,Arrêt
@@ -135,9 +135,12 @@ configuration:authentication:error_pass,Vous devez fournir un mot de passe
 configuration:authentication:error_user,Vous devez fournir un nom d'utilisateur
 configuration:connectors:title_delete,
 configuration:connectors:warn_delete,
+configuration:drivers:provision,
+configuration:drivers:provision_title,
 configuration:drivers:title_delete,
 configuration:drivers:type,
 configuration:drivers:warn_delete,
+configuration:errors:alert,Alert
 configuration:settings:address,Adresse
 configuration:settings:alert_health_check,Alerte de santé du système
 configuration:settings:brightness,
@@ -148,16 +151,16 @@ configuration:settings:interface,Interface
 configuration:settings:max_cpu,CPU maximum
 configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,Mémoire maximum
-configuration:settings:report_enable,Enable periodic status reports
-configuration:settings:report_schedule,Report schedule (cron)
-configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:name,Nom
-configuration:settings:network_address_required,Adresse réseau requise
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)
+configuration:settings:network_address_required,Adresse réseau requise
 configuration:settings:network_interface_required,Interface réseau requise
 configuration:settings:notification,Notification
 configuration:settings:pprof,Activer le profilage
 configuration:settings:prometheus,
+configuration:settings:report_enable,Enable periodic status reports
+configuration:settings:report_schedule,Report schedule (cron)
+configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:rpi_pwm_freq,Fréquence RPI PWM
 configuration:settings:use_https,Utiliser HTTPS
 configuration:tab:about,À propos
@@ -207,8 +210,8 @@ equipment:chart:ctrlpanel,
 equipment:sort,Sort
 equipment:sort_name_az,Name (A→Z)
 equipment:sort_name_za,Name (Z→A)
-equipment:sort_on_first,On first
 equipment:sort_off_first,Off first
+equipment:sort_on_first,On first
 equipment:title_delete,
 equipment:warn_delete,
 fatal_error:connection_lost,
@@ -223,11 +226,11 @@ function:equipment,
 function:lightings,
 function:macro,
 function:phprobes,
+function:pwm,PWM
 function:reminder,
 function:subsystem,
 function:temperature,
 function:timers,
-function:pwm,PWM
 function:wait,
 health_chart:cpu_memory,
 health_chart:current,
@@ -256,6 +259,7 @@ lighting:add_point,
 lighting:change_mode,
 lighting:channel_name,
 lighting:chart_color,
+lighting:jack,Jack
 lighting:mode_auto,
 lighting:mode_manual,
 lighting:mode_mixed,
@@ -271,6 +275,8 @@ macro:action,
 macro:alert:message,
 macro:alert:title,
 macro:one_step_required,
+macro:pwm:jack,Jack
+macro:pwm:value,Value (%)
 macro:reversible,
 macro:revert,
 macro:reverting,
@@ -283,8 +289,6 @@ macro:turn_off,
 macro:turn_on,
 macro:wait:duration,
 macro:warn_delete,
-macro:pwm:jack,Jack
-macro:pwm:value,Value (%)
 ph:alert_above,
 ph:alert_below,
 ph:calibrate,
@@ -348,8 +352,8 @@ temperature:controlequipment,
 temperature:controlmacro,
 temperature:controlnothing,
 temperature:current_reading,
-temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:fahrenheit,
+temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:heater_cooler,
 temperature:hysteresis,
 temperature:hysteresis_less_than,
@@ -368,7 +372,9 @@ timers:and_then,
 timers:duration,
 timers:function,
 timers:message,
+timers:reverse,
 timers:revert,
+timers:run,
 timers:sec,
 timers:stay_off,
 timers:stay_on,
@@ -378,8 +384,6 @@ timers:turn_back_off,
 timers:turn_back_on,
 timers:turn_off,
 timers:turn_on,
-timers:run,
-timers:reverse,
 timers:warn_delete,
 validation:a_must_be_greater_than_b,
 validation:a_must_be_less_than_b,
@@ -397,5 +401,3 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
-ato:debounce,Debounce
-lighting:jack,Jack

--- a/front-end/assets/translations/hi.csv
+++ b/front-end/assets/translations/hi.csv
@@ -80,6 +80,7 @@ ato:control_target,
 ato:controlequipment,
 ato:controlmacro,
 ato:controlnothing,
+ato:debounce,Debounce
 ato:disable_on_alert,
 ato:reset_usage,
 ato:title_delete,
@@ -123,7 +124,6 @@ configuration:about:status,
 configuration:about:uptime,
 configuration:about:version,
 configuration:about:website,
-configuration:errors:alert,Alert
 configuration:admin:db_export,
 configuration:admin:db_import,
 configuration:admin:poweroff,
@@ -135,9 +135,12 @@ configuration:authentication:error_pass,
 configuration:authentication:error_user,
 configuration:connectors:title_delete,
 configuration:connectors:warn_delete,
+configuration:drivers:provision,
+configuration:drivers:provision_title,
 configuration:drivers:title_delete,
 configuration:drivers:type,
 configuration:drivers:warn_delete,
+configuration:errors:alert,Alert
 configuration:settings:address,
 configuration:settings:alert_health_check,
 configuration:settings:brightness,
@@ -148,16 +151,16 @@ configuration:settings:interface,
 configuration:settings:max_cpu,
 configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,
-configuration:settings:report_enable,Enable periodic status reports
-configuration:settings:report_schedule,Report schedule (cron)
-configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:name,
-configuration:settings:network_address_required,
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)
+configuration:settings:network_address_required,
 configuration:settings:network_interface_required,
 configuration:settings:notification,
 configuration:settings:pprof,
 configuration:settings:prometheus,
+configuration:settings:report_enable,Enable periodic status reports
+configuration:settings:report_schedule,Report schedule (cron)
+configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:rpi_pwm_freq,
 configuration:settings:use_https,
 configuration:tab:about,
@@ -207,8 +210,8 @@ equipment:chart:ctrlpanel,
 equipment:sort,Sort
 equipment:sort_name_az,Name (A→Z)
 equipment:sort_name_za,Name (Z→A)
-equipment:sort_on_first,On first
 equipment:sort_off_first,Off first
+equipment:sort_on_first,On first
 equipment:title_delete,
 equipment:warn_delete,
 fatal_error:connection_lost,
@@ -223,11 +226,11 @@ function:equipment,
 function:lightings,
 function:macro,
 function:phprobes,
+function:pwm,PWM
 function:reminder,
 function:subsystem,
 function:temperature,
 function:timers,
-function:pwm,PWM
 function:wait,
 health_chart:cpu_memory,
 health_chart:current,
@@ -256,6 +259,7 @@ lighting:add_point,
 lighting:change_mode,
 lighting:channel_name,
 lighting:chart_color,
+lighting:jack,Jack
 lighting:mode_auto,
 lighting:mode_manual,
 lighting:mode_mixed,
@@ -271,6 +275,8 @@ macro:action,
 macro:alert:message,
 macro:alert:title,
 macro:one_step_required,
+macro:pwm:jack,Jack
+macro:pwm:value,Value (%)
 macro:reversible,
 macro:revert,
 macro:reverting,
@@ -283,8 +289,6 @@ macro:turn_off,
 macro:turn_on,
 macro:wait:duration,
 macro:warn_delete,
-macro:pwm:jack,Jack
-macro:pwm:value,Value (%)
 ph:alert_above,
 ph:alert_below,
 ph:calibrate,
@@ -348,8 +352,8 @@ temperature:controlequipment,
 temperature:controlmacro,
 temperature:controlnothing,
 temperature:current_reading,
-temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:fahrenheit,
+temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:heater_cooler,
 temperature:hysteresis,
 temperature:hysteresis_less_than,
@@ -368,7 +372,9 @@ timers:and_then,
 timers:duration,
 timers:function,
 timers:message,
+timers:reverse,
 timers:revert,
+timers:run,
 timers:sec,
 timers:stay_off,
 timers:stay_on,
@@ -378,8 +384,6 @@ timers:turn_back_off,
 timers:turn_back_on,
 timers:turn_off,
 timers:turn_on,
-timers:run,
-timers:reverse,
 timers:warn_delete,
 validation:a_must_be_greater_than_b,
 validation:a_must_be_less_than_b,
@@ -397,5 +401,3 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
-ato:debounce,Debounce
-lighting:jack,Jack

--- a/front-end/assets/translations/it.csv
+++ b/front-end/assets/translations/it.csv
@@ -80,6 +80,7 @@ ato:control_target,
 ato:controlequipment,
 ato:controlmacro,
 ato:controlnothing,
+ato:debounce,Debounce
 ato:disable_on_alert,
 ato:reset_usage,
 ato:title_delete,
@@ -123,7 +124,6 @@ configuration:about:status,
 configuration:about:uptime,
 configuration:about:version,
 configuration:about:website,
-configuration:errors:alert,Alert
 configuration:admin:db_export,
 configuration:admin:db_import,
 configuration:admin:poweroff,
@@ -135,9 +135,12 @@ configuration:authentication:error_pass,
 configuration:authentication:error_user,
 configuration:connectors:title_delete,
 configuration:connectors:warn_delete,
+configuration:drivers:provision,
+configuration:drivers:provision_title,
 configuration:drivers:title_delete,
 configuration:drivers:type,
 configuration:drivers:warn_delete,
+configuration:errors:alert,Alert
 configuration:settings:address,
 configuration:settings:alert_health_check,
 configuration:settings:brightness,
@@ -148,16 +151,16 @@ configuration:settings:interface,
 configuration:settings:max_cpu,
 configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,
-configuration:settings:report_enable,Enable periodic status reports
-configuration:settings:report_schedule,Report schedule (cron)
-configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:name,
-configuration:settings:network_address_required,
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)
+configuration:settings:network_address_required,
 configuration:settings:network_interface_required,
 configuration:settings:notification,
 configuration:settings:pprof,
 configuration:settings:prometheus,
+configuration:settings:report_enable,Enable periodic status reports
+configuration:settings:report_schedule,Report schedule (cron)
+configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:rpi_pwm_freq,
 configuration:settings:use_https,
 configuration:tab:about,
@@ -207,8 +210,8 @@ equipment:chart:ctrlpanel,
 equipment:sort,Sort
 equipment:sort_name_az,Name (A→Z)
 equipment:sort_name_za,Name (Z→A)
-equipment:sort_on_first,On first
 equipment:sort_off_first,Off first
+equipment:sort_on_first,On first
 equipment:title_delete,
 equipment:warn_delete,
 fatal_error:connection_lost,
@@ -223,11 +226,11 @@ function:equipment,
 function:lightings,
 function:macro,
 function:phprobes,
+function:pwm,PWM
 function:reminder,
 function:subsystem,
 function:temperature,
 function:timers,
-function:pwm,PWM
 function:wait,
 health_chart:cpu_memory,
 health_chart:current,
@@ -256,6 +259,7 @@ lighting:add_point,
 lighting:change_mode,
 lighting:channel_name,
 lighting:chart_color,
+lighting:jack,Jack
 lighting:mode_auto,
 lighting:mode_manual,
 lighting:mode_mixed,
@@ -271,6 +275,8 @@ macro:action,
 macro:alert:message,
 macro:alert:title,
 macro:one_step_required,
+macro:pwm:jack,Jack
+macro:pwm:value,Value (%)
 macro:reversible,
 macro:revert,
 macro:reverting,
@@ -283,8 +289,6 @@ macro:turn_off,
 macro:turn_on,
 macro:wait:duration,
 macro:warn_delete,
-macro:pwm:jack,Jack
-macro:pwm:value,Value (%)
 ph:alert_above,
 ph:alert_below,
 ph:calibrate,
@@ -348,8 +352,8 @@ temperature:controlequipment,
 temperature:controlmacro,
 temperature:controlnothing,
 temperature:current_reading,
-temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:fahrenheit,
+temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:heater_cooler,
 temperature:hysteresis,
 temperature:hysteresis_less_than,
@@ -368,7 +372,9 @@ timers:and_then,
 timers:duration,
 timers:function,
 timers:message,
+timers:reverse,
 timers:revert,
+timers:run,
 timers:sec,
 timers:stay_off,
 timers:stay_on,
@@ -378,8 +384,6 @@ timers:turn_back_off,
 timers:turn_back_on,
 timers:turn_off,
 timers:turn_on,
-timers:run,
-timers:reverse,
 timers:warn_delete,
 validation:a_must_be_greater_than_b,
 validation:a_must_be_less_than_b,
@@ -397,5 +401,3 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
-ato:debounce,Debounce
-lighting:jack,Jack

--- a/front-end/assets/translations/nl.csv
+++ b/front-end/assets/translations/nl.csv
@@ -80,6 +80,7 @@ ato:control_target,
 ato:controlequipment,Apparatuur
 ato:controlmacro,Macro
 ato:controlnothing,Niets
+ato:debounce,Debounce
 ato:disable_on_alert,Uitschakelen bij alarm
 ato:reset_usage,
 ato:title_delete,
@@ -123,7 +124,6 @@ configuration:about:status,Status
 configuration:about:uptime,Uptime
 configuration:about:version,Versie
 configuration:about:website,Website
-configuration:errors:alert,Alert
 configuration:admin:db_export,
 configuration:admin:db_import,
 configuration:admin:poweroff,Uitschakelen
@@ -135,9 +135,12 @@ configuration:authentication:error_pass,Geef een passwoord in
 configuration:authentication:error_user,Geef een gebruikersnaam in
 configuration:connectors:title_delete,
 configuration:connectors:warn_delete,
+configuration:drivers:provision,
+configuration:drivers:provision_title,
 configuration:drivers:title_delete,
 configuration:drivers:type,
 configuration:drivers:warn_delete,
+configuration:errors:alert,Alert
 configuration:settings:address,Adres
 configuration:settings:alert_health_check,Alarm bij health check
 configuration:settings:brightness,
@@ -148,16 +151,16 @@ configuration:settings:interface,Interface
 configuration:settings:max_cpu,Max CPU
 configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,Max Geheugen
-configuration:settings:report_enable,Enable periodic status reports
-configuration:settings:report_schedule,Report schedule (cron)
-configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:name,Naam
-configuration:settings:network_address_required,Netwerkadres is nodig
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)
+configuration:settings:network_address_required,Netwerkadres is nodig
 configuration:settings:network_interface_required,Netwerkinterface is nodig
 configuration:settings:notification,Notificatie
 configuration:settings:pprof,Profiling inschakelen
 configuration:settings:prometheus,Prometheus inschakelen
+configuration:settings:report_enable,Enable periodic status reports
+configuration:settings:report_schedule,Report schedule (cron)
+configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:rpi_pwm_freq,Rpi Pwm Frequencie
 configuration:settings:use_https,Gebruik HTTPS
 configuration:tab:about,Over
@@ -207,8 +210,8 @@ equipment:chart:ctrlpanel,
 equipment:sort,Sort
 equipment:sort_name_az,Name (A→Z)
 equipment:sort_name_za,Name (Z→A)
-equipment:sort_on_first,On first
 equipment:sort_off_first,Off first
+equipment:sort_on_first,On first
 equipment:title_delete,
 equipment:warn_delete,
 fatal_error:connection_lost,Connectie verloren
@@ -223,11 +226,11 @@ function:equipment,
 function:lightings,
 function:macro,
 function:phprobes,
+function:pwm,PWM
 function:reminder,
 function:subsystem,
 function:temperature,
 function:timers,
-function:pwm,PWM
 function:wait,
 health_chart:cpu_memory,CPU/Geheugen
 health_chart:current,
@@ -256,6 +259,7 @@ lighting:add_point,
 lighting:change_mode,
 lighting:channel_name,
 lighting:chart_color,
+lighting:jack,Jack
 lighting:mode_auto,
 lighting:mode_manual,
 lighting:mode_mixed,
@@ -271,6 +275,8 @@ macro:action,
 macro:alert:message,
 macro:alert:title,
 macro:one_step_required,
+macro:pwm:jack,Jack
+macro:pwm:value,Value (%)
 macro:reversible,
 macro:revert,
 macro:reverting,
@@ -283,8 +289,6 @@ macro:turn_off,Uitschakelen
 macro:turn_on,Inschakelen
 macro:wait:duration,
 macro:warn_delete,
-macro:pwm:jack,Jack
-macro:pwm:value,Value (%)
 ph:alert_above,Alarm boven
 ph:alert_below,Alarm onder
 ph:calibrate,Calibreren
@@ -348,8 +352,8 @@ temperature:controlequipment,Apparatuur
 temperature:controlmacro,Macro
 temperature:controlnothing,Niets
 temperature:current_reading,Huidige uitlezing
-temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:fahrenheit,Fahrenheit
+temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:heater_cooler,Verwarming/Koeling
 temperature:hysteresis,Hysteresis
 temperature:hysteresis_less_than,Hysteresis kleiner dan de aanvaardbaar drempelwaarde
@@ -368,7 +372,9 @@ timers:and_then,AEn Daarna
 timers:duration,
 timers:function,Functie
 timers:message,Bericht
+timers:reverse,
 timers:revert,
+timers:run,
 timers:sec,sec
 timers:stay_off,Uit blijven
 timers:stay_on,Aan blijven
@@ -378,8 +384,6 @@ timers:turn_back_off,Terug uitschakelen
 timers:turn_back_on,Terug inschakelen
 timers:turn_off,Uitschakelen
 timers:turn_on,Inschakelen
-timers:run,
-timers:reverse,
 timers:warn_delete,
 validation:a_must_be_greater_than_b,
 validation:a_must_be_less_than_b,
@@ -397,5 +401,3 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
-ato:debounce,Debounce
-lighting:jack,Jack

--- a/front-end/assets/translations/pt.csv
+++ b/front-end/assets/translations/pt.csv
@@ -80,6 +80,7 @@ ato:control_target, objectivo
 ato:controlequipment,Controlo do equipamento
 ato:controlmacro,Macro do equipamento
 ato:controlnothing,Não controlar
+ato:debounce,Debounce
 ato:disable_on_alert,Desativar alerta
 ato:reset_usage,Reninciar o uso
 ato:title_delete,Apagar
@@ -123,7 +124,6 @@ configuration:about:status,Estado
 configuration:about:uptime,Uptime
 configuration:about:version,Versão
 configuration:about:website,Site
-configuration:errors:alert,Alert
 configuration:admin:db_export,Exportar DB
 configuration:admin:db_import,Importar DB
 configuration:admin:poweroff,Desligar
@@ -135,9 +135,12 @@ configuration:authentication:error_pass,Tens que inserir uma password
 configuration:authentication:error_user,Tens que inserir um nome de utilizador
 configuration:connectors:title_delete,Apagar
 configuration:connectors:warn_delete,Aviso Apagar
+configuration:drivers:provision,
+configuration:drivers:provision_title,
 configuration:drivers:title_delete,Apaga
 configuration:drivers:type,Tipo
 configuration:drivers:warn_delete, Aviso apagar
+configuration:errors:alert,Alert
 configuration:settings:address,Endereço
 configuration:settings:alert_health_check,Avisos de Estado Geral
 configuration:settings:brightness,Brilho
@@ -148,16 +151,16 @@ configuration:settings:interface,Interface
 configuration:settings:max_cpu,Maximo de CPU
 configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,Maximo de Memoria
-configuration:settings:report_enable,Enable periodic status reports
-configuration:settings:report_schedule,Report schedule (cron)
-configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:name,Nome
-configuration:settings:network_address_required,Endereço de rede é obrigatório
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)
+configuration:settings:network_address_required,Endereço de rede é obrigatório
 configuration:settings:network_interface_required,Nome do interface de rede é obrigatório
 configuration:settings:notification,Notificação
 configuration:settings:pprof,Activar profiling
 configuration:settings:prometheus,Activar prometheus
+configuration:settings:report_enable,Enable periodic status reports
+configuration:settings:report_schedule,Report schedule (cron)
+configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:rpi_pwm_freq,Rpi Pwm Frequencia
 configuration:settings:use_https,Usar HTTPS
 configuration:tab:about,Sobre
@@ -207,8 +210,8 @@ equipment:chart:ctrlpanel,Painel de Control
 equipment:sort,Sort
 equipment:sort_name_az,Name (A→Z)
 equipment:sort_name_za,Name (Z→A)
-equipment:sort_on_first,On first
 equipment:sort_off_first,Off first
+equipment:sort_on_first,On first
 equipment:title_delete,Apagar
 equipment:warn_delete,Aviso Apagar
 fatal_error:connection_lost,Ligação Perdida
@@ -223,11 +226,11 @@ function:equipment,Equipamento
 function:lightings,Luzes
 function:macro,Macro
 function:phprobes,Sonda de PH
+function:pwm,PWM
 function:reminder,Lembretes
 function:subsystem,Subsistema
 function:temperature,Temperatura
 function:timers,Temporizadores
-function:pwm,PWM
 function:wait,Aguarda
 health_chart:cpu_memory,CPU/Memory
 health_chart:current,Atual
@@ -256,6 +259,7 @@ lighting:add_point,Adicionar Ponto
 lighting:change_mode,Mudar Modo
 lighting:channel_name,Nome do Canal
 lighting:chart_color,Cor
+lighting:jack,Jack
 lighting:mode_auto,Modo Automatico
 lighting:mode_manual,Modo Manual
 lighting:mode_mixed,Modo Misto
@@ -271,6 +275,8 @@ macro:action,Acção
 macro:alert:message,Mensagem
 macro:alert:title,Titulo
 macro:one_step_required,Um passo é necessáio
+macro:pwm:jack,Jack
+macro:pwm:value,Value (%)
 macro:reversible,Reversivel
 macro:revert,Reverter
 macro:reverting,Revertendo
@@ -283,8 +289,6 @@ macro:turn_off,Desligar
 macro:turn_on,Ligar é Obrigatório
 macro:wait:duration,Duração
 macro:warn_delete,Apagar
-macro:pwm:jack,Jack
-macro:pwm:value,Value (%)
 ph:alert_above,Alerta superior de
 ph:alert_below,Alerta inferior de
 ph:calibrate,Calibrar
@@ -348,8 +352,8 @@ temperature:controlequipment,controlar equipamento
 temperature:controlmacro,controlar macro
 temperature:controlnothing,não controlar
 temperature:current_reading,Leitura atual
-temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:fahrenheit,Fahrenheit
+temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:heater_cooler,Aquecedor/refrigeração
 temperature:hysteresis,hysteresis
 temperature:hysteresis_less_than,hysteresis menos de 
@@ -368,7 +372,9 @@ timers:and_then,e depois
 timers:duration,duração
 timers:function,Função
 timers:message,Mensagem
+timers:reverse,
 timers:revert,reverter
+timers:run,
 timers:sec,sec
 timers:stay_off,manter desligado
 timers:stay_on,Manter ligado
@@ -378,8 +384,6 @@ timers:turn_back_off,Voltar a desligar
 timers:turn_back_on,Voltar a Ligar
 timers:turn_off,Desligar
 timers:turn_on,Ligar é Obrigatório
-timers:run,
-timers:reverse,
 timers:warn_delete,apagar
 validation:a_must_be_greater_than_b, A tem que ser maior do que B
 validation:a_must_be_less_than_b,A tem que ser menos do que B
@@ -397,5 +401,3 @@ validation:name_required,nome é obrigatório
 validation:number_required,numero é obrigatória
 validation:selection_required,Selecção é obrigatória
 validation:time_required,Tempo é obrigatória
-ato:debounce,Debounce
-lighting:jack,Jack

--- a/front-end/assets/translations/zh.csv
+++ b/front-end/assets/translations/zh.csv
@@ -80,6 +80,7 @@ ato:control_target,
 ato:controlequipment,
 ato:controlmacro,
 ato:controlnothing,
+ato:debounce,Debounce
 ato:disable_on_alert,禁用发生于告警
 ato:reset_usage,
 ato:title_delete,
@@ -123,7 +124,6 @@ configuration:about:status,状态
 configuration:about:uptime,运行时间
 configuration:about:version,版本
 configuration:about:website,网站
-configuration:errors:alert,Alert
 configuration:admin:db_export,
 configuration:admin:db_import,
 configuration:admin:poweroff,关机
@@ -135,9 +135,12 @@ configuration:authentication:error_pass,你必须提供一个密码
 configuration:authentication:error_user,你必须提供一个用户名
 configuration:connectors:title_delete,
 configuration:connectors:warn_delete,
+configuration:drivers:provision,
+configuration:drivers:provision_title,
 configuration:drivers:title_delete,
 configuration:drivers:type,
 configuration:drivers:warn_delete,
+configuration:errors:alert,Alert
 configuration:settings:address,日志
 configuration:settings:alert_health_check,健康检查警告
 configuration:settings:brightness,
@@ -148,16 +151,16 @@ configuration:settings:interface,接口
 configuration:settings:max_cpu,最大CPU
 configuration:settings:max_cpu_temp,Max CPU Temp (°C)
 configuration:settings:max_memory,最大内存
-configuration:settings:report_enable,Enable periodic status reports
-configuration:settings:report_schedule,Report schedule (cron)
-configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:name,名字
-configuration:settings:network_address_required,必须填写网络地址
 configuration:settings:network_address_format,Address must be in host:port format (e.g. 0.0.0.0:80)
+configuration:settings:network_address_required,必须填写网络地址
 configuration:settings:network_interface_required,必须填写网络接口
 configuration:settings:notification,通知
 configuration:settings:pprof,启用资料收集
 configuration:settings:prometheus,启用监控
+configuration:settings:report_enable,Enable periodic status reports
+configuration:settings:report_schedule,Report schedule (cron)
+configuration:settings:report_schedule_help,"Standard 5-field cron expression, e.g. ""0 8 * * *"" for daily at 8am"
 configuration:settings:rpi_pwm_freq,树莓派整流器
 configuration:settings:use_https,使用HTTPS
 configuration:tab:about,关于
@@ -207,8 +210,8 @@ equipment:chart:ctrlpanel,
 equipment:sort,Sort
 equipment:sort_name_az,Name (A→Z)
 equipment:sort_name_za,Name (Z→A)
-equipment:sort_on_first,On first
 equipment:sort_off_first,Off first
+equipment:sort_on_first,On first
 equipment:title_delete,
 equipment:warn_delete,
 fatal_error:connection_lost,连接丢失
@@ -223,11 +226,11 @@ function:equipment,
 function:lightings,
 function:macro,
 function:phprobes,
+function:pwm,PWM
 function:reminder,
 function:subsystem,
 function:temperature,
 function:timers,
-function:pwm,PWM
 function:wait,
 health_chart:cpu_memory,CPU/内存
 health_chart:current,
@@ -256,6 +259,7 @@ lighting:add_point,
 lighting:change_mode,
 lighting:channel_name,
 lighting:chart_color,
+lighting:jack,Jack
 lighting:mode_auto,
 lighting:mode_manual,
 lighting:mode_mixed,
@@ -271,6 +275,8 @@ macro:action,
 macro:alert:message,
 macro:alert:title,
 macro:one_step_required,
+macro:pwm:jack,Jack
+macro:pwm:value,Value (%)
 macro:reversible,
 macro:revert,
 macro:reverting,
@@ -283,8 +289,6 @@ macro:turn_off,关闭
 macro:turn_on,开启
 macro:wait:duration,
 macro:warn_delete,
-macro:pwm:jack,Jack
-macro:pwm:value,Value (%)
 ph:alert_above,告警上限
 ph:alert_below,告警下限
 ph:calibrate,校正
@@ -348,8 +352,8 @@ temperature:controlequipment,设备
 temperature:controlmacro,宏
 temperature:controlnothing,
 temperature:current_reading,当前读数
-temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:fahrenheit,华氏的
+temperature:fail_safe,Fail safe (disable heater on sensor error)
 temperature:heater_cooler,加热器/冷水机
 temperature:hysteresis,
 temperature:hysteresis_less_than,
@@ -368,7 +372,9 @@ timers:and_then,然后
 timers:duration,
 timers:function,功能
 timers:message,消息
+timers:reverse,
 timers:revert,
+timers:run,
 timers:sec,秒
 timers:stay_off,保持关闭
 timers:stay_on,保持开启
@@ -378,8 +384,6 @@ timers:turn_back_off,重新关闭
 timers:turn_back_on,重新开启
 timers:turn_off,关闭
 timers:turn_on,开启
-timers:run,
-timers:reverse,
 timers:warn_delete,
 validation:a_must_be_greater_than_b,
 validation:a_must_be_less_than_b,
@@ -397,5 +401,3 @@ validation:name_required,
 validation:number_required,
 validation:selection_required,
 validation:time_required,
-ato:debounce,Debounce
-lighting:jack,Jack

--- a/front-end/src/drivers/driver.jsx
+++ b/front-end/src/drivers/driver.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { confirm } from 'utils/confirm'
+import { showUpdateSuccessful } from 'utils/alert'
 import i18n from 'utils/i18n'
 import DriverForm from './driver_form'
 
@@ -103,6 +104,7 @@ export default class Driver extends React.Component {
   render () {
     let btnEdit = null
     let btnDelete = null
+    let btnProvision = null
 
     if (this.props.read_only !== true) {
       if (!this.state.edit) {
@@ -112,6 +114,18 @@ export default class Driver extends React.Component {
             className='edit-outlet btn btn-sm btn-outline-primary float-right d-block d-sm-inline ml-2'
             value={this.state.lbl}
             onClick={this.handleEdit}
+          />
+        )
+        btnProvision = (
+          <input
+            type='button'
+            className='btn btn-sm btn-outline-info float-right d-block d-sm-inline ml-2'
+            title={i18n.t('configuration:drivers:provision_title')}
+            value={i18n.t('configuration:drivers:provision')}
+            onClick={() => {
+              this.props.provision(this.props.driver.id)
+              showUpdateSuccessful()
+            }}
           />
         )
       }
@@ -131,6 +145,7 @@ export default class Driver extends React.Component {
         <div className='col-4 col-md-3'>
           {btnDelete}
           {btnEdit}
+          {btnProvision}
         </div>
       </div>
     )
@@ -141,5 +156,6 @@ Driver.propTypes = {
   driver: PropTypes.object,
   remove: PropTypes.func.isRequired,
   update: PropTypes.func.isRequired,
+  provision: PropTypes.func.isRequired,
   driverOptions: PropTypes.object
 }

--- a/front-end/src/drivers/main.jsx
+++ b/front-end/src/drivers/main.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fetchDrivers, fetchDriverOptions, deleteDriver, createDriver, updateDriver } from 'redux/actions/drivers'
+import { fetchDrivers, fetchDriverOptions, deleteDriver, createDriver, updateDriver, provisionDriver } from 'redux/actions/drivers'
 import { connect } from 'react-redux'
 import Driver from './driver'
 import New from './new'
@@ -41,6 +41,7 @@ class drivers extends React.Component {
             read_only={(d.type === 'rpi')}
             remove={this.props.delete}
             update={this.props.update}
+            provision={this.props.provision}
           />
         )
       })
@@ -79,7 +80,8 @@ const mapDispatchToProps = dispatch => {
     fetchDriverOptions: () => dispatch(fetchDriverOptions()),
     create: d => dispatch(createDriver(d)),
     delete: id => dispatch(deleteDriver(id)),
-    update: (id, p) => dispatch(updateDriver(id, p))
+    update: (id, p) => dispatch(updateDriver(id, p)),
+    provision: id => dispatch(provisionDriver(id))
   }
 }
 

--- a/front-end/src/redux/actions/drivers.js
+++ b/front-end/src/redux/actions/drivers.js
@@ -56,3 +56,12 @@ export const driverOptionsLoaded = (options) => {
     payload: options
   })
 }
+
+export const provisionDriver = (id) => {
+  return (
+    reduxPost({
+      url: '/api/drivers/' + id + '/provision',
+      data: {},
+      success: fetchDrivers
+    }))
+}


### PR DESCRIPTION
## Summary

- When a driver is created, reef-pi now automatically provisions all connectors exposed by that driver based on its capabilities: **DigitalOutput → Outlets**, **DigitalInput → Inlets**, **PWM → Jacks**, **AnalogInput → Analog Inputs**
- Individual connector failures are logged but do not abort provisioning (e.g. adding the same driver twice won't fail — already-existing connectors are skipped with a log message)
- Adds a `POST /api/drivers/{id}/provision` endpoint for re-provisioning at any time (e.g. to sync after renaming)
- Adds a **Provision** button to each driver card in the Drivers UI that calls the provision endpoint and refreshes the page

Before this change, setting up a 6-outlet Kasa HS300 required 6 manual outlet-creation steps plus 6 more equipment steps. Now it's automatic on driver creation.

## Test plan

- [x] `go test ./controller/device_manager/...` — all tests pass
- [x] `go test ./controller/...` — all tests pass
- [x] Frontend tests: `npm test -- --testPathPattern="connectors|driver"` — 16 tests pass
- [ ] Manual: add an `hs300` driver, verify 6 outlets are created automatically
- [ ] Manual: click "Provision" on an existing driver, verify missing connectors are added

Fixes #1899

🤖 Generated with [Claude Code](https://claude.com/claude-code)