### PR TITLE
test: extend controller/modules/doser coverage (46% → ~70%)

### DIFF
--- a/controller/modules/doser/pump_test.go
+++ b/controller/modules/doser/pump_test.go
@@ -1,0 +1,106 @@
+package doser
+
+import "testing"
+
+func TestPumpIsValid(t *testing.T) {
+	t.Parallel()
+
+	// empty name
+	p := Pump{}
+	if err := p.IsValid(); err == nil {
+		t.Error("expected error for empty name")
+	}
+
+	// default type: jack missing
+	p = Pump{Name: "P1", Jack: "", Regiment: DosingRegiment{
+		Schedule: Schedule{Second: "0", Minute: "*", Hour: "*", Day: "*", Month: "*", Week: "*"},
+	}}
+	if err := p.IsValid(); err == nil {
+		t.Error("expected error for missing jack")
+	}
+
+	// default type: negative duration
+	p = Pump{Name: "P1", Jack: "1", Regiment: DosingRegiment{
+		Duration: -1,
+		Schedule: Schedule{Second: "0", Minute: "*", Hour: "*", Day: "*", Month: "*", Week: "*"},
+	}}
+	if err := p.IsValid(); err == nil {
+		t.Error("expected error for negative duration")
+	}
+
+	// valid default pump
+	p = Pump{Name: "P1", Jack: "1", Regiment: DosingRegiment{
+		Schedule: Schedule{Second: "0", Minute: "*", Hour: "*", Day: "*", Month: "*", Week: "*"},
+	}}
+	if err := p.IsValid(); err != nil {
+		t.Error("expected valid pump, got:", err)
+	}
+
+	// stepper type: zero volume
+	p = Pump{Name: "P2", Type: "stepper", Regiment: DosingRegiment{Volume: 0}}
+	if err := p.IsValid(); err == nil {
+		t.Error("expected error for stepper with zero volume")
+	}
+
+	// stepper type: nil stepper config
+	p = Pump{Name: "P2", Type: "stepper", Regiment: DosingRegiment{Volume: 5}}
+	if err := p.IsValid(); err == nil {
+		t.Error("expected error for stepper with nil stepper config")
+	}
+
+	// stepper type: stepper with invalid config (missing step pin)
+	p = Pump{Name: "P2", Type: "stepper", Regiment: DosingRegiment{Volume: 5}, Stepper: &DRV8825{}}
+	if err := p.IsValid(); err == nil {
+		t.Error("expected error for stepper with invalid stepper config")
+	}
+}
+
+func TestDRV8825IsValid(t *testing.T) {
+	t.Parallel()
+
+	d := &DRV8825{}
+	if err := d.IsValid(); err == nil {
+		t.Error("expected error for missing step pin")
+	}
+
+	d.StepPin = "p1"
+	if err := d.IsValid(); err == nil {
+		t.Error("expected error for missing direction pin")
+	}
+
+	d.DirectionPin = "p2"
+	if err := d.IsValid(); err == nil {
+		t.Error("expected error for zero SPR")
+	}
+
+	d.SPR = 200
+	if err := d.IsValid(); err == nil {
+		t.Error("expected error for zero VPR")
+	}
+
+	d.VPR = 1.0
+	if err := d.IsValid(); err == nil {
+		t.Error("expected error for missing MSPinA")
+	}
+
+	d.MSPinA = "pa"
+	if err := d.IsValid(); err == nil {
+		t.Error("expected error for missing MSPinB")
+	}
+
+	d.MSPinB = "pb"
+	if err := d.IsValid(); err == nil {
+		t.Error("expected error for missing MSPinC")
+	}
+
+	d.MSPinC = "pc"
+	if err := d.IsValid(); err == nil {
+		t.Error("expected error for zero delay")
+	}
+
+	d.Delay = 20800000
+	if err := d.IsValid(); err != nil {
+		t.Error("expected valid DRV8825, got:", err)
+	}
+}
+

--- a/controller/modules/doser/usage_test.go
+++ b/controller/modules/doser/usage_test.go
@@ -1,0 +1,49 @@
+package doser
+
+import (
+	"testing"
+	"time"
+
+	"github.com/reef-pi/reef-pi/controller/telemetry"
+)
+
+func TestDoserUsage(t *testing.T) {
+	t.Parallel()
+	t1 := time.Now()
+
+	u1 := Usage{
+		Pump: 2,
+		Time: telemetry.TeleTime(t1),
+	}
+	u2 := Usage{
+		Pump: 3,
+		Time: telemetry.TeleTime(t1.Add(24 * time.Hour)),
+	}
+
+	// u1 before u2
+	if !u1.Before(u2) {
+		t.Error("u1 should be before u2")
+	}
+
+	// Rollup across different days should return u2 and signal next bucket
+	result, next := u1.Rollup(u2)
+	if !next {
+		t.Error("expected next=true for different day rollup")
+	}
+	if result.(Usage).Pump != u2.Pump {
+		t.Error("expected rolled-up value to be u2")
+	}
+
+	// Rollup on same day should accumulate pump counts
+	u3 := Usage{
+		Pump: 5,
+		Time: telemetry.TeleTime(t1),
+	}
+	result, next = u1.Rollup(u3)
+	if next {
+		t.Error("expected next=false for same-day rollup")
+	}
+	if result.(Usage).Pump != u1.Pump+u3.Pump {
+		t.Errorf("expected accumulated pump=%d, got %d", u1.Pump+u3.Pump, result.(Usage).Pump)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `pump_test.go` covering pump validation (IsValid, name/driver constraints)
- Add `usage_test.go` covering Usage Rollup/Before helpers used by the stats manager

## Test plan
- [ ] `go test ./controller/modules/doser/...` passes at ≥70%
- [ ] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)