### PR TITLE
Slice 04: clarify backend config and shutdown flow

### DIFF
--- a/commands/main.go
+++ b/commands/main.go
@@ -72,7 +72,11 @@ func main() {
 			cmd.PrintDefaults()
 		}
 		cmd.Parse(args)
-		config := loadConfig(*configFile)
+		config, err := loadConfig(*configFile)
+		if err != nil {
+			fmt.Println("Failed to load config file. Error:", err)
+			os.Exit(1)
+		}
 		resetPassword(config.Database, *user, *password)
 	case "restore-db":
 		cmd := flag.NewFlagSet("restore-db", flag.ExitOnError)
@@ -121,7 +125,11 @@ func main() {
 			cmd.PrintDefaults()
 		}
 		cmd.Parse(args)
-		config := loadConfig(*configFile)
+		config, err := loadConfig(*configFile)
+		if err != nil {
+			fmt.Println("Failed to load config file. Error:", err)
+			os.Exit(1)
+		}
 		daemonize(config.Database)
 	default:
 		fmt.Println("Unknown command: '", v, "'")
@@ -129,15 +137,9 @@ func main() {
 	}
 }
 
-func loadConfig(file string) daemon.Config {
-	config := daemon.DefaultConfig
-	if file != "" {
-		conf, err := daemon.ParseConfig(file)
-		if err != nil {
-			fmt.Println("Failed to parse config file", err)
-			os.Exit(1)
-		}
-		config = conf
+func loadConfig(file string) (daemon.Config, error) {
+	if file == "" {
+		return daemon.DefaultConfig, nil
 	}
-	return config
+	return daemon.ParseConfig(file)
 }

--- a/controller/daemon/config.go
+++ b/controller/daemon/config.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"fmt"
 	"os"
 
 	yaml "gopkg.in/yaml.v2"
@@ -18,7 +19,10 @@ func ParseConfig(filename string) (Config, error) {
 	c := DefaultConfig
 	content, err := os.ReadFile(filename)
 	if err != nil {
-		return c, err
+		return c, fmt.Errorf("read config %q: %w", filename, err)
 	}
-	return c, yaml.Unmarshal(content, &c)
+	if err := yaml.Unmarshal(content, &c); err != nil {
+		return c, fmt.Errorf("parse config %q: %w", filename, err)
+	}
+	return c, nil
 }

--- a/controller/daemon/reef_pi.go
+++ b/controller/daemon/reef_pi.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"errors"
+	"fmt"
 	"log"
 	"time"
 
@@ -29,24 +31,18 @@ func New(version, database string) (*ReefPi, error) {
 	store, err := storage.NewStore(database)
 	if err != nil {
 		log.Println("ERROR: Failed to create store. DB:", database)
-		return nil, err
+		return nil, fmt.Errorf("create store %q: %w", database, err)
 	}
-	s, err := loadSettings(store)
+	s, err := loadOrInitializeSettings(store)
 	if err != nil {
-		log.Println("Warning: Failed to load settings from db, Error:", err)
-		log.Println("Warning: Initializing default settings in database")
-		initialSettings, err := initializeSettings(store)
-		if err != nil {
-			return nil, err
-		}
-		s = initialSettings
+		return nil, err
 	}
 	fn := func(t, m string) error { return logError(store, t, m) }
 	tele := telemetry.Initialize(s.Name, Bucket, store, fn, s.Prometheus)
 
 	auth, err := utils.NewAuth(Bucket, store)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("initialize auth: %w", err)
 	}
 
 	r := &ReefPi{
@@ -92,10 +88,7 @@ func (r *ReefPi) Stop() error {
 	dmError := r.dm.Close()
 	log.Println("reef-pi is shutting down")
 	storeError := r.store.Close()
-	if dmError != nil {
-		return dmError
-	}
-	return storeError
+	return errors.Join(dmError, storeError)
 }
 
 func (r *ReefPi) Subsystem(s string) (controller.Subsystem, error) {
@@ -112,4 +105,19 @@ func (r *ReefPi) Store() storage.Store {
 
 func (r *ReefPi) Telemetry() telemetry.Telemetry {
 	return r.telemetry
+}
+
+func loadOrInitializeSettings(store storage.Store) (settings.Settings, error) {
+	s, err := loadSettings(store)
+	if err == nil {
+		return s, nil
+	}
+
+	log.Println("Warning: Failed to load settings from db, Error:", err)
+	log.Println("Warning: Initializing default settings in database")
+	initialSettings, initErr := initializeSettings(store)
+	if initErr != nil {
+		return settings.Settings{}, fmt.Errorf("initialize default settings: %w", initErr)
+	}
+	return initialSettings, nil
 }


### PR DESCRIPTION
## Summary

Clarify backend config loading and teardown flow without changing config schema or runtime behavior.

This PR:

- moves config-loading error handling back to the command call sites instead of exiting inside `loadConfig`
- wraps config and controller-construction errors with more useful context
- extracts settings fallback logic into a dedicated helper in `daemon.New`
- makes `ReefPi.Stop()` return joined teardown errors instead of silently preferring one

## Linked issue

Closes #2508
Refs #2504

## Scope

- [x] Behavior-preserving refactor only
- [x] No API schema changes
- [x] No UI/UX changes
- [x] No hardware behavior changes

## Verification

```text
go test ./controller/daemon ./commands
go test ./...
git diff -- commands/main.go controller/daemon/config.go controller/daemon/reef_pi.go
```

## Risk review

- Main regression risks: command-line config error paths and teardown error propagation.
- Areas reviewers should scrutinize: unchanged default-config behavior, unchanged command flags, and use of `errors.Join` in `Stop()`.
- Rollback approach: revert this PR to restore the previous control flow.

## Build failure handling

If CI failed during this work:

- [x] reproduced locally where possible
- [x] classified the failure
- [x] fixed it in this PR or linked a follow-up issue
- [x] added a prevention artifact if the failure mode is reusable
