### PR TITLE
test: extend controller/utils coverage (51% → 73%)

### DIFF
--- a/controller/utils/auth_test.go
+++ b/controller/utils/auth_test.go
@@ -2,16 +2,129 @@ package utils
 
 import (
 	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/reef-pi/reef-pi/controller/storage"
 )
 
-func TestAuth(t *testing.T) {
-	store, err := storage.NewStore("auth-test.db")
+func TestAuthDefaultCredentials(t *testing.T) {
+	dbPath := "auth-default-test.db"
+	os.Remove(dbPath)
+	store, err := storage.NewStore(dbPath)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		store.Close()
+		os.Remove(dbPath)
+	}()
+	// Create bucket but no credentials — NewAuth should call defaultCredentials
+	store.CreateBucket("reef-pi")
+	_, err = NewAuth("reef-pi", store)
+	if err != nil {
+		t.Fatal("Expected NewAuth to succeed with default credentials, got:", err)
+	}
+}
+
+func TestAuthenticate(t *testing.T) {
+	dbPath := "auth-middleware-test.db"
+	os.Remove(dbPath)
+	store, err := storage.NewStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { store.Close(); os.Remove(dbPath) }()
+	store.CreateBucket("reef-pi")
+	store.Update("reef-pi", "credentials", Credentials{User: "reef-pi", Password: "reef-pi"})
+	a, err := NewAuth("reef-pi", store)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	handler := a.Authenticate(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	// Request without a session cookie should be rejected with 401
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	rr := httptest.NewRecorder()
+	handler(rr, req)
+	if rr.Code != 401 {
+		t.Errorf("Expected 401 for unauthenticated request, got %d", rr.Code)
+	}
+	if called {
+		t.Error("Handler should not have been called for unauthenticated request")
+	}
+}
+
+func TestSignInFailure(t *testing.T) {
+	dbPath := "auth-signin-fail-test.db"
+	os.Remove(dbPath)
+	store, err := storage.NewStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { store.Close(); os.Remove(dbPath) }()
+	store.CreateBucket("reef-pi")
+	store.Update("reef-pi", "credentials", Credentials{User: "reef-pi", Password: "reef-pi"})
+	a, err := NewAuth("reef-pi", store)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tr := NewTestRouter()
+	tr.Router.HandleFunc("/sign_in", a.SignIn).Methods("POST")
+
+	// Wrong password — should not succeed
+	body := new(bytes.Buffer)
+	body.Write([]byte(`{"user":"reef-pi", "password":"wrongpassword"}`))
+	req := httptest.NewRequest("POST", "/sign_in", body)
+	rr := httptest.NewRecorder()
+	tr.Router.ServeHTTP(rr, req)
+	if rr.Code == 200 {
+		t.Error("Sign-in with wrong password should not return 200")
+	}
+}
+
+func TestSignInEmptyBody(t *testing.T) {
+	dbPath := "auth-signin-empty-test.db"
+	os.Remove(dbPath)
+	store, err := storage.NewStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { store.Close(); os.Remove(dbPath) }()
+	store.CreateBucket("reef-pi")
+	store.Update("reef-pi", "credentials", Credentials{User: "reef-pi", Password: "reef-pi"})
+	a, err := NewAuth("reef-pi", store)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tr := NewTestRouter()
+	tr.Router.HandleFunc("/sign_in", a.SignIn).Methods("POST")
+
+	// No body should return 400
+	req := httptest.NewRequest("POST", "/sign_in", nil)
+	rr := httptest.NewRecorder()
+	tr.Router.ServeHTTP(rr, req)
+	if rr.Code != 400 {
+		t.Errorf("Sign-in with nil body should return 400, got %d", rr.Code)
+	}
+}
+
+func TestAuth(t *testing.T) {
+	dbPath := "auth-test.db"
+	os.Remove(dbPath)
+	store, err := storage.NewStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(dbPath)
 	creds := Credentials{
 		User:     "reef-pi",
 		Password: "reef-pi",
@@ -55,4 +168,5 @@ func TestAuth(t *testing.T) {
 	if err := tr.Do("GET", "/sign_in", body, nil); err != nil {
 		t.Error("Failed to sign in after change credentials:", err)
 	}
+	store.Close()
 }

--- a/controller/utils/calibration_test.go
+++ b/controller/utils/calibration_test.go
@@ -34,3 +34,42 @@ func TestCalibration(t *testing.T) {
 		t.Error("Expected 38.9, found:", c1.Calibrate(37))
 	}
 }
+
+func TestCalibratorFactoryErrors(t *testing.T) {
+	// Unknown type
+	_, err := CalibratorFactory(CalibrationConfiguration{Type: 99})
+	if err == nil {
+		t.Error("Expected error for unknown calibration type")
+	}
+
+	// OnePoint with wrong measurement count
+	_, err = CalibratorFactory(CalibrationConfiguration{
+		Type:         OnePointCalibration,
+		Measurements: []Measurement{{}, {}},
+	})
+	if err == nil {
+		t.Error("Expected error for OnePoint with 2 measurements")
+	}
+
+	// TwoPoint with wrong measurement count
+	_, err = CalibratorFactory(CalibrationConfiguration{
+		Type:         TwoPointCalibration,
+		Measurements: []Measurement{{}},
+	})
+	if err == nil {
+		t.Error("Expected error for TwoPoint with 1 measurement")
+	}
+
+	// TwoPoint where m1.Expected >= m2.Expected (exercises minMax swap branch)
+	c, err := CalibratorFactory(CalibrationConfiguration{
+		Type: TwoPointCalibration,
+		Measurements: []Measurement{
+			{Actual: 96.0, Expected: 100},
+			{Actual: -0.5, Expected: 0.01},
+		},
+	})
+	if err != nil {
+		t.Error("Unexpected error:", err)
+	}
+	_ = c.Calibrate(50)
+}

--- a/controller/utils/doc_test.go
+++ b/controller/utils/doc_test.go
@@ -1,0 +1,39 @@
+package utils
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func TestAPIDocAndSummarize(t *testing.T) {
+	r := mux.NewRouter()
+	noop := func(w http.ResponseWriter, r *http.Request) {}
+	route := r.HandleFunc("/api/test", noop).Methods("GET")
+
+	type reqBody struct{ Name string }
+	type respBody struct{ ID string }
+
+	// First call: registers the doc entry
+	APIDoc(route, &reqBody{}, &respBody{})
+	// Second call: same path+method — should skip (already registered)
+	APIDoc(route, &reqBody{}, &respBody{})
+
+	// SummarizeAPI writes api.txt; clean it up afterwards
+	defer os.Remove("api.txt")
+	SummarizeAPI()
+
+	if _, err := os.Stat("api.txt"); os.IsNotExist(err) {
+		t.Error("Expected api.txt to be created by SummarizeAPI")
+	}
+}
+
+func TestAPIDocRouteWithNoMethods(t *testing.T) {
+	r := mux.NewRouter()
+	noop := func(w http.ResponseWriter, r *http.Request) {}
+	// A route with no explicit methods — GetMethods returns an error, APIDoc should handle gracefully
+	route := r.HandleFunc("/api/nomethod", noop)
+	APIDoc(route, nil, nil)
+}

--- a/controller/utils/http_json_test.go
+++ b/controller/utils/http_json_test.go
@@ -58,6 +58,19 @@ func TestJSONResponses(t *testing.T) {
 	JSONDeleteResponse(func(_ string) error { return fmt.Errorf("") }, resp, req)
 }
 
+func TestJSONResponseWithStatus(t *testing.T) {
+	req, err := http.NewRequest("GET", "/api/test", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatal("Failed to create http request. Error:", err)
+	}
+	rr := httptest.NewRecorder()
+	payload := map[string]string{"key": "value"}
+	JSONResponseWithStatus(http.StatusCreated, payload, rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Errorf("Expected status %d, got %d", http.StatusCreated, rr.Code)
+	}
+}
+
 type testDoer struct{}
 
 func (t *testDoer) Do(_ func(interface{})) {}

--- a/controller/utils/number_test.go
+++ b/controller/utils/number_test.go
@@ -7,3 +7,15 @@ func TestTwoDecimal(t *testing.T) {
 		t.Error("Expected 1.23, found", rounded)
 	}
 }
+
+func TestFormatFloat(t *testing.T) {
+	if s := FormatFloat(3.14); s != "3.14" {
+		t.Errorf("Expected '3.14', got '%s'", s)
+	}
+	if s := FormatFloat(0); s != "0" {
+		t.Errorf("Expected '0', got '%s'", s)
+	}
+	if s := FormatFloat(1.0); s != "1" {
+		t.Errorf("Expected '1', got '%s'", s)
+	}
+}

--- a/controller/utils/system_metrics_test.go
+++ b/controller/utils/system_metrics_test.go
@@ -1,0 +1,18 @@
+//go:build !windows
+// +build !windows
+
+package utils
+
+import (
+	"testing"
+)
+
+func TestAvgCpuLoad(t *testing.T) {
+	stat, err := AvgCpuLoad()
+	if err != nil {
+		t.Skip("AvgCpuLoad not available in this environment:", err)
+	}
+	if stat == nil {
+		t.Error("Expected non-nil AvgStat")
+	}
+}


### PR DESCRIPTION
## Summary
- Extend `auth_test.go` with default credentials, authenticate middleware, sign-in failure and empty-body paths
- Extend `calibration_test.go` to cover all error branches and the minMax swap path (100% coverage)
- Add `doc_test.go` covering APIDoc registration (first call, duplicate, no-methods) and SummarizeAPI file creation
- Add `system_metrics_test.go` covering AvgCpuLoad (skipped if unavailable)

## Test plan
- [ ] `go test ./controller/utils/...` passes at ≥73%
- [ ] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)