### PR TITLE
feat: group connectors by driver in the connectors UI

### DIFF
--- a/front-end/src/connectors/analog_inputs.jsx
+++ b/front-end/src/connectors/analog_inputs.jsx
@@ -88,15 +88,31 @@ class analogInputs extends React.Component {
   }
 
   list () {
-    const list = []
+    const driverMap = {}
+    this.props.drivers.forEach(d => { driverMap[d.id] = d })
+
+    const groups = {}
     this.props.analog_inputs.sort((a, b) => SortByName(a, b))
-      .forEach((j, i) => {
+      .forEach(j => {
+        const driverName = (driverMap[j.driver] || {}).name || j.driver
+        if (!groups[driverName]) groups[driverName] = []
+        groups[driverName].push(j)
+      })
+
+    const list = []
+    Object.keys(groups).sort().forEach(driverName => {
+      list.push(
+        <div key={'driver-' + driverName} className='mt-2'>
+          <small className='text-muted font-weight-bold'>{driverName}</small>
+        </div>
+      )
+      groups[driverName].forEach(j => {
         list.push(
           <AnalogInput
             name={j.name}
             key={j.id}
             pin={j.pin}
-            driver={this.props.drivers.filter(d => d.id === j.driver)[0] || {}}
+            driver={driverMap[j.driver] || {}}
             drivers={this.props.drivers}
             analog_input_id={j.id}
             remove={this.remove(j)}
@@ -107,6 +123,7 @@ class analogInputs extends React.Component {
           />
         )
       })
+    })
     return list
   }
 

--- a/front-end/src/connectors/inlets.jsx
+++ b/front-end/src/connectors/inlets.jsx
@@ -90,10 +90,25 @@ class inlets extends React.Component {
   }
 
   list () {
-    const items = []
+    const driverMap = {}
+    this.props.drivers.forEach(d => { driverMap[d.id] = d })
+
+    const groups = {}
     this.props.inlets.sort((a, b) => SortByName(a, b))
-      .forEach((i, n) => {
-        const d = this.props.drivers.filter(d => d.id === i.driver)[0] || {}
+      .forEach(i => {
+        const driverName = (driverMap[i.driver] || {}).name || i.driver
+        if (!groups[driverName]) groups[driverName] = []
+        groups[driverName].push(i)
+      })
+
+    const items = []
+    Object.keys(groups).sort().forEach(driverName => {
+      items.push(
+        <div key={'driver-' + driverName} className='mt-2'>
+          <small className='text-muted font-weight-bold'>{driverName}</small>
+        </div>
+      )
+      groups[driverName].forEach(i => {
         items.push(
           <Inlet
             name={i.name}
@@ -101,7 +116,7 @@ class inlets extends React.Component {
             reverse={i.reverse}
             equipment={i.equipment}
             inlet_id={i.id}
-            driver={d}
+            driver={driverMap[i.driver] || {}}
             drivers={this.props.drivers}
             key={i.id}
             remove={this.remove(i)}
@@ -112,6 +127,7 @@ class inlets extends React.Component {
           />
         )
       })
+    })
     return items
   }
 

--- a/front-end/src/connectors/jacks.jsx
+++ b/front-end/src/connectors/jacks.jsx
@@ -99,9 +99,25 @@ class jacks extends React.Component {
   }
 
   list () {
-    const list = []
+    const driverMap = {}
+    this.props.drivers.forEach(d => { driverMap[d.id] = d })
+
+    const groups = {}
     this.props.jacks.sort((a, b) => SortByName(a, b))
-      .forEach((j, i) => {
+      .forEach(j => {
+        const driverName = (driverMap[j.driver] || {}).name || j.driver
+        if (!groups[driverName]) groups[driverName] = []
+        groups[driverName].push(j)
+      })
+
+    const list = []
+    Object.keys(groups).sort().forEach(driverName => {
+      list.push(
+        <div key={'driver-' + driverName} className='mt-2'>
+          <small className='text-muted font-weight-bold'>{driverName}</small>
+        </div>
+      )
+      groups[driverName].forEach(j => {
         list.push(
           <Jack
             name={j.name}
@@ -119,6 +135,7 @@ class jacks extends React.Component {
           />
         )
       })
+    })
     return list
   }
 

--- a/front-end/src/connectors/outlets.jsx
+++ b/front-end/src/connectors/outlets.jsx
@@ -91,10 +91,26 @@ class outlets extends React.Component {
   }
 
   list () {
-    const list = []
+    const driverMap = {}
+    this.props.drivers.forEach(d => { driverMap[d.id] = d })
+
+    const groups = {}
     this.props.outlets
       .sort((a, b) => SortByName(a, b))
-      .forEach((o, i) => {
+      .forEach(o => {
+        const driverName = (driverMap[o.driver] || {}).name || o.driver
+        if (!groups[driverName]) groups[driverName] = []
+        groups[driverName].push(o)
+      })
+
+    const list = []
+    Object.keys(groups).sort().forEach(driverName => {
+      list.push(
+        <div key={'driver-' + driverName} className='mt-2'>
+          <small className='text-muted font-weight-bold'>{driverName}</small>
+        </div>
+      )
+      groups[driverName].forEach(o => {
         list.push(
           <Outlet
             name={o.name}
@@ -105,7 +121,7 @@ class outlets extends React.Component {
             equipment={o.equipment}
             remove={this.remove(o)}
             drivers={this.props.drivers}
-            driver={this.props.drivers.filter(d => d.id === o.driver)[0] || {}}
+            driver={driverMap[o.driver] || {}}
             update={p => {
               this.props.update(o.id, p)
               this.props.fetch()
@@ -113,6 +129,7 @@ class outlets extends React.Component {
           />
         )
       })
+    })
     return list
   }
 


### PR DESCRIPTION
## Summary

- Outlets, inlets, jacks, and analog inputs in the Connectors page are now grouped under their driver name
- Each group displays a small driver-name header, making it easy to identify which peripherals belong to which driver (e.g. two ESP32s serving different aquariums)
- Groups are sorted alphabetically; connectors within each group are sorted by name as before

## Test plan

- [x] `npm test -- --testPathPattern="connectors"` — 8 tests pass
- [ ] Manual: add outlets/inlets to multiple drivers and verify they appear under the correct group headers in the Connectors page

Fixes #2166

🤖 Generated with [Claude Code](https://claude.com/claude-code)