### PR TITLE
test: add ph ControlChart tests

### DIFF
--- a/front-end/src/ph/control_chart.test.js
+++ b/front-end/src/ph/control_chart.test.js
@@ -1,0 +1,49 @@
+import React from 'react'
+import Enzyme, { shallow } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+import ControlChart from './control_chart'
+import configureMockStore from 'redux-mock-store'
+import 'isomorphic-fetch'
+import thunk from 'redux-thunk'
+
+Enzyme.configure({ adapter: new Adapter() })
+const mockStore = configureMockStore([thunk])
+
+const probeConfig = {
+  id: '1',
+  name: 'pH Probe',
+  chart: { ymin: 6, ymax: 9, unit: 'pH', color: '#0088ff' }
+}
+
+describe('Ph ControlChart', () => {
+  it('renders when probe config is missing from store', () => {
+    const store = mockStore({ phprobes: [], ph_readings: {} })
+    const wrapper = shallow(<ControlChart probe_id='1' store={store} />).dive()
+    expect(wrapper).toBeDefined()
+  })
+
+  it('renders when readings are missing from store', () => {
+    const store = mockStore({ phprobes: [probeConfig], ph_readings: {} })
+    const wrapper = shallow(<ControlChart probe_id='1' store={store} />).dive()
+    expect(wrapper).toBeDefined()
+  })
+
+  it('renders with config and readings present', () => {
+    const readings = { historical: [{ time: '08:00', value: 7.5, up: 10, down: 5 }] }
+    const store = mockStore({ phprobes: [probeConfig], ph_readings: { 1: readings } })
+    const wrapper = shallow(<ControlChart probe_id='1' store={store} />).dive()
+    expect(wrapper).toBeDefined()
+  })
+
+  it('fetches probe readings on mount via interval', () => {
+    jest.useFakeTimers()
+    const readings = { historical: [] }
+    const store = mockStore({ phprobes: [probeConfig], ph_readings: { 1: readings } })
+    const wrapper = shallow(<ControlChart probe_id='1' store={store} />).dive()
+    // advance timer to trigger interval fetch
+    jest.advanceTimersByTime(15000)
+    wrapper.unmount()
+    jest.useRealTimers()
+    expect(wrapper).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `front-end/src/ph/control_chart.test.js` with 4 tests
- Covers Redux-connected `ControlChart` in three render states: missing probe config (early return), missing readings (early return), and full render with historical data
- Covers the `setInterval`/`componentWillUnmount` timer lifecycle path

## Test plan
- [ ] `npm run jest -- --testPathPattern="src/ph/control_chart"` — all 4 tests pass
- [ ] No regressions in existing ph tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)