### PR TITLE
Add refactor governance artifacts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# Global fallback
+* @ranjib
+
+# Backend
+/commands/ @ranjib
+/controller/ @ranjib
+/go.mod @ranjib
+/go.sum @ranjib
+
+# Frontend
+/front-end/ @ranjib
+/package.json @ranjib
+/yarn.lock @ranjib
+/webpack.config.js @ranjib
+
+# CI and release automation
+/.github/ @ranjib
+/Makefile @ranjib
+/Dockerfile @ranjib
+/build/ @ranjib
+
+# Documentation and API definitions
+/docs/ @ranjib
+/README.md @ranjib
+/openapi.yaml @ranjib
+/swagger.json @ranjib
+/swagger.yml @ranjib

--- a/.github/ISSUE_TEMPLATE/ci-regression.yml
+++ b/.github/ISSUE_TEMPLATE/ci-regression.yml
@@ -1,0 +1,54 @@
+name: CI Regression
+description: Track a workflow failure discovered during refactor work that is not local to the current slice.
+title: "CI Regression: "
+labels:
+  - refactor
+  - refactor:ci
+body:
+  - type: input
+    id: workflow
+    attributes:
+      label: Workflow or check name
+      placeholder: "go / builds"
+    validations:
+      required: true
+  - type: input
+    id: pr
+    attributes:
+      label: Related PR
+      placeholder: "#1234"
+    validations:
+      required: true
+  - type: textarea
+    id: failure
+    attributes:
+      label: Failure summary
+      description: Describe the failing step and the observed behavior.
+    validations:
+      required: true
+  - type: dropdown
+    id: class
+    attributes:
+      label: Failure class
+      options:
+        - toolchain drift
+        - flaky test
+        - hidden coupling
+        - behavior regression
+        - environment assumption
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Local reproduction
+      description: Record the exact local command and notes used to reproduce the failure.
+    validations:
+      required: true
+  - type: textarea
+    id: prevention
+    attributes:
+      label: Prevention artifact
+      description: State what should be added so this failure class is less likely to recur.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Refactor Plan
+    url: https://github.com/reef-pi/reef-pi/blob/main/docs/refactor-plan.md
+    about: Review the refactor program and issue sequence before opening a new refactor-related issue.

--- a/.github/ISSUE_TEMPLATE/refactor-slice.yml
+++ b/.github/ISSUE_TEMPLATE/refactor-slice.yml
@@ -1,0 +1,66 @@
+name: Refactor Slice
+description: Track one behavior-preserving refactor slice from the reef-pi refactor plan.
+title: "Slice XX: "
+labels:
+  - refactor
+body:
+  - type: input
+    id: source
+    attributes:
+      label: Source plan section
+      description: Reference the relevant section in docs/refactor-plan.md.
+      placeholder: "Phase 1 / PR 3"
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: List the exact modules, packages, or screens included in this slice.
+    validations:
+      required: true
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: Record what must not change in this slice.
+      placeholder: "No API schema changes. No UI/UX drift."
+    validations:
+      required: true
+  - type: textarea
+    id: invariants
+    attributes:
+      label: Invariants
+      description: List behavior-preserving constraints for this issue.
+      value: |
+        - no API drift
+        - no UI or UX drift
+        - no hardware behavior drift
+        - each task starts from fresh main
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation commands
+      description: List the commands expected to be run before opening the PR.
+      placeholder: |
+        go test ./...
+        make lint
+        make jest
+    validations:
+      required: true
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks
+      description: Call out the main regression risks for reviewers.
+    validations:
+      required: true
+  - type: textarea
+    id: done
+    attributes:
+      label: Completion criteria
+      description: State what must be true for this slice to be considered done.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+## Summary
+
+Describe the refactor objective and the specific simplification made.
+
+## Linked issue
+
+Closes #
+
+## Scope
+
+- [ ] Behavior-preserving refactor only
+- [ ] No API schema changes
+- [ ] No UI/UX changes
+- [ ] No hardware behavior changes
+
+## Verification
+
+List the exact commands you ran locally.
+
+```text
+go test ./...
+```
+
+## Risk review
+
+- Main regression risks:
+- Areas reviewers should scrutinize:
+- Rollback approach:
+
+## Build failure handling
+
+If CI failed during this work:
+
+- [ ] reproduced locally
+- [ ] classified the failure
+- [ ] fixed it in this PR or linked a follow-up issue
+- [ ] added a prevention artifact if the failure mode is reusable

--- a/docs/github-issues/README.md
+++ b/docs/github-issues/README.md
@@ -1,0 +1,26 @@
+# GitHub Issue Drafts
+
+This directory contains ready-to-paste issue bodies for the refactor program described in [../refactor-plan.md](../refactor-plan.md).
+
+Suggested creation order:
+
+1. create the meta issue
+2. create slice issues in sequence
+3. link each PR to its slice issue
+4. open CI regression issues only when a failure is not local to the current PR
+
+Recommended labels:
+
+- `refactor`
+- `refactor:backend`
+- `refactor:frontend`
+- `refactor:ci`
+- `risk:low`
+- `risk:medium`
+- `risk:high`
+
+Suggested issue linking:
+
+- each slice issue should reference the meta issue
+- each PR should use `Closes #<slice-issue>`
+- follow-up issues should reference both the slice issue and the failed PR

--- a/docs/github-issues/meta-refactor-program.md
+++ b/docs/github-issues/meta-refactor-program.md
@@ -1,0 +1,71 @@
+# Meta: Refactor reef-pi for maintainability without API or UX drift
+
+## Objective
+
+Track the multi-PR refactor program for reef-pi.
+
+This program is intended to simplify the codebase while preserving:
+
+- runtime behavior
+- API schema
+- UI and UX behavior
+- hardware-facing semantics
+
+## Source of truth
+
+- `docs/refactor-plan.md`
+
+## Invariants
+
+- no API drift
+- no UI or UX drift
+- no hardware behavior drift
+- no hidden migrations
+- every task starts from fresh `main`
+
+## Execution model
+
+Each linked issue maps to one independently reviewable PR slice.
+
+Standard branch start:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git checkout -b <topic-branch>
+```
+
+## Planned slices
+
+- [ ] Slice 01: Align CI and repository invariants
+- [ ] Slice 02: Add PR hygiene and repository workflow templates
+- [ ] Slice 03: Simplify backend startup and HTTP composition
+- [ ] Slice 04: Standardize backend error, config, and shutdown flow
+- [ ] Slice 05: Clarify backend storage and service boundaries
+- [ ] Slice 06: Backend naming and test cleanup
+- [ ] Slice 07: Fix Redux immutability and store ownership
+- [ ] Slice 08: Unify frontend API request behavior
+- [ ] Slice 09: Simplify app shell and routing boundaries
+- [ ] Slice 10: Refactor configuration and admin surfaces
+- [ ] Slice 11: Refactor dashboard and telemetry surfaces
+- [ ] Slice 12: Refactor equipment, connectors, and automation surfaces
+- [ ] Slice 13: Introduce semantic design tokens
+- [ ] Slice 14: Harden responsive layouts
+- [ ] Slice 15: Stabilize frontend test ergonomics
+
+## Failure-handling rule
+
+If a PR fails CI:
+
+1. reproduce locally
+2. classify the failure
+3. fix in the current PR if local to the slice
+4. create a linked follow-up issue if it exposes broader debt
+5. add one prevention artifact so the failure class is less likely to repeat
+
+## Completion criteria
+
+- all planned slices merged or intentionally closed
+- CI aligned and stable
+- codebase simpler to navigate
+- review workflow repeatable and well documented

--- a/docs/github-issues/slice-01-ci-alignment.md
+++ b/docs/github-issues/slice-01-ci-alignment.md
@@ -1,0 +1,33 @@
+# Slice 01: Align CI and repository invariants
+
+## Goal
+
+Make repository automation match the current repository reality before deeper refactors begin.
+
+## Scope
+
+- align workflow Go version with `go.mod`
+- replace stale `master` references with `main`
+- normalize workflow names and required-check friendliness
+- document local reproduction commands for workflow failures
+
+## Non-goals
+
+- no application behavior changes
+- no dependency upgrade sweep beyond what is needed for CI correctness
+
+## Risks
+
+- branch protection may reference old check names
+- workflow changes may reveal hidden assumptions
+
+## Validation
+
+- workflow files reference the correct default branch
+- Go CI uses the supported toolchain
+- local reproduction commands are documented
+
+## Completion criteria
+
+- repository automation is aligned with `main`
+- later refactor PRs can rely on stable CI expectations

--- a/docs/github-issues/slice-02-pr-hygiene.md
+++ b/docs/github-issues/slice-02-pr-hygiene.md
@@ -1,0 +1,32 @@
+# Slice 02: Add PR hygiene and repository workflow templates
+
+## Goal
+
+Encode the refactor workflow directly into GitHub repo metadata.
+
+## Scope
+
+- add `CODEOWNERS`
+- add pull request template
+- add issue forms
+- add issue configuration
+
+## Non-goals
+
+- no branch protection setting changes from code
+- no workflow behavior changes
+
+## Risks
+
+- templates that are too heavy will annoy contributors
+- code owner patterns may need iteration
+
+## Validation
+
+- issue forms render correctly
+- PR template reflects refactor invariants
+- ownership paths reflect current repo structure
+
+## Completion criteria
+
+- new PRs and issues collect the minimum information required for safe refactor review

--- a/docs/github-issues/slice-03-backend-startup-http.md
+++ b/docs/github-issues/slice-03-backend-startup-http.md
@@ -1,0 +1,33 @@
+# Slice 03: Simplify backend startup and HTTP composition
+
+## Goal
+
+Make backend startup, routing, auth mounting, and asset serving easier to reason about without changing behavior.
+
+## Scope
+
+- untangle startup path in daemon and API setup
+- reduce mixed mux ownership patterns
+- make route registration more explicit
+
+## Non-goals
+
+- no API path changes
+- no auth behavior changes
+- no static asset behavior changes
+
+## Risks
+
+- subtle routing regressions
+- auth middleware ordering mistakes
+
+## Validation
+
+- `go test ./...`
+- targeted API tests pass
+- smoke checks for app shell still pass
+
+## Completion criteria
+
+- startup path has one obvious flow
+- HTTP composition is easier to test

--- a/docs/github-issues/slice-04-backend-error-config-shutdown.md
+++ b/docs/github-issues/slice-04-backend-error-config-shutdown.md
@@ -1,0 +1,29 @@
+# Slice 04: Standardize backend error, config, and shutdown flow
+
+## Goal
+
+Reduce incidental complexity in backend lifecycle code.
+
+## Scope
+
+- standardize constructor error handling
+- standardize config loading flow
+- standardize shutdown behavior and return paths
+
+## Non-goals
+
+- no config schema changes
+- no startup option changes
+
+## Risks
+
+- changing lifecycle sequencing can hide regressions
+
+## Validation
+
+- `go test ./...`
+- focused lifecycle tests for touched packages
+
+## Completion criteria
+
+- lifecycle code is flatter, clearer, and easier to review

--- a/docs/github-issues/slice-05-backend-storage-service-seams.md
+++ b/docs/github-issues/slice-05-backend-storage-service-seams.md
@@ -1,0 +1,29 @@
+# Slice 05: Clarify backend storage and service boundaries
+
+## Goal
+
+Reduce handler-to-storage coupling and improve testability.
+
+## Scope
+
+- introduce clearer service seams where they simplify module logic
+- keep bucket names and stored data formats unchanged
+- reduce direct storage reach-through from higher layers
+
+## Non-goals
+
+- no data migration
+- no persistence format changes
+
+## Risks
+
+- hidden coupling across subsystems
+
+## Validation
+
+- `go test ./...`
+- targeted tests for touched modules
+
+## Completion criteria
+
+- storage access patterns are easier to isolate and reason about

--- a/docs/github-issues/slice-06-backend-naming-tests.md
+++ b/docs/github-issues/slice-06-backend-naming-tests.md
@@ -1,0 +1,28 @@
+# Slice 06: Backend naming and test cleanup
+
+## Goal
+
+Move backend code closer to idiomatic Go without changing behavior.
+
+## Scope
+
+- improve misleading names
+- add or improve package docs where useful
+- convert brittle tests to clearer table-driven or subtest patterns where helpful
+
+## Non-goals
+
+- no broad package reorganization without clear payoff
+
+## Risks
+
+- large rename diffs can reduce review clarity
+
+## Validation
+
+- `go test ./...`
+- reviewer can understand the diff without semantic ambiguity
+
+## Completion criteria
+
+- backend reads more cleanly and reviews faster

--- a/docs/github-issues/slice-07-redux-correctness.md
+++ b/docs/github-issues/slice-07-redux-correctness.md
@@ -1,0 +1,30 @@
+# Slice 07: Fix Redux immutability and store ownership
+
+## Goal
+
+Make frontend state updates predictable before touching large UI surfaces.
+
+## Scope
+
+- remove reducer mutations
+- remove singleton store leakage
+- centralize state ownership and selectors where helpful
+
+## Non-goals
+
+- no visible UI changes
+- no broad component rewrite
+
+## Risks
+
+- subtle state timing regressions
+- tests may encode current mutation behavior
+
+## Validation
+
+- `make standard`
+- `make jest`
+
+## Completion criteria
+
+- reducers are side-effect free and state flow is easier to reason about

--- a/docs/github-issues/slice-08-frontend-api-client.md
+++ b/docs/github-issues/slice-08-frontend-api-client.md
@@ -1,0 +1,30 @@
+# Slice 08: Unify frontend API request behavior
+
+## Goal
+
+Move the UI toward one clear network request model.
+
+## Scope
+
+- centralize `fetch` behavior
+- standardize auth, errors, and JSON handling
+- preserve existing endpoint usage and screen behavior
+
+## Non-goals
+
+- no endpoint changes
+- no state-management migration
+
+## Risks
+
+- error handling changes can alter edge-case UX if not carefully preserved
+
+## Validation
+
+- `make standard`
+- `make jest`
+- targeted manual checks on touched screens
+
+## Completion criteria
+
+- network behavior is consistent and easier to maintain

--- a/docs/github-issues/slice-09-app-shell-routing.md
+++ b/docs/github-issues/slice-09-app-shell-routing.md
@@ -1,0 +1,31 @@
+# Slice 09: Simplify app shell and routing boundaries
+
+## Goal
+
+Reduce complexity in the main shell, navigation, and shared page chrome.
+
+## Scope
+
+- simplify route metadata
+- simplify shared navigation rendering
+- preserve labels, paths, and capability-aware behavior
+
+## Non-goals
+
+- no route changes
+- no navigation redesign
+
+## Risks
+
+- mobile navigation regressions
+- capability gating regressions
+
+## Validation
+
+- `make standard`
+- `make jest`
+- `make smoke`
+
+## Completion criteria
+
+- app shell is easier to extend and review

--- a/docs/github-issues/slice-10-configuration-admin.md
+++ b/docs/github-issues/slice-10-configuration-admin.md
@@ -1,0 +1,31 @@
+# Slice 10: Refactor configuration and admin surfaces
+
+## Goal
+
+Simplify the highest-leverage admin-facing views without UX drift.
+
+## Scope
+
+- configuration views
+- admin views
+- auth-adjacent forms and shared helpers
+
+## Non-goals
+
+- no workflow redesign
+- no field layout changes unless required to preserve responsiveness
+
+## Risks
+
+- subtle form-validation drift
+- notification behavior drift
+
+## Validation
+
+- `make standard`
+- `make jest`
+- targeted manual checks of touched forms
+
+## Completion criteria
+
+- admin-facing screens are broken into clearer component boundaries

--- a/docs/github-issues/slice-11-dashboard-telemetry.md
+++ b/docs/github-issues/slice-11-dashboard-telemetry.md
@@ -1,0 +1,31 @@
+# Slice 11: Refactor dashboard and telemetry surfaces
+
+## Goal
+
+Simplify dashboard composition and telemetry configuration without changing what users see.
+
+## Scope
+
+- dashboard composition
+- telemetry configuration
+- shared chart and status helpers touched by the refactor
+
+## Non-goals
+
+- no chart redesign
+- no capability semantics changes
+
+## Risks
+
+- capability-gated rendering regressions
+- chart data shape assumptions
+
+## Validation
+
+- `make standard`
+- `make jest`
+- `make smoke`
+
+## Completion criteria
+
+- dashboard and telemetry code is easier to follow and test

--- a/docs/github-issues/slice-12-equipment-connectors-automation.md
+++ b/docs/github-issues/slice-12-equipment-connectors-automation.md
@@ -1,0 +1,35 @@
+# Slice 12: Refactor equipment, connectors, and automation surfaces
+
+## Goal
+
+Incrementally simplify the highest-churn operational modules.
+
+## Scope
+
+- equipment
+- connectors
+- timers
+- lighting
+- ato
+- doser
+- ph
+- related shared pieces touched by the slice
+
+## Non-goals
+
+- no capability redesign
+- no hardware semantics changes
+
+## Risks
+
+- broad surface area can create overly large diffs
+
+## Validation
+
+- `make standard`
+- `make jest`
+- `make smoke`
+
+## Completion criteria
+
+- each touched module has clearer boundaries and fewer incidental dependencies

--- a/docs/github-issues/slice-13-design-tokens.md
+++ b/docs/github-issues/slice-13-design-tokens.md
@@ -1,0 +1,31 @@
+# Slice 13: Introduce semantic design tokens
+
+## Goal
+
+Make styling more maintainable while preserving reef-pi's existing visual identity.
+
+## Scope
+
+- semantic color tokens
+- feedback and border tokens
+- shared spacing and radius conventions
+- limited Sass organization improvements
+
+## Non-goals
+
+- no visual redesign
+- no brand change
+
+## Risks
+
+- token substitution can cause low-contrast or edge-case visual drift
+
+## Validation
+
+- compare touched screens before and after
+- verify contrast-sensitive surfaces
+- `make ui`
+
+## Completion criteria
+
+- shared styling logic is more systematic and less ad hoc

--- a/docs/github-issues/slice-14-responsive-hardening.md
+++ b/docs/github-issues/slice-14-responsive-hardening.md
@@ -1,0 +1,31 @@
+# Slice 14: Harden responsive layouts
+
+## Goal
+
+Keep existing UX while preventing breakage on smaller screens.
+
+## Scope
+
+- nav behavior
+- forms
+- tables
+- charts
+- common layout containers
+
+## Non-goals
+
+- no information architecture changes
+
+## Risks
+
+- responsive fixes can accidentally change desktop spacing
+
+## Validation
+
+- `make ui`
+- `make smoke`
+- manual checks on narrow widths for touched pages
+
+## Completion criteria
+
+- common supported screens avoid overflow and cramped interactions

--- a/docs/github-issues/slice-15-frontend-test-stabilization.md
+++ b/docs/github-issues/slice-15-frontend-test-stabilization.md
@@ -1,0 +1,27 @@
+# Slice 15: Stabilize frontend test ergonomics
+
+## Goal
+
+Make frontend tests easier to maintain after structural refactors.
+
+## Scope
+
+- reduce duplicated test setup
+- document snapshot policy
+- improve touched tests without broad churn
+
+## Non-goals
+
+- no wholesale test-framework migration unless separately approved
+
+## Risks
+
+- over-reaching here will create churn unrelated to product safety
+
+## Validation
+
+- `make jest`
+
+## Completion criteria
+
+- touched tests are easier to understand and less brittle

--- a/docs/refactor-plan.md
+++ b/docs/refactor-plan.md
@@ -1,0 +1,539 @@
+# reef-pi Refactor Plan
+
+## Goal
+
+Refactor reef-pi for maintainability, readability, and reviewability without changing:
+
+- functional behavior
+- API schema
+- UI or UX behavior
+- hardware-facing semantics
+
+This plan is designed to be executed as a series of independent pull requests that can be reviewed, tracked, merged, and rolled back separately.
+
+## Project Understanding
+
+reef-pi is a Raspberry Pi based reef aquarium controller with a browser UI. It supports modular capabilities such as:
+
+- equipment control
+- timers
+- lighting automation
+- temperature monitoring and control
+- auto top off
+- pH monitoring
+- dosing
+- telemetry and alerts
+- dashboarding
+- camera support
+
+The product is intentionally modular. Users enable only the capabilities they need, and the dashboard, APIs, and automation behavior adapt accordingly.
+
+## Current Technical Snapshot
+
+Backend:
+
+- Go backend in `commands/` and `controller/`
+- BoltDB storage through `go.etcd.io/bbolt`
+- Gorilla Mux routing
+- modular subsystems loaded through the controller composite
+- OpenAPI and Swagger artifacts committed in-repo
+
+Frontend:
+
+- React 16 UI in `front-end/src`
+- Redux with `redux-thunk`
+- class components plus `connect`
+- Webpack build
+- Bootstrap 4 and SCSS styling
+- Jest, Enzyme-era tests, and TestCafe smoke coverage
+
+CI and automation:
+
+- Go, Jest, smoke, deb packaging, release, translations, CodeQL, Dependabot
+- Claude review workflow already present
+
+## Refactor Principles
+
+Every PR must preserve the following invariants:
+
+- no API path, payload, or schema drift
+- no visible UX drift unless explicitly approved in a separate product change
+- no hardware control semantics drift
+- no hidden data migration
+- no package or component move without tests or call-site verification
+
+When in doubt:
+
+- prefer smaller PRs
+- prefer behavior-preserving extraction over redesign
+- prefer explicit seams over shared implicit state
+- prefer new tests before risky movement
+
+## Best-Practice Targets
+
+### Go
+
+Target style:
+
+- small, domain-shaped packages
+- clear constructor and lifecycle ownership
+- explicit error propagation with wrapping
+- thin HTTP handlers and testable services
+- interfaces owned by consumers, not producers
+- table-driven tests and focused test helpers
+- package names that reflect domain meaning
+- no hidden coupling through globals or mixed registries
+
+Specific expectations:
+
+- use `gofmt` and `goimports`
+- keep error strings lowercase and unpunctuated
+- use `%w` when wrapping errors
+- keep indentation of error flow flat
+- pass `context.Context` where work is request-scoped or long-running
+- keep exported API docs accurate
+- avoid package names like `util`, `common`, and `types` for new code
+
+### React and Redux
+
+Target style:
+
+- one clear data flow path for network requests
+- reducers that are fully immutable
+- explicit selectors and state ownership
+- modernized touched code, but no mass rewrite for its own sake
+- function components for newly refactored surfaces when risk is low
+- hooks only when they reduce complexity and preserve behavior
+
+Specific expectations:
+
+- do not mutate state objects in reducers
+- do not rely on singleton store access from utility modules
+- centralize API request behavior and auth handling
+- keep component state local only when it is truly local
+- isolate routing metadata and page shell logic
+- prefer composable presentational components over monolithic screens
+
+### Frontend Design and UX Preservation
+
+reef-pi already has a recognizable green brand language. Refactoring should preserve that identity while making it more systematic.
+
+Design rules for maintenance refactors:
+
+- preserve current information architecture and interaction flow
+- convert hard-coded colors to semantic tokens
+- keep contrast at or above WCAG AA targets
+- keep touch targets comfortably usable on tablets and phones
+- avoid layout overflow in charts, tables, nav, and forms
+- prefer responsive stacking over horizontal compression
+- keep mobile-first assumptions in shared components
+
+Suggested token families:
+
+- brand
+- surface
+- border
+- text
+- feedback
+- chart-series
+- spacing
+- radius
+
+## PR Execution Protocol
+
+Every refactor task starts from fresh `main`.
+
+Standard start sequence:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git checkout -b <topic-branch>
+```
+
+Standard pre-push sequence:
+
+```bash
+go test ./...
+make lint
+```
+
+If frontend files are touched:
+
+```bash
+yarn
+make standard
+make jest
+```
+
+If app shell, routing, or dashboard surfaces are touched:
+
+```bash
+make ui
+make go
+make smoke
+```
+
+Every PR should:
+
+- stay scoped to one refactor objective
+- include before/after rationale in the PR body
+- list exact local verification commands run
+- call out touched runtime surfaces
+- describe rollback safety
+
+## Build Failure Playbook
+
+When a PR fails CI:
+
+1. Reproduce the failing job locally using the workflow command, not an approximation.
+2. Classify the failure:
+   - toolchain drift
+   - flaky test
+   - hidden coupling
+   - behavior regression
+   - environment assumption
+3. Decide disposition:
+   - fix inside the PR if the failure is caused by the current slice
+   - open a linked follow-up issue if the failure exposes unrelated infrastructure debt
+4. Add a prevention artifact:
+   - a new lint rule
+   - a workflow guard
+   - a test helper
+   - a checklist item
+   - a local reproduction note
+
+Never merge a refactor PR that reveals a repeated failure class without adding a prevention artifact.
+
+## Learning Loop
+
+After every failed or noisy PR:
+
+- record the root cause in the linked issue
+- update the plan or template if the failure mode is reusable
+- add the failure mode to the PR checklist if human review can catch it
+- add automation only where it eliminates repeated reviewer effort
+
+Examples:
+
+- If frontend snapshots fail due to implicit formatting drift, document and automate the exact snapshot update policy.
+- If packaging fails because release metadata is spread across Makefile and workflow files, add a dedicated packaging verification task before future packaging-sensitive PRs.
+- If a subsystem refactor breaks capability-gated routing, add a focused regression test before continuing with adjacent subsystem work.
+
+## Refactor Roadmap
+
+### Phase 0: Baseline and Governance
+
+#### PR 1: CI Alignment and Repository Invariants
+
+Scope:
+
+- align workflow Go version with `go.mod`
+- replace stale `master` references with `main`
+- normalize workflow names and job names for stable required checks
+- add workflow linting guidance
+- document local reproduction commands for each workflow
+
+Why first:
+
+- prevents false failures
+- gives every later PR predictable gates
+
+Primary risks:
+
+- branch protection configuration drift
+- unexpected workflow naming dependencies
+
+Success criteria:
+
+- workflow branches match repository reality
+- required checks are stable and understandable
+
+#### PR 2: PR Hygiene and Review Automation
+
+Scope:
+
+- add `CODEOWNERS`
+- add PR template
+- add issue forms
+- document required status checks and review expectations
+- keep Claude review, CodeQL, and Dependabot in the standard path
+
+Why next:
+
+- encodes the process before the refactor series starts
+
+Success criteria:
+
+- every PR and issue captures the same minimum decision data
+
+### Phase 1: Backend Structural Simplification
+
+#### PR 3: Backend Startup and HTTP Composition Boundaries
+
+Scope:
+
+- separate HTTP server bootstrap from route registration
+- make asset serving, auth, and API mounting explicit
+- reduce mixed use of default mux and custom router patterns
+
+Success criteria:
+
+- startup path is easier to read and test
+- behavior remains identical
+
+#### PR 4: Backend Error, Config, and Shutdown Discipline
+
+Scope:
+
+- standardize constructor error handling
+- standardize shutdown ordering and return paths
+- improve config-loading clarity
+- reduce repeated logging and implicit fallback logic
+
+Success criteria:
+
+- startup and shutdown paths have one obvious control flow
+
+#### PR 5: Backend Storage and Service Seams
+
+Scope:
+
+- make subsystem storage access more explicit
+- reduce handler-to-store coupling
+- introduce internal service seams where they simplify tests
+
+Success criteria:
+
+- storage access is easier to mock and reason about
+- bucket names and stored formats stay unchanged
+
+#### PR 6: Backend Naming, Package, and Test Cleanup
+
+Scope:
+
+- fix misleading names and package documentation
+- convert brittle tests to table-driven structure where useful
+- remove avoidable incidental complexity
+
+Success criteria:
+
+- backend code reads closer to idiomatic Go
+
+### Phase 2: Frontend State and API Simplification
+
+#### PR 7: Redux Store and Reducer Correctness
+
+Scope:
+
+- remove reducer mutations
+- remove store singleton leakage
+- centralize initial-state ownership
+- add selectors where repeated state access is noisy
+
+Why first on frontend:
+
+- correctness and testability improve before component rewrites
+
+Success criteria:
+
+- reducers are predictable and side-effect free
+
+#### PR 8: Unified Frontend API Client
+
+Scope:
+
+- centralize `fetch` behavior
+- unify auth handling and error reporting
+- standardize JSON parsing and failure paths
+
+Success criteria:
+
+- API interactions follow one pattern
+
+#### PR 9: App Shell, Routing, and Shared UI Boundaries
+
+Scope:
+
+- simplify route metadata
+- simplify navigation rendering
+- simplify shared shell components
+- preserve existing routes and labels
+
+Success criteria:
+
+- app shell becomes easier to extend without hidden coupling
+
+### Phase 3: Frontend Module-by-Module Cleanup
+
+#### PR 10: Configuration and Admin Surfaces
+
+Scope:
+
+- refactor configuration, admin, and auth-adjacent views into clearer component boundaries
+- preserve field layout and behavior
+
+#### PR 11: Dashboard and Telemetry Surfaces
+
+Scope:
+
+- simplify dashboard composition
+- simplify telemetry configuration flows
+- preserve charts and capability-aware rendering
+
+#### PR 12: Equipment, Connectors, and Automation Modules
+
+Scope:
+
+- clean up the highest-churn modules incrementally
+- prioritize readability and local testability
+
+### Phase 4: Styling and Responsiveness Hardening
+
+#### PR 13: Design Tokens and SCSS Organization
+
+Scope:
+
+- introduce semantic variables for color and feedback
+- reduce ad hoc color use
+- organize shared Sass utilities
+
+Success criteria:
+
+- visual output is preserved while styling becomes easier to maintain
+
+#### PR 14: Responsive Layout Guardrails
+
+Scope:
+
+- harden navigation, forms, tables, and charts for smaller screens
+- preserve current UX while preventing overflow and cramped interactions
+
+Success criteria:
+
+- no horizontal spillover in common supported views
+
+### Phase 5: Test and Tooling Modernization
+
+#### PR 15: Frontend Test Stabilization
+
+Scope:
+
+- reduce fragile test setup duplication
+- document snapshot policy
+- modernize only the tests touched by current refactors
+
+#### PR 16: Optional Testing Migration Track
+
+Scope:
+
+- evaluate and incrementally migrate away from Enzyme-era patterns
+- only proceed after state and API layers are stable
+
+This is intentionally last:
+
+- it is easy to create churn here
+- earlier structural cleanup reduces migration cost
+
+## GitHub Integration Plan
+
+Repository settings and automation should support the refactor program.
+
+Recommended repository configuration:
+
+- protect `main`
+- require pull requests before merge
+- require status checks to pass
+- require review from code owners
+- enable auto-merge only for green PRs
+- enable merge queue after required checks stabilize
+
+Recommended required checks:
+
+- Go CI
+- Jest
+- Smoke
+- Debian packaging
+- CodeQL
+- Claude review if the repository decides to make it blocking
+
+Recommended labels:
+
+- `refactor`
+- `refactor:backend`
+- `refactor:frontend`
+- `refactor:ci`
+- `risk:low`
+- `risk:medium`
+- `risk:high`
+- `failure:toolchain`
+- `failure:flaky-test`
+- `failure:hidden-coupling`
+- `failure:regression`
+
+## GitHub Issue Strategy
+
+Create one meta issue and one execution issue per PR slice.
+
+Issue hierarchy:
+
+- meta issue: overall program tracking
+- one issue per planned PR
+- one CI regression issue type for unexpected failures
+
+Every slice issue should include:
+
+- scope
+- non-goals
+- invariants
+- validation commands
+- likely risks
+- completion criteria
+- follow-up candidates
+
+## Suggested Initial Issue Set
+
+- Meta: Refactor reef-pi for maintainability without API or UX drift
+- Slice 01: Align CI and repository invariants
+- Slice 02: Add PR hygiene and repository workflow templates
+- Slice 03: Simplify backend startup and HTTP composition
+- Slice 04: Standardize backend error, config, and shutdown flow
+- Slice 05: Clarify backend storage and service boundaries
+- Slice 06: Backend naming and test cleanup
+- Slice 07: Fix Redux immutability and store ownership
+- Slice 08: Unify frontend API request behavior
+- Slice 09: Simplify app shell and routing boundaries
+- Slice 10: Refactor configuration and admin surfaces
+- Slice 11: Refactor dashboard and telemetry surfaces
+- Slice 12: Refactor equipment, connectors, and automation surfaces
+- Slice 13: Introduce semantic design tokens
+- Slice 14: Harden responsive layouts
+- Slice 15: Stabilize frontend test ergonomics
+
+## Notes for Reviewers
+
+Refactor PR reviews should prioritize:
+
+- accidental behavior change
+- accidental schema change
+- hidden control-flow changes
+- lost tests or weakened assertions
+- package boundary confusion
+- refactors that combine movement and logic change in one diff
+
+Reviewers should push back on:
+
+- opportunistic rewrites outside slice scope
+- dependency upgrades mixed into behavioral refactors
+- broad formatting-only churn when it obscures semantic review
+
+## Exit Criteria
+
+The program is complete when:
+
+- the codebase is easier to navigate and reason about
+- CI is stable and aligned with the current repository
+- backend seams are explicit enough for safe change
+- frontend state and request flow are predictable
+- styling is tokenized and easier to maintain
+- the PR-by-PR workflow is documented and repeatable


### PR DESCRIPTION
## Summary

Add the checked-in governance artifacts for the reef-pi refactor program.

This PR adds:

- the detailed refactor plan and PR sequencing document
- ready-to-paste GitHub issue draft files
- issue forms for refactor slices and CI regressions
- a pull request template aligned with the refactor invariants
- `CODEOWNERS` for backend, frontend, CI, and docs review paths

## Linked issue

Closes #2506
Refs #2504

## Scope

- [x] Behavior-preserving refactor only
- [x] No API schema changes
- [x] No UI/UX changes
- [x] No hardware behavior changes

## Verification

These are repository governance and documentation artifacts only.

```text
git status --short
git show --stat HEAD
find .github -maxdepth 3 -type f | sort
find docs -maxdepth 3 -type f | sort
```

## Risk review

- Main regression risks: low runtime risk; main risk is review-process friction if templates or CODEOWNERS need tuning.
- Areas reviewers should scrutinize: issue-form fields, PR checklist wording, and CODEOWNERS path coverage.
- Rollback approach: revert this PR to remove the governance artifacts.

## Build failure handling

If CI failed during this work:

- [x] reproduced locally where possible
- [x] classified the failure
- [x] fixed it in this PR or linked a follow-up issue
- [x] added a prevention artifact if the failure mode is reusable
