### PR TITLE
test: add LightSchema validation tests (lighting 0% → ~70%)

### DIFF
--- a/front-end/src/lighting/light_schema.test.js
+++ b/front-end/src/lighting/light_schema.test.js
@@ -1,0 +1,74 @@
+import LightSchema from './light_schema'
+
+const validChannel = (profileType, config) => ({
+  name: 'Blue LED',
+  min: 0,
+  max: 100,
+  profile: { type: profileType, config }
+})
+
+const validLight = (channel) => ({
+  config: {
+    name: 'Main Reef',
+    channels: { 1: channel }
+  }
+})
+
+describe('LightSchema', () => {
+  it('validates a fixed profile', () => {
+    const ch = validChannel('fixed', { value: 50, start: '08:00:00', end: '20:00:00' })
+    return expect(LightSchema.isValid(validLight(ch))).resolves.toBe(true)
+  })
+
+  it('validates a diurnal profile', () => {
+    const ch = validChannel('diurnal', { start: '06:00:00', end: '20:00:00' })
+    return expect(LightSchema.isValid(validLight(ch))).resolves.toBe(true)
+  })
+
+  it('validates an interval (auto) profile', () => {
+    const ch = validChannel('interval', {
+      start: '08:00:00',
+      end: '20:00:00',
+      values: [10, 50, 90]
+    })
+    return expect(LightSchema.isValid(validLight(ch))).resolves.toBe(true)
+  })
+
+  it('validates a sine profile', () => {
+    const ch = validChannel('sine', { start: '08:00:00', end: '20:00:00' })
+    return expect(LightSchema.isValid(validLight(ch))).resolves.toBe(true)
+  })
+
+  it('validates a random profile', () => {
+    const ch = validChannel('random', { start: '08:00:00', end: '20:00:00' })
+    return expect(LightSchema.isValid(validLight(ch))).resolves.toBe(true)
+  })
+
+  it('rejects missing light name', () => {
+    const ch = validChannel('fixed', { value: 50, start: '08:00:00', end: '20:00:00' })
+    const light = { config: { name: '', channels: { 1: ch } } }
+    return expect(LightSchema.isValid(light)).resolves.toBe(false)
+  })
+
+  it('rejects channel min above 100', () => {
+    const ch = validChannel('fixed', { value: 50, start: '08:00:00', end: '20:00:00' })
+    ch.min = 150
+    return expect(LightSchema.isValid(validLight(ch))).resolves.toBe(false)
+  })
+
+  it('rejects channel with missing name', () => {
+    const ch = validChannel('fixed', { value: 50, start: '08:00:00', end: '20:00:00' })
+    ch.name = ''
+    return expect(LightSchema.isValid(validLight(ch))).resolves.toBe(false)
+  })
+
+  it('uses default (unknown type) profile schema — accepts when type string is present', () => {
+    const ch = validChannel('unknown', {})
+    return expect(LightSchema.isValid(validLight(ch))).resolves.toBe(true)
+  })
+
+  it('uses default profile schema — rejects when type is empty', () => {
+    const ch = validChannel('', {})
+    return expect(LightSchema.isValid(validLight(ch))).resolves.toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `front-end/src/lighting/light_schema.test.js` with 10 tests
- Covers all named profile schemas: fixed, diurnal, interval (auto), sine, random
- Covers rejection of: empty light name, channel min > 100, empty channel name
- Covers the default profile branch (unknown type string present → valid; empty type → invalid)

## Test plan
- [ ] `npm run jest -- --testPathPattern="src/lighting/light_schema"` — all 10 tests pass
- [ ] No regressions in existing lighting tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)