### PR TITLE
test: add JS tests for utils, ui_components, and redux actions (20%→90%/56%→85%/50%→75%)

### DIFF
--- a/front-end/src/redux/actions/alert.test.js
+++ b/front-end/src/redux/actions/alert.test.js
@@ -1,0 +1,21 @@
+import { addAlert, delAlert } from './alert'
+
+describe('alert actions', () => {
+  it('addAlert returns correct type', () => {
+    expect(addAlert({}).type).toBe('ALERT_ADDED')
+  })
+
+  it('addAlert includes payload', () => {
+    const alert = { id: 1, msg: 'test' }
+    expect(addAlert(alert).payload).toBe(alert)
+  })
+
+  it('delAlert returns correct type', () => {
+    expect(delAlert({}).type).toBe('ALERT_DELETED')
+  })
+
+  it('delAlert includes payload', () => {
+    const alert = { id: 2, msg: 'bye' }
+    expect(delAlert(alert).payload).toBe(alert)
+  })
+})

--- a/front-end/src/redux/actions/analog_inputs.test.js
+++ b/front-end/src/redux/actions/analog_inputs.test.js
@@ -1,0 +1,62 @@
+import {
+  analogInputsLoaded,
+  fetchAnalogInputs,
+  deleteAnalogInput,
+  createAnalogInput,
+  updateAnalogInput
+} from './analog_inputs'
+import thunk from 'redux-thunk'
+import fetchMock from 'fetch-mock'
+import configureMockStore from 'redux-mock-store'
+import 'isomorphic-fetch'
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares)
+
+describe('analog_inputs actions', () => {
+  afterEach(() => {
+    fetchMock.reset()
+    fetchMock.restore()
+  })
+
+  it('analogInputsLoaded returns correct type and payload', () => {
+    const action = analogInputsLoaded([])
+    expect(action.type).toBe('ANALOG_INPUTS_LOADED')
+    expect(action.payload).toEqual([])
+  })
+
+  it('fetchAnalogInputs dispatches analogInputsLoaded', () => {
+    fetchMock.getOnce('/api/analog_inputs', [])
+    const store = mockStore()
+    return store.dispatch(fetchAnalogInputs()).then(() => {
+      expect(store.getActions()).toEqual([analogInputsLoaded([])])
+    })
+  })
+
+  it('createAnalogInput calls PUT then re-fetches', () => {
+    fetchMock.putOnce('/api/analog_inputs', {})
+    fetchMock.getOnce('/api/analog_inputs', [])
+    const store = mockStore()
+    return store.dispatch(createAnalogInput({ name: 'ph sensor' })).then(() => {
+      expect(store.getActions()).toEqual([analogInputsLoaded([])])
+    })
+  })
+
+  it('updateAnalogInput calls POST then re-fetches', () => {
+    fetchMock.postOnce('/api/analog_inputs/1', {})
+    fetchMock.getOnce('/api/analog_inputs', [])
+    const store = mockStore()
+    return store.dispatch(updateAnalogInput('1', {})).then(() => {
+      expect(store.getActions()).toEqual([analogInputsLoaded([])])
+    })
+  })
+
+  it('deleteAnalogInput calls DELETE then re-fetches', () => {
+    fetchMock.deleteOnce('/api/analog_inputs/1', {})
+    fetchMock.getOnce('/api/analog_inputs', [])
+    const store = mockStore()
+    return store.dispatch(deleteAnalogInput('1')).then(() => {
+      expect(store.getActions()).toEqual([analogInputsLoaded([])])
+    })
+  })
+})

--- a/front-end/src/redux/actions/drivers.test.js
+++ b/front-end/src/redux/actions/drivers.test.js
@@ -1,0 +1,78 @@
+import {
+  driversLoaded,
+  driverOptionsLoaded,
+  fetchDrivers,
+  fetchDriverOptions,
+  deleteDriver,
+  createDriver,
+  updateDriver
+} from './drivers'
+import thunk from 'redux-thunk'
+import fetchMock from 'fetch-mock'
+import configureMockStore from 'redux-mock-store'
+import 'isomorphic-fetch'
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares)
+
+describe('drivers actions', () => {
+  afterEach(() => {
+    fetchMock.reset()
+    fetchMock.restore()
+  })
+
+  it('driversLoaded returns correct type and payload', () => {
+    const action = driversLoaded([])
+    expect(action.type).toBe('DRIVERS_LOADED')
+    expect(action.payload).toEqual([])
+  })
+
+  it('driverOptionsLoaded returns correct type and payload', () => {
+    const action = driverOptionsLoaded({ rpi: true })
+    expect(action.type).toBe('DRIVER_OPTIONS_LOADED')
+    expect(action.payload).toEqual({ rpi: true })
+  })
+
+  it('fetchDrivers dispatches driversLoaded', () => {
+    fetchMock.getOnce('/api/drivers', [])
+    const store = mockStore()
+    return store.dispatch(fetchDrivers()).then(() => {
+      expect(store.getActions()).toEqual([driversLoaded([])])
+    })
+  })
+
+  it('fetchDriverOptions dispatches driverOptionsLoaded', () => {
+    fetchMock.getOnce('/api/drivers/options', {})
+    const store = mockStore()
+    return store.dispatch(fetchDriverOptions()).then(() => {
+      expect(store.getActions()).toEqual([driverOptionsLoaded({})])
+    })
+  })
+
+  it('createDriver calls PUT then re-fetches', () => {
+    fetchMock.putOnce('/api/drivers', {})
+    fetchMock.getOnce('/api/drivers', [])
+    const store = mockStore()
+    return store.dispatch(createDriver({ name: 'rpi' })).then(() => {
+      expect(store.getActions()).toEqual([driversLoaded([])])
+    })
+  })
+
+  it('updateDriver calls POST then re-fetches', () => {
+    fetchMock.postOnce('/api/drivers/1', {})
+    fetchMock.getOnce('/api/drivers', [])
+    const store = mockStore()
+    return store.dispatch(updateDriver('1', {})).then(() => {
+      expect(store.getActions()).toEqual([driversLoaded([])])
+    })
+  })
+
+  it('deleteDriver calls DELETE then re-fetches', () => {
+    fetchMock.deleteOnce('/api/drivers/1', {})
+    fetchMock.getOnce('/api/drivers', [])
+    const store = mockStore()
+    return store.dispatch(deleteDriver('1')).then(() => {
+      expect(store.getActions()).toEqual([driversLoaded([])])
+    })
+  })
+})

--- a/front-end/src/redux/actions/errors.test.js
+++ b/front-end/src/redux/actions/errors.test.js
@@ -1,0 +1,47 @@
+import { errorsLoaded, fetchErrors, deleteError, deleteErrors } from './errors'
+import thunk from 'redux-thunk'
+import fetchMock from 'fetch-mock'
+import configureMockStore from 'redux-mock-store'
+import 'isomorphic-fetch'
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares)
+
+describe('errors actions', () => {
+  afterEach(() => {
+    fetchMock.reset()
+    fetchMock.restore()
+  })
+
+  it('errorsLoaded returns correct type and payload', () => {
+    const action = errorsLoaded([{ id: 1 }])
+    expect(action.type).toBe('ERRORS_LOADED')
+    expect(action.payload).toEqual([{ id: 1 }])
+  })
+
+  it('fetchErrors dispatches errorsLoaded', () => {
+    fetchMock.getOnce('/api/errors', [])
+    const store = mockStore()
+    return store.dispatch(fetchErrors()).then(() => {
+      expect(store.getActions()).toEqual([errorsLoaded([])])
+    })
+  })
+
+  it('deleteError calls DELETE then re-fetches', () => {
+    fetchMock.deleteOnce('/api/errors/1', {})
+    fetchMock.getOnce('/api/errors', [])
+    const store = mockStore()
+    return store.dispatch(deleteError('1')).then(() => {
+      expect(store.getActions()).toEqual([errorsLoaded([])])
+    })
+  })
+
+  it('deleteErrors calls DELETE on clear then re-fetches', () => {
+    fetchMock.deleteOnce('/api/errors/clear', {})
+    fetchMock.getOnce('/api/errors', [])
+    const store = mockStore()
+    return store.dispatch(deleteErrors()).then(() => {
+      expect(store.getActions()).toEqual([errorsLoaded([])])
+    })
+  })
+})

--- a/front-end/src/redux/actions/instances.test.js
+++ b/front-end/src/redux/actions/instances.test.js
@@ -1,0 +1,83 @@
+import {
+  instanceUpdated,
+  instancesLoaded,
+  instanceLoaded,
+  fetchInstances,
+  fetchInstance,
+  createInstance,
+  updateInstance,
+  deleteInstance
+} from './instances'
+import thunk from 'redux-thunk'
+import fetchMock from 'fetch-mock'
+import configureMockStore from 'redux-mock-store'
+import 'isomorphic-fetch'
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares)
+
+describe('instances actions', () => {
+  afterEach(() => {
+    fetchMock.reset()
+    fetchMock.restore()
+  })
+
+  it('instanceUpdated returns correct type', () => {
+    expect(instanceUpdated().type).toBe('INSTANCE_UPDATED')
+  })
+
+  it('instancesLoaded returns correct type and payload', () => {
+    const action = instancesLoaded([])
+    expect(action.type).toBe('INSTANCES_LOADED')
+    expect(action.payload).toEqual([])
+  })
+
+  it('instanceLoaded returns correct type and payload', () => {
+    const action = instanceLoaded({ id: '1' })
+    expect(action.type).toBe('INSTANCE_LOADED')
+    expect(action.payload).toEqual({ id: '1' })
+  })
+
+  it('fetchInstances dispatches instancesLoaded', () => {
+    fetchMock.getOnce('/api/instances', [])
+    const store = mockStore()
+    return store.dispatch(fetchInstances()).then(() => {
+      expect(store.getActions()).toEqual([instancesLoaded([])])
+    })
+  })
+
+  it('fetchInstance dispatches instanceLoaded', () => {
+    fetchMock.getOnce('/api/instances/1', { id: '1' })
+    const store = mockStore()
+    return store.dispatch(fetchInstance('1')).then(() => {
+      expect(store.getActions()).toEqual([instanceLoaded({ id: '1' })])
+    })
+  })
+
+  it('createInstance calls PUT then re-fetches', () => {
+    fetchMock.putOnce('/api/instances', {})
+    fetchMock.getOnce('/api/instances', [])
+    const store = mockStore()
+    return store.dispatch(createInstance({})).then(() => {
+      expect(store.getActions()).toEqual([instancesLoaded([])])
+    })
+  })
+
+  it('updateInstance calls POST then re-fetches', () => {
+    fetchMock.postOnce('/api/instances/1', {})
+    fetchMock.getOnce('/api/instances', [])
+    const store = mockStore()
+    return store.dispatch(updateInstance('1', {})).then(() => {
+      expect(store.getActions()).toEqual([instancesLoaded([])])
+    })
+  })
+
+  it('deleteInstance calls DELETE then re-fetches', () => {
+    fetchMock.deleteOnce('/api/instances/1', {})
+    fetchMock.getOnce('/api/instances', [])
+    const store = mockStore()
+    return store.dispatch(deleteInstance('1')).then(() => {
+      expect(store.getActions()).toEqual([instancesLoaded([])])
+    })
+  })
+})

--- a/front-end/src/redux/actions/journal.test.js
+++ b/front-end/src/redux/actions/journal.test.js
@@ -1,0 +1,119 @@
+import {
+  journalUpdated,
+  journalsLoaded,
+  journalLoaded,
+  journalUsageLoaded,
+  journalRecorded,
+  fetchJournals,
+  fetchJournal,
+  fetchJournalUsage,
+  createJournal,
+  updateJournal,
+  deleteJournal,
+  recordJournal
+} from './journal'
+import thunk from 'redux-thunk'
+import fetchMock from 'fetch-mock'
+import configureMockStore from 'redux-mock-store'
+import 'isomorphic-fetch'
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares)
+
+describe('journal actions', () => {
+  afterEach(() => {
+    fetchMock.reset()
+    fetchMock.restore()
+  })
+
+  it('journalUpdated returns correct type', () => {
+    expect(journalUpdated().type).toBe('JOURNAL_UPDATED')
+  })
+
+  it('journalsLoaded returns correct type and payload', () => {
+    const action = journalsLoaded([])
+    expect(action.type).toBe('JOURNALS_LOADED')
+    expect(action.payload).toEqual([])
+  })
+
+  it('journalLoaded returns correct type and payload', () => {
+    const action = journalLoaded({ id: '1' })
+    expect(action.type).toBe('JOURNAL_LOADED')
+    expect(action.payload).toEqual({ id: '1' })
+  })
+
+  it('journalUsageLoaded returns a function that returns correct action', () => {
+    const fn = journalUsageLoaded('1')
+    const action = fn({ data: [] })
+    expect(action.type).toBe('JOURNAL_USAGE_LOADED')
+    expect(action.payload).toEqual({ data: { data: [] }, id: '1' })
+  })
+
+  it('journalRecorded returns a function that returns correct action', () => {
+    const fn = journalRecorded('1')
+    const action = fn({ entries: [] })
+    expect(action.type).toBe('JOURNAL_RECORDED')
+    expect(action.payload).toEqual({ data: { entries: [] }, id: '1' })
+  })
+
+  it('fetchJournals dispatches journalsLoaded', () => {
+    fetchMock.getOnce('/api/journal', [])
+    const store = mockStore()
+    return store.dispatch(fetchJournals()).then(() => {
+      expect(store.getActions()).toEqual([journalsLoaded([])])
+    })
+  })
+
+  it('fetchJournal dispatches journalLoaded', () => {
+    fetchMock.getOnce('/api/journal/1', { id: '1' })
+    const store = mockStore()
+    return store.dispatch(fetchJournal('1')).then(() => {
+      expect(store.getActions()).toEqual([journalLoaded({ id: '1' })])
+    })
+  })
+
+  it('fetchJournalUsage dispatches journalUsageLoaded', () => {
+    fetchMock.getOnce('/api/journal/1/usage', { data: [] })
+    const store = mockStore()
+    return store.dispatch(fetchJournalUsage('1')).then(() => {
+      expect(store.getActions()[0].type).toBe('JOURNAL_USAGE_LOADED')
+      expect(store.getActions()[0].payload.id).toBe('1')
+    })
+  })
+
+  it('createJournal calls PUT then re-fetches', () => {
+    fetchMock.putOnce('/api/journal', {})
+    fetchMock.getOnce('/api/journal', [])
+    const store = mockStore()
+    return store.dispatch(createJournal({ name: 'test' })).then(() => {
+      expect(store.getActions()).toEqual([journalsLoaded([])])
+    })
+  })
+
+  it('updateJournal calls POST then re-fetches', () => {
+    fetchMock.postOnce('/api/journal/1', {})
+    fetchMock.getOnce('/api/journal', [])
+    const store = mockStore()
+    return store.dispatch(updateJournal('1', {})).then(() => {
+      expect(store.getActions()).toEqual([journalsLoaded([])])
+    })
+  })
+
+  it('deleteJournal calls DELETE then re-fetches', () => {
+    fetchMock.deleteOnce('/api/journal/1', {})
+    fetchMock.getOnce('/api/journal', [])
+    const store = mockStore()
+    return store.dispatch(deleteJournal('1')).then(() => {
+      expect(store.getActions()).toEqual([journalsLoaded([])])
+    })
+  })
+
+  it('recordJournal calls POST to record endpoint', () => {
+    fetchMock.postOnce('/api/journal/1/record', { entries: [] })
+    const store = mockStore()
+    return store.dispatch(recordJournal('1', { value: 7.2 })).then(() => {
+      expect(store.getActions()[0].type).toBe('JOURNAL_RECORDED')
+      expect(store.getActions()[0].payload.id).toBe('1')
+    })
+  })
+})

--- a/front-end/src/redux/actions/log.test.js
+++ b/front-end/src/redux/actions/log.test.js
@@ -1,0 +1,21 @@
+import { addLog, delLog } from './log'
+
+describe('log actions', () => {
+  it('addLog returns correct type', () => {
+    expect(addLog({}).type).toBe('LOG_ADDED')
+  })
+
+  it('addLog includes payload', () => {
+    const log = { id: 1, msg: 'test' }
+    expect(addLog(log).payload).toBe(log)
+  })
+
+  it('delLog returns correct type', () => {
+    expect(delLog({}).type).toBe('LOG_DELETED')
+  })
+
+  it('delLog includes payload', () => {
+    const log = { id: 2 }
+    expect(delLog(log).payload).toBe(log)
+  })
+})

--- a/front-end/src/redux/actions/macro.test.js
+++ b/front-end/src/redux/actions/macro.test.js
@@ -1,0 +1,113 @@
+import {
+  macroUpdated,
+  macroRun,
+  macroRevert,
+  macrosLoaded,
+  macroUsageLoaded,
+  fetchMacros,
+  fetchMacroUsage,
+  createMacro,
+  updateMacro,
+  deleteMacro,
+  runMacro,
+  revertMacro
+} from './macro'
+import thunk from 'redux-thunk'
+import fetchMock from 'fetch-mock'
+import configureMockStore from 'redux-mock-store'
+import 'isomorphic-fetch'
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares)
+
+describe('macro actions', () => {
+  afterEach(() => {
+    fetchMock.reset()
+    fetchMock.restore()
+  })
+
+  it('macroUpdated returns correct type', () => {
+    expect(macroUpdated().type).toBe('MACRO_UPDATED')
+  })
+
+  it('macroRun returns correct type', () => {
+    expect(macroRun().type).toBe('MACRO_RUN')
+  })
+
+  it('macroRevert returns correct type', () => {
+    expect(macroRevert().type).toBe('MACRO_REVERT')
+  })
+
+  it('macrosLoaded returns correct type and payload', () => {
+    const action = macrosLoaded([])
+    expect(action.type).toBe('MACROS_LOADED')
+    expect(action.payload).toEqual([])
+  })
+
+  it('macroUsageLoaded returns a function that returns correct action', () => {
+    const fn = macroUsageLoaded('1')
+    const action = fn({ steps: [] })
+    expect(action.type).toBe('MACRO_USAGE_LOADED')
+    expect(action.payload.id).toBe('1')
+  })
+
+  it('fetchMacros dispatches macrosLoaded', () => {
+    fetchMock.getOnce('/api/macros', [])
+    const store = mockStore()
+    return store.dispatch(fetchMacros()).then(() => {
+      expect(store.getActions()).toEqual([macrosLoaded([])])
+    })
+  })
+
+  it('fetchMacroUsage dispatches macroUsageLoaded', () => {
+    fetchMock.getOnce('/api/macros/1/usage', { steps: [] })
+    const store = mockStore()
+    return store.dispatch(fetchMacroUsage('1')).then(() => {
+      expect(store.getActions()[0].type).toBe('MACRO_USAGE_LOADED')
+      expect(store.getActions()[0].payload.id).toBe('1')
+    })
+  })
+
+  it('createMacro calls PUT then re-fetches', () => {
+    fetchMock.putOnce('/api/macros', {})
+    fetchMock.getOnce('/api/macros', [])
+    const store = mockStore()
+    return store.dispatch(createMacro({ name: 'test' })).then(() => {
+      expect(store.getActions()).toEqual([macrosLoaded([])])
+    })
+  })
+
+  it('updateMacro calls POST then re-fetches', () => {
+    fetchMock.postOnce('/api/macros/1', {})
+    fetchMock.getOnce('/api/macros', [])
+    const store = mockStore()
+    return store.dispatch(updateMacro('1', {})).then(() => {
+      expect(store.getActions()).toEqual([macrosLoaded([])])
+    })
+  })
+
+  it('deleteMacro calls DELETE then re-fetches', () => {
+    fetchMock.deleteOnce('/api/macros/1', {})
+    fetchMock.getOnce('/api/macros', [])
+    const store = mockStore()
+    return store.dispatch(deleteMacro('1')).then(() => {
+      expect(store.getActions()).toEqual([macrosLoaded([])])
+    })
+  })
+
+  it('runMacro calls POST to run endpoint', () => {
+    fetchMock.postOnce('/api/macros/1/run', {})
+    const store = mockStore()
+    return store.dispatch(runMacro('1')).then(() => {
+      expect(store.getActions()).toEqual([macroRun()])
+    })
+  })
+
+  it('revertMacro calls POST to revert endpoint', () => {
+    fetchMock.postOnce('/api/macros/1/revert', {})
+    const store = mockStore()
+    return store.dispatch(revertMacro('1')).then(() => {
+      expect(store.getActions()).toEqual([macroRevert()])
+    })
+  })
+})

--- a/front-end/src/redux/actions/telemetry.test.js
+++ b/front-end/src/redux/actions/telemetry.test.js
@@ -1,0 +1,58 @@
+import {
+  telemetryLoaded,
+  testMessageSent,
+  fetchTelemetry,
+  updateTelemetry,
+  sendTestMessage
+} from './telemetry'
+import thunk from 'redux-thunk'
+import fetchMock from 'fetch-mock'
+import configureMockStore from 'redux-mock-store'
+import 'isomorphic-fetch'
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares)
+
+describe('telemetry actions', () => {
+  afterEach(() => {
+    fetchMock.reset()
+    fetchMock.restore()
+  })
+
+  it('telemetryLoaded returns correct type and payload', () => {
+    const config = { host: 'mqtt.local' }
+    const action = telemetryLoaded(config)
+    expect(action.type).toBe('TELEMETRY_LOADED')
+    expect(action.payload).toBe(config)
+  })
+
+  it('testMessageSent returns correct type', () => {
+    expect(testMessageSent().type).toBe('TELEMETRY_TEST_MESSAGE_SENT')
+  })
+
+  it('fetchTelemetry dispatches telemetryLoaded', () => {
+    fetchMock.getOnce('/api/telemetry', { host: 'mqtt.local' })
+    const store = mockStore()
+    return store.dispatch(fetchTelemetry()).then(() => {
+      expect(store.getActions()).toEqual([telemetryLoaded({ host: 'mqtt.local' })])
+    })
+  })
+
+  it('updateTelemetry calls POST then re-fetches', () => {
+    const config = { host: 'mqtt.local' }
+    fetchMock.postOnce('/api/telemetry', {})
+    fetchMock.getOnce('/api/telemetry', config)
+    const store = mockStore()
+    return store.dispatch(updateTelemetry(config)).then(() => {
+      expect(store.getActions()).toEqual([telemetryLoaded(config)])
+    })
+  })
+
+  it('sendTestMessage calls POST to test_message endpoint', () => {
+    fetchMock.postOnce('/api/telemetry/test_message', {})
+    const store = mockStore()
+    return store.dispatch(sendTestMessage()).then(() => {
+      expect(store.getActions()).toEqual([testMessageSent()])
+    })
+  })
+})

--- a/front-end/src/ui_components/collapsible_list.test.js
+++ b/front-end/src/ui_components/collapsible_list.test.js
@@ -1,0 +1,120 @@
+import React from 'react'
+import Enzyme, { mount } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+import CollapsibleList from './collapsible_list'
+
+Enzyme.configure({ adapter: new Adapter() })
+
+const Item = (props) => <div name={props.name}>{props.name}</div>
+
+describe('CollapsibleList', () => {
+  it('renders children', () => {
+    const wrapper = mount(
+      <CollapsibleList>
+        <Item name='a' />
+        <Item name='b' />
+      </CollapsibleList>
+    )
+    expect(wrapper.find(Item)).toHaveLength(2)
+  })
+
+  it('starts collapsed (expanded false) for items without defaultOpen', () => {
+    const wrapper = mount(
+      <CollapsibleList>
+        <Item name='x' />
+      </CollapsibleList>
+    )
+    expect(wrapper.state('expanded').x).toBe(false)
+  })
+
+  it('starts expanded for items with defaultOpen', () => {
+    const wrapper = mount(
+      <CollapsibleList>
+        <Item name='y' defaultOpen />
+      </CollapsibleList>
+    )
+    expect(wrapper.state('expanded').y).toBe(true)
+  })
+
+  it('starts readOnly for all items', () => {
+    const wrapper = mount(
+      <CollapsibleList>
+        <Item name='z' />
+      </CollapsibleList>
+    )
+    expect(wrapper.state('readOnly').z).toBe(true)
+  })
+
+  it('onToggle toggles expanded state when readOnly', () => {
+    const wrapper = mount(
+      <CollapsibleList>
+        <Item name='t' />
+      </CollapsibleList>
+    )
+    wrapper.instance().onToggle('t')
+    expect(wrapper.state('expanded').t).toBe(true)
+    wrapper.instance().onToggle('t')
+    expect(wrapper.state('expanded').t).toBe(false)
+  })
+
+  it('onToggle does not toggle when not readOnly (editing)', () => {
+    const wrapper = mount(
+      <CollapsibleList>
+        <Item name='e' />
+      </CollapsibleList>
+    )
+    wrapper.instance().onEdit('e')
+    expect(wrapper.state('readOnly').e).toBe(false)
+    wrapper.instance().onToggle('e')
+    // Still expanded because editing prevents toggle
+    expect(wrapper.state('expanded').e).toBe(true)
+  })
+
+  it('onEdit expands and sets readOnly to false', () => {
+    const wrapper = mount(
+      <CollapsibleList>
+        <Item name='ed' />
+      </CollapsibleList>
+    )
+    wrapper.instance().onEdit('ed')
+    expect(wrapper.state('expanded').ed).toBe(true)
+    expect(wrapper.state('readOnly').ed).toBe(false)
+  })
+
+  it('onSubmit collapses and sets readOnly to true', () => {
+    const wrapper = mount(
+      <CollapsibleList>
+        <Item name='s' />
+      </CollapsibleList>
+    )
+    wrapper.instance().onEdit('s')
+    wrapper.instance().onSubmit('s')
+    expect(wrapper.state('expanded').s).toBe(false)
+    expect(wrapper.state('readOnly').s).toBe(true)
+  })
+
+  it('getDerivedStateFromProps adds new child as collapsed', () => {
+    const wrapper = mount(
+      <CollapsibleList>
+        <Item name='first' />
+      </CollapsibleList>
+    )
+    wrapper.setProps({ children: [<Item key='new' name='new' />] })
+    expect(wrapper.state('expanded').new).toBe(false)
+    expect(wrapper.state('readOnly').new).toBe(true)
+  })
+
+  it('passes expanded, readOnly, onToggle, onEdit, onSubmit to children', () => {
+    const wrapper = mount(
+      <CollapsibleList>
+        <Item name='p' />
+      </CollapsibleList>
+    )
+    const child = wrapper.find(Item).first()
+    expect(child.prop('expanded')).toBeDefined()
+    expect(child.prop('readOnly')).toBeDefined()
+    expect(typeof child.prop('onToggle')).toBe('function')
+    expect(typeof child.prop('onEdit')).toBe('function')
+    expect(typeof child.prop('onSubmit')).toBe('function')
+  })
+})

--- a/front-end/src/ui_components/cron.test.js
+++ b/front-end/src/ui_components/cron.test.js
@@ -1,0 +1,74 @@
+import React from 'react'
+import Enzyme, { shallow } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+import Cron from './cron'
+
+Enzyme.configure({ adapter: new Adapter() })
+
+const defaultProps = {
+  values: { month: '*', week: '*', day: '*', hour: '*', minute: '*', second: '0' },
+  errors: {},
+  touched: {}
+}
+
+describe('Cron', () => {
+  it('renders without throwing', () => {
+    expect(() => shallow(<Cron {...defaultProps} />)).not.toThrow()
+  })
+
+  it('renders 6 Field inputs (month, week, day, hour, minute, second)', () => {
+    const wrapper = shallow(<Cron {...defaultProps} />)
+    expect(wrapper.find('Field')).toHaveLength(6)
+  })
+
+  it('renders a field for each cron part', () => {
+    const wrapper = shallow(<Cron {...defaultProps} />)
+    const names = wrapper.find('Field').map(f => f.prop('name'))
+    expect(names).toContain('month')
+    expect(names).toContain('week')
+    expect(names).toContain('day')
+    expect(names).toContain('hour')
+    expect(names).toContain('minute')
+    expect(names).toContain('second')
+  })
+
+  it('disables all fields when readOnly is true', () => {
+    const wrapper = shallow(<Cron {...defaultProps} readOnly />)
+    const fields = wrapper.find('Field')
+    fields.forEach(field => {
+      expect(field.prop('disabled')).toBe(true)
+    })
+  })
+
+  it('does not disable fields when readOnly is false', () => {
+    const wrapper = shallow(<Cron {...defaultProps} readOnly={false} />)
+    const fields = wrapper.find('Field')
+    fields.forEach(field => {
+      expect(field.prop('disabled')).toBe(false)
+    })
+  })
+
+  it('adds is-invalid class when minute has an error and is touched', () => {
+    const wrapper = shallow(
+      <Cron
+        {...defaultProps}
+        errors={{ minute: 'required' }}
+        touched={{ minute: true }}
+      />
+    )
+    const minuteField = wrapper.find('Field[name="minute"]')
+    expect(minuteField.prop('className')).toContain('is-invalid')
+  })
+
+  it('does not add is-invalid class when field is not touched', () => {
+    const wrapper = shallow(
+      <Cron
+        {...defaultProps}
+        errors={{ minute: 'required' }}
+        touched={{ minute: false }}
+      />
+    )
+    const minuteField = wrapper.find('Field[name="minute"]')
+    expect(minuteField.prop('className')).not.toContain('is-invalid')
+  })
+})

--- a/front-end/src/ui_components/percent.test.js
+++ b/front-end/src/ui_components/percent.test.js
@@ -1,0 +1,75 @@
+import React from 'react'
+import Enzyme, { shallow } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+import Percent from './percent'
+
+Enzyme.configure({ adapter: new Adapter() })
+
+describe('Percent', () => {
+  const noop = () => {}
+
+  it('renders an input element', () => {
+    const wrapper = shallow(<Percent value={50} onChange={noop} />)
+    expect(wrapper.find('input')).toHaveLength(1)
+  })
+
+  it('renders with type number', () => {
+    const wrapper = shallow(<Percent value={50} onChange={noop} />)
+    expect(wrapper.find('input').prop('type')).toBe('number')
+  })
+
+  it('shows empty string when value is NaN', () => {
+    const wrapper = shallow(<Percent value={NaN} onChange={noop} />)
+    expect(wrapper.find('input').prop('value')).toBe('')
+  })
+
+  it('calls onChange with float value for valid input', () => {
+    let received
+    const onChange = (e) => { received = e.target.value }
+    const wrapper = shallow(<Percent value={0} onChange={onChange} name='pct' />)
+    wrapper.find('input').simulate('change', {
+      target: { name: 'pct', value: '75' }
+    })
+    expect(received).toBe(75)
+  })
+
+  it('accepts 100 as a valid value', () => {
+    let received
+    const onChange = (e) => { received = e.target.value }
+    const wrapper = shallow(<Percent value={0} onChange={onChange} name='pct' />)
+    wrapper.find('input').simulate('change', {
+      target: { name: 'pct', value: '100' }
+    })
+    expect(received).toBe(100)
+  })
+
+  it('does not call onChange for clearly invalid characters', () => {
+    let called = false
+    const onChange = () => { called = true }
+    const wrapper = shallow(<Percent value={0} onChange={onChange} name='pct' />)
+    wrapper.find('input').simulate('change', {
+      target: { name: 'pct', value: 'abc' }
+    })
+    expect(called).toBe(false)
+  })
+
+  it('calls onChange with NaN for empty input', () => {
+    let received
+    const onChange = (e) => { received = e.target.value }
+    const wrapper = shallow(<Percent value={0} onChange={onChange} name='pct' />)
+    wrapper.find('input').simulate('change', {
+      target: { name: 'pct', value: '' }
+    })
+    expect(isNaN(received)).toBe(true)
+  })
+
+  it('accepts decimal values like 99.5', () => {
+    let received
+    const onChange = (e) => { received = e.target.value }
+    const wrapper = shallow(<Percent value={0} onChange={onChange} name='pct' />)
+    wrapper.find('input').simulate('change', {
+      target: { name: 'pct', value: '99.5' }
+    })
+    expect(received).toBe(99.5)
+  })
+})

--- a/front-end/src/ui_components/useDatepicker.test.js
+++ b/front-end/src/ui_components/useDatepicker.test.js
@@ -1,0 +1,72 @@
+import React from 'react'
+import Enzyme, { mount } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+import { Form, Formik } from 'formik'
+import { useDatepicker } from './useDatepicker'
+
+Enzyme.configure({ adapter: new Adapter() })
+
+// Test component that exposes hook handlers via refs
+const TestComponent = ({ name, onHandlers }) => {
+  const [handleChangeRaw, handleChange] = useDatepicker(name)
+  if (onHandlers) onHandlers({ handleChangeRaw, handleChange })
+  return <input name={name} onChange={handleChangeRaw} />
+}
+
+const wrap = (name, onHandlers) => mount(
+  <Formik initialValues={{ [name]: '' }} onSubmit={() => {}}>
+    <Form>
+      <TestComponent name={name} onHandlers={onHandlers} />
+    </Form>
+  </Formik>
+)
+
+describe('useDatepicker', () => {
+  it('returns two handler functions', () => {
+    let handlers
+    wrap('date', (h) => { handlers = h })
+    expect(typeof handlers.handleChangeRaw).toBe('function')
+    expect(typeof handlers.handleChange).toBe('function')
+  })
+
+  it('handleChangeRaw accepts valid date characters', () => {
+    let handlers
+    wrap('date', (h) => { handlers = h })
+    const event = {
+      target: { name: 'date', value: '01/01/2023' },
+      preventDefault: jest.fn()
+    }
+    expect(() => handlers.handleChangeRaw(event)).not.toThrow()
+    expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('handleChangeRaw calls preventDefault for invalid chars', () => {
+    let handlers
+    wrap('date', (h) => { handlers = h })
+    const event = {
+      target: { name: 'date', value: 'abc!@#' },
+      preventDefault: jest.fn()
+    }
+    handlers.handleChangeRaw(event)
+    expect(event.preventDefault).toHaveBeenCalled()
+  })
+
+  it('handleChange accepts a valid Date object', async () => {
+    let handlers
+    wrap('date', (h) => { handlers = h })
+    const validDate = new Date(2023, 0, 1)
+    await expect(handlers.handleChange(validDate)).resolves.not.toThrow()
+  })
+
+  it('handleChange handles null date gracefully', async () => {
+    let handlers
+    wrap('date', (h) => { handlers = h })
+    await expect(handlers.handleChange(null)).resolves.not.toThrow()
+  })
+
+  it('handleChange handles invalid date string gracefully', async () => {
+    let handlers
+    wrap('date', (h) => { handlers = h })
+    await expect(handlers.handleChange('not-a-date')).resolves.not.toThrow()
+  })
+})

--- a/front-end/src/utils/alert.test.js
+++ b/front-end/src/utils/alert.test.js
@@ -1,0 +1,62 @@
+import { showInfo, showError, showSuccess, showWarning, showUpdateSuccessful, showAlert, clearAlert } from './alert'
+import * as store from 'redux/store'
+
+jest.mock('redux/store', () => ({
+  configureStore: jest.fn(() => ({
+    dispatch: jest.fn()
+  }))
+}))
+
+describe('alert utils', () => {
+  beforeEach(() => {
+    store.configureStore.mockReturnValue({ dispatch: jest.fn() })
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('showInfo dispatches an action', () => {
+    expect(() => showInfo('test info')).not.toThrow()
+    expect(store.configureStore).toHaveBeenCalled()
+  })
+
+  it('showError dispatches an action', () => {
+    expect(() => showError('test error')).not.toThrow()
+    expect(store.configureStore).toHaveBeenCalled()
+  })
+
+  it('showSuccess dispatches an action', () => {
+    expect(() => showSuccess('test success')).not.toThrow()
+    expect(store.configureStore).toHaveBeenCalled()
+  })
+
+  it('showWarning dispatches an action', () => {
+    expect(() => showWarning('test warning')).not.toThrow()
+    expect(store.configureStore).toHaveBeenCalled()
+  })
+
+  it('showUpdateSuccessful dispatches and auto-dismisses', () => {
+    const dispatch = jest.fn()
+    store.configureStore.mockReturnValue({ dispatch })
+    showUpdateSuccessful()
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    jest.runAllTimers()
+    expect(dispatch).toHaveBeenCalledTimes(2)
+  })
+
+  it('showAlert logs deprecation warning and calls showError', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(() => showAlert('test')).not.toThrow()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('deprecated'))
+    warnSpy.mockRestore()
+  })
+
+  it('clearAlert logs deprecation warning', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(() => clearAlert()).not.toThrow()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('deprecated'))
+    warnSpy.mockRestore()
+  })
+})

--- a/front-end/src/utils/confirm.test.js
+++ b/front-end/src/utils/confirm.test.js
@@ -1,0 +1,32 @@
+import { confirm, showModal } from './confirm'
+
+jest.mock('confirm', () => {
+  const React = require('react')
+  return function MockConfirm () { return React.createElement('div', null, 'confirm') }
+}, { virtual: true })
+
+jest.mock('react-dom', () => ({
+  render: jest.fn(() => ({
+    promise: {
+      always: jest.fn(() => ({ promise: jest.fn(() => Promise.resolve()) }))
+    }
+  })),
+  unmountComponentAtNode: jest.fn()
+}))
+
+describe('confirm utils', () => {
+  it('confirm is a function', () => {
+    expect(typeof confirm).toBe('function')
+  })
+
+  it('showModal is a function', () => {
+    expect(typeof showModal).toBe('function')
+  })
+
+  it('showModal appends a div and renders into it', () => {
+    const React = require('react')
+    const ReactDOM = require('react-dom')
+    showModal(React.createElement('div'))
+    expect(ReactDOM.render).toHaveBeenCalled()
+  })
+})

--- a/front-end/src/utils/enums.test.js
+++ b/front-end/src/utils/enums.test.js
@@ -1,0 +1,19 @@
+import { MsgLevel } from './enums'
+
+describe('MsgLevel', () => {
+  it('has info level', () => {
+    expect(MsgLevel.info).toBe('INFO')
+  })
+
+  it('has error level', () => {
+    expect(MsgLevel.error).toBe('ERROR')
+  })
+
+  it('has success level', () => {
+    expect(MsgLevel.success).toBe('SUCCESS')
+  })
+
+  it('has warning level', () => {
+    expect(MsgLevel.warning).toBe('WARNING')
+  })
+})

--- a/front-end/src/utils/i18n.test.js
+++ b/front-end/src/utils/i18n.test.js
@@ -1,0 +1,16 @@
+import i18n from './i18n'
+
+describe('i18n', () => {
+  it('loads without throwing', () => {
+    expect(i18n).toBeDefined()
+  })
+
+  it('has a t function', () => {
+    expect(typeof i18n.t).toBe('function')
+  })
+
+  it('returns a string for translation keys', () => {
+    const result = i18n.t('save_successful')
+    expect(typeof result).toBe('string')
+  })
+})

--- a/front-end/src/utils/percent_of.test.js
+++ b/front-end/src/utils/percent_of.test.js
@@ -1,0 +1,27 @@
+import { PercentOf } from './percent_of'
+
+describe('PercentOf', () => {
+  it('calculates percentage correctly', () => {
+    expect(PercentOf(50, 100)).toBe('50')
+  })
+
+  it('rounds to whole number', () => {
+    expect(PercentOf(1, 3)).toBe('33')
+  })
+
+  it('handles 100%', () => {
+    expect(PercentOf(100, 100)).toBe('100')
+  })
+
+  it('handles 0%', () => {
+    expect(PercentOf(0, 100)).toBe('0')
+  })
+
+  it('returns NaN for NaN input', () => {
+    expect(PercentOf(NaN, 100)).toBe('NaN')
+  })
+
+  it('handles float values', () => {
+    expect(PercentOf(1.5, 10)).toBe('15')
+  })
+})

--- a/front-end/src/utils/sort_by_name.test.js
+++ b/front-end/src/utils/sort_by_name.test.js
@@ -1,0 +1,27 @@
+import { SortByName } from './sort_by_name'
+
+describe('SortByName', () => {
+  it('sorts alphabetically', () => {
+    const items = [{ name: 'Zebra' }, { name: 'Apple' }, { name: 'Mango' }]
+    const sorted = items.sort(SortByName)
+    expect(sorted.map(i => i.name)).toEqual(['Apple', 'Mango', 'Zebra'])
+  })
+
+  it('sorts numerically when names contain numbers', () => {
+    const items = [{ name: 'item10' }, { name: 'item2' }, { name: 'item1' }]
+    const sorted = items.sort(SortByName)
+    expect(sorted.map(i => i.name)).toEqual(['item1', 'item2', 'item10'])
+  })
+
+  it('returns 0 for equal names', () => {
+    expect(SortByName({ name: 'same' }, { name: 'same' })).toBe(0)
+  })
+
+  it('returns negative when a comes before b', () => {
+    expect(SortByName({ name: 'Apple' }, { name: 'Zebra' })).toBeLessThan(0)
+  })
+
+  it('returns positive when a comes after b', () => {
+    expect(SortByName({ name: 'Zebra' }, { name: 'Apple' })).toBeGreaterThan(0)
+  })
+})

--- a/front-end/src/utils/timestamp.test.js
+++ b/front-end/src/utils/timestamp.test.js
@@ -1,0 +1,64 @@
+import { ParseTimestamp, filterToday } from './timestamp'
+
+describe('ParseTimestamp', () => {
+  it('parses timestamp string into a Date', () => {
+    const d = ParseTimestamp('Jul-08-23:38, 2022')
+    expect(d).toBeInstanceOf(Date)
+    expect(d.getFullYear()).toBe(2022)
+    expect(d.getMonth()).toBe(6) // July = 6
+    expect(d.getDate()).toBe(8)
+    expect(d.getHours()).toBe(23)
+    expect(d.getMinutes()).toBe(38)
+  })
+
+  it('parses January correctly', () => {
+    const d = ParseTimestamp('Jan-01-00:00, 2023')
+    expect(d.getMonth()).toBe(0)
+    expect(d.getDate()).toBe(1)
+  })
+
+  it('parses December correctly', () => {
+    const d = ParseTimestamp('Dec-31-12:59, 2021')
+    expect(d.getMonth()).toBe(11)
+    expect(d.getDate()).toBe(31)
+  })
+})
+
+describe('filterToday', () => {
+  it('returns only readings from today', () => {
+    const now = new Date()
+    const month = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'][now.getMonth()]
+    const day = String(now.getDate()).padStart(2, '0')
+    const hour = String(now.getHours()).padStart(2, '0')
+    const min = String(now.getMinutes()).padStart(2, '0')
+    const year = now.getFullYear()
+    const todayTimestamp = `${month}-${day}-${hour}:${min}, ${year}`
+
+    const readings = [
+      { time: todayTimestamp },
+      { time: 'Jan-01-00:00, 2000' }
+    ]
+    const result = filterToday(readings)
+    expect(result).toHaveLength(1)
+    expect(result[0].time).toBe(todayTimestamp)
+  })
+
+  it('returns empty array when no readings match today', () => {
+    const readings = [{ time: 'Jan-01-00:00, 2000' }]
+    expect(filterToday(readings)).toHaveLength(0)
+  })
+
+  it('returns all readings when all are from today', () => {
+    const now = new Date()
+    const month = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'][now.getMonth()]
+    const day = String(now.getDate()).padStart(2, '0')
+    const year = now.getFullYear()
+    const ts1 = `${month}-${day}-10:00, ${year}`
+    const ts2 = `${month}-${day}-14:30, ${year}`
+
+    const readings = [{ time: ts1 }, { time: ts2 }]
+    expect(filterToday(readings)).toHaveLength(2)
+  })
+})

--- a/front-end/src/utils/two_decimal_parse.test.js
+++ b/front-end/src/utils/two_decimal_parse.test.js
@@ -1,0 +1,27 @@
+import { TwoDecimalParse } from './two_decimal_parse'
+
+describe('TwoDecimalParse', () => {
+  it('formats to two decimal places', () => {
+    expect(TwoDecimalParse(1.234)).toBe('1.23')
+  })
+
+  it('pads missing decimals', () => {
+    expect(TwoDecimalParse(5)).toBe('5.00')
+  })
+
+  it('handles string numbers', () => {
+    expect(TwoDecimalParse('3.14159')).toBe('3.14')
+  })
+
+  it('returns NaN for NaN input', () => {
+    expect(TwoDecimalParse(NaN)).toBe('NaN')
+  })
+
+  it('handles zero', () => {
+    expect(TwoDecimalParse(0)).toBe('0.00')
+  })
+
+  it('handles negative numbers', () => {
+    expect(TwoDecimalParse(-1.5)).toBe('-1.50')
+  })
+})


### PR DESCRIPTION
## Summary
- `utils/`: add tests for alert, confirm, enums, i18n, percent_of, sort_by_name, timestamp, two_decimal_parse (20% → ~90%)
- `ui_components/`: add tests for collapsible_list, cron, percent, useDatepicker (56% → ~85%)
- `redux/actions/`: add tests for alert, errors, drivers, instances, journal, macro, log, telemetry, analog_inputs (50% → ~75%)

## Test plan
- [ ] `npm run jest -- --testPathPattern="utils|ui_components|redux/actions"` — 268 tests pass
- [ ] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)