### PR TITLE
Slice 05: add timer repository seam

### DIFF
--- a/commands/db_test.go
+++ b/commands/db_test.go
@@ -253,7 +253,10 @@ func TestDBCmdUpdate(t *testing.T) {
 }
 
 func TestLoadConfig_Default(t *testing.T) {
-	cfg := loadConfig("")
+	cfg, err := loadConfig("")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if cfg.Database == "" {
 		t.Error("Expected non-empty default database path")
 	}

--- a/controller/modules/timer/controller.go
+++ b/controller/modules/timer/controller.go
@@ -17,6 +17,7 @@ type Controller struct {
 	runner  *cron.Cron
 	cronIDs map[string]cron.EntryID
 	c       controller.Controller
+	repo    repository
 }
 
 func New(c controller.Controller) *Controller {
@@ -26,12 +27,13 @@ func New(c controller.Controller) *Controller {
 			cron.WithParser(cron.NewParser(_cronParserSpec)),
 			cron.WithChain(cron.Recover(cron.DefaultLogger)),
 		),
-		c:       c,
+		c:    c,
+		repo: newRepository(c.Store()),
 	}
 }
 
 func (c *Controller) Setup() error {
-	return c.c.Store().CreateBucket(Bucket)
+	return c.repo.Setup()
 }
 
 func (c *Controller) Start() {

--- a/controller/modules/timer/job.go
+++ b/controller/modules/timer/job.go
@@ -68,37 +68,23 @@ func (j *Job) Validate() error {
 }
 
 func (c *Controller) Get(id string) (Job, error) {
-	var job Job
-	return job, c.c.Store().Get(Bucket, id, &job)
+	return c.repo.Get(id)
 }
 
 func (c *Controller) List() ([]Job, error) {
-	jobs := []Job{}
-	fn := func(_ string, v []byte) error {
-		var job Job
-		if err := json.Unmarshal(v, &job); err != nil {
-			return err
-		}
-		jobs = append(jobs, job)
-		return nil
-	}
-	return jobs, c.c.Store().List(Bucket, fn)
+	return c.repo.List()
 }
 
 func (c *Controller) Create(job Job) error {
 	if err := job.Validate(); err != nil {
 		return err
 	}
-
-	fn := func(id string) interface{} {
-		job.ID = id
-		return job
-	}
-	if err := c.c.Store().Create(Bucket, fn); err != nil {
+	created, err := c.repo.Create(job)
+	if err != nil {
 		return err
 	}
-	if job.Enable {
-		return c.addToCron(job)
+	if created.Enable {
+		return c.addToCron(created)
 	}
 	return nil
 }
@@ -118,7 +104,7 @@ func (c *Controller) Update(id string, payload Job) error {
 		}
 	}
 	payload.ID = id
-	if err := c.c.Store().Update(Bucket, id, &payload); err != nil {
+	if err := c.repo.Update(id, payload); err != nil {
 		return err
 	}
 	if payload.Enable {
@@ -132,7 +118,7 @@ func (c *Controller) Delete(id string) error {
 	if err != nil {
 		return err
 	}
-	if err := c.c.Store().Delete(Bucket, id); err != nil {
+	if err := c.repo.Delete(id); err != nil {
 		return err
 	}
 	if j.Enable {

--- a/controller/modules/timer/repository.go
+++ b/controller/modules/timer/repository.go
@@ -1,0 +1,63 @@
+package timer
+
+import (
+	"encoding/json"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+type repository interface {
+	Setup() error
+	Get(string) (Job, error)
+	List() ([]Job, error)
+	Create(Job) (Job, error)
+	Update(string, Job) error
+	Delete(string) error
+}
+
+type storeRepository struct {
+	store storage.Store
+}
+
+func newRepository(store storage.Store) repository {
+	return storeRepository{store: store}
+}
+
+func (r storeRepository) Setup() error {
+	return r.store.CreateBucket(Bucket)
+}
+
+func (r storeRepository) Get(id string) (Job, error) {
+	var job Job
+	return job, r.store.Get(Bucket, id, &job)
+}
+
+func (r storeRepository) List() ([]Job, error) {
+	jobs := []Job{}
+	err := r.store.List(Bucket, func(_ string, v []byte) error {
+		var job Job
+		if err := json.Unmarshal(v, &job); err != nil {
+			return err
+		}
+		jobs = append(jobs, job)
+		return nil
+	})
+	return jobs, err
+}
+
+func (r storeRepository) Create(job Job) (Job, error) {
+	created := job
+	err := r.store.Create(Bucket, func(id string) interface{} {
+		created.ID = id
+		return created
+	})
+	return created, err
+}
+
+func (r storeRepository) Update(id string, job Job) error {
+	return r.store.Update(Bucket, id, &job)
+}
+
+func (r storeRepository) Delete(id string) error {
+	return r.store.Delete(Bucket, id)
+}

--- a/controller/modules/timer/repository_test.go
+++ b/controller/modules/timer/repository_test.go
@@ -1,0 +1,36 @@
+package timer
+
+import (
+	"testing"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+func TestStoreRepositoryCreateAssignsID(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	repo := newRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	job, err := repo.Create(Job{Name: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.ID == "" {
+		t.Fatal("expected repository to assign an id")
+	}
+
+	stored, err := repo.Get(job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Name != "test" {
+		t.Fatalf("expected stored job name %q, got %q", "test", stored.Name)
+	}
+}


### PR DESCRIPTION
## Summary
- hide timer persistence behind a module-local repository so controller logic no longer reaches into the store directly
- keep timer cron behavior and API semantics unchanged while making the assigned job ID explicit at the storage boundary
- repair the stale commands loadConfig test that broke the full Go suite after Slice 04 changed the helper signature

## Testing
- go test ./controller/modules/timer ./controller/modules/equipment ./controller/device_manager/connectors
- go test ./...

Closes #2509