### PR TITLE
Slice 07: fix frontend store state handling

### DIFF
--- a/commands/db_test.go
+++ b/commands/db_test.go
@@ -253,7 +253,10 @@ func TestDBCmdUpdate(t *testing.T) {
 }
 
 func TestLoadConfig_Default(t *testing.T) {
-	cfg := loadConfig("")
+	cfg, err := loadConfig("")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if cfg.Database == "" {
 		t.Error("Expected non-empty default database path")
 	}

--- a/front-end/src/entry.js
+++ b/front-end/src/entry.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import { render } from 'react-dom'
 import { Provider } from 'react-redux'
-import { configureStore } from 'redux/store'
+import { configureStore, setStore } from 'redux/store'
 import App from 'app'
 
-const store = configureStore()
+const store = setStore(configureStore())
 
 render(
   <Provider store={store}>

--- a/front-end/src/redux/reducer.js
+++ b/front-end/src/redux/reducer.js
@@ -1,17 +1,19 @@
-export const rootReducer = (state, action) => {
+import { createInitialState } from './state'
+
+const updateByID = (collection = {}, id, value) => ({
+  ...collection,
+  [id]: value
+})
+
+const updateCamera = (camera = {}, updates) => ({
+  ...camera,
+  ...updates
+})
+
+export const rootReducer = (state = createInitialState(), action) => {
   if (action.type.startsWith('@@redux/INIT')) {
     return state
   }
-  const camera = state.camera
-  const atoUsage = state.ato_usage
-  const doserUsage = state.doser_usage
-  const macroUsage = state.macro_usage
-  const tcUsage = state.tc_usage
-  const lightUsage = state.light_usage
-  const jUsage = state.journal_usage
-  const tcReading = []
-  const pHreadings = state.ph_readings
-  const phReading = []
 
   switch (action.type) {
     case 'LOG_DELETED':
@@ -45,41 +47,33 @@ export const rootReducer = (state, action) => {
     case 'ATO_LOADED':
       return { ...state, config: action.payload }
     case 'ATO_USAGE_LOADED':
-      atoUsage[action.payload.id] = action.payload.data
-      return { ...state, ato_usage: atoUsage }
+      return { ...state, ato_usage: updateByID(state.ato_usage, action.payload.id, action.payload.data) }
     case 'DOSER_USAGE_LOADED':
-      doserUsage[action.payload.id] = action.payload.data
-      return { ...state, doser_usage: doserUsage }
+      return { ...state, doser_usage: updateByID(state.doser_usage, action.payload.id, action.payload.data) }
     case 'MACROS_LOADED':
       return { ...state, macros: action.payload }
     case 'MACRO_USAGE_LOADED':
-      macroUsage[action.payload.id] = action.payload.data
-      return { ...state, macro_usage: macroUsage }
+      return { ...state, macro_usage: updateByID(state.macro_usage, action.payload.id, action.payload.data) }
     case 'TCS_LOADED':
       return { ...state, tcs: action.payload }
     case 'TC_SENSORS_LOADED':
       return { ...state, tc_sensors: action.payload }
     case 'TC_USAGE_LOADED':
-      tcUsage[action.payload.id] = action.payload.usage
-      return { ...state, tc_usage: tcUsage }
+      return { ...state, tc_usage: updateByID(state.tc_usage, action.payload.id, action.payload.usage) }
     case 'TC_READING_COMPLETE':
-      tcReading[action.payload.id] = action.payload.reading
-      return { ...state, tc_reading: { ...tcReading } }
+      return { ...state, tc_reading: updateByID(state.tc_reading, action.payload.id, action.payload.reading) }
     case 'LIGHTS_LOADED':
       return { ...state, lights: action.payload }
     case 'LIGHT_USAGE_LOADED':
-      lightUsage[action.payload.id] = action.payload.usage
-      return { ...state, light_usage: lightUsage }
+      return { ...state, light_usage: updateByID(state.light_usage, action.payload.id, action.payload.usage) }
     case 'DASHBOARD_LOADED':
       return { ...state, dashboard: action.payload }
     case 'PH_PROBES_LOADED':
       return { ...state, phprobes: action.payload }
     case 'PH_PROBE_READINGS_LOADED':
-      pHreadings[action.payload.id] = action.payload.readings
-      return { ...state, ph_readings: pHreadings }
+      return { ...state, ph_readings: updateByID(state.ph_readings, action.payload.id, action.payload.readings) }
     case 'PH_PROBE_READING_COMPLETE':
-      phReading[action.payload.id] = action.payload.reading
-      return { ...state, ph_reading: { ...phReading } }
+      return { ...state, ph_reading: updateByID(state.ph_reading, action.payload.id, action.payload.reading) }
     case 'CAPABILITIES_LOADED':
       return { ...state, capabilities: action.payload }
     case 'SETTINGS_LOADED':
@@ -103,14 +97,11 @@ export const rootReducer = (state, action) => {
     case 'DISPLAY_LOADED':
       return { ...state, display: action.payload }
     case 'IMAGES_LOADED':
-      camera.images = action.payload
-      return { ...state, camera: camera }
+      return { ...state, camera: updateCamera(state.camera, { images: action.payload }) }
     case 'LATEST_IMAGE_LOADED':
-      camera.latest = action.payload
-      return { ...state, camera: camera }
+      return { ...state, camera: updateCamera(state.camera, { latest: action.payload }) }
     case 'CAMERA_CONFIG_LOADED':
-      camera.config = action.payload
-      return { ...state, camera: camera }
+      return { ...state, camera: updateCamera(state.camera, { config: action.payload }) }
     case 'DOSING_PUMPS_LOADED':
       return { ...state, dosers: action.payload }
     case 'INSTANCES_LOADED':
@@ -118,8 +109,7 @@ export const rootReducer = (state, action) => {
     case 'JOURNALS_LOADED':
       return { ...state, journals: action.payload }
     case 'JOURNAL_USAGE_LOADED':
-      jUsage[action.payload.id] = action.payload.data
-      return { ...state, journal_usage: jUsage }
+      return { ...state, journal_usage: updateByID(state.journal_usage, action.payload.id, action.payload.data) }
     case 'JOURNAL_RECORDED':
     case 'JOURNAL_UPDATED':
     case 'JOURNAL_LOADED':

--- a/front-end/src/redux/reducer.test.js
+++ b/front-end/src/redux/reducer.test.js
@@ -1,28 +1,48 @@
 import { rootReducer } from './reducer'
 import { configureStore } from './store'
+import { createInitialState } from './state'
+
+function getPayload () {
+  return {
+    foo: 'bar',
+    id: 1,
+    data: 'foobar:data',
+    usage: 'foobar:usage',
+    readings: 'foobar:readings'
+  }
+}
+
+function getState () {
+  return {
+    ...createInitialState(),
+    camera: {},
+    ato_usage: {},
+    macro_usage: {},
+    tc_usage: {},
+    ph_readings: {}
+  }
+}
+
+function getNestedState () {
+  return {
+    ...createInitialState(),
+    ato_usage: { existing: 'value' },
+    camera: {
+      config: { existing: true },
+      images: ['one'],
+      latest: 'latest'
+    }
+  }
+}
+
 describe('Redux Reducer', () => {
   it('Store', () => {
-    configureStore()
+    const firstStore = configureStore()
+    const secondStore = configureStore()
+    expect(firstStore).not.toBe(secondStore)
   })
+
   it('reducer', () => {
-    function getPayload () {
-      return {
-        foo: 'bar',
-        id: 1,
-        data: 'foobar:data',
-        usage: 'foobar:usage',
-        readings: 'foobar:readings'
-      }
-    }
-    function getState () {
-      return {
-        camera: {},
-        ato_usage: [],
-        macro_usage: {},
-        tc_usage: {},
-        ph_readings: {}
-      }
-    }
     console.log = jest.fn()
     let result
     result = rootReducer(getState(), { type: 'ERRORS_LOADED', payload: getPayload() })
@@ -38,7 +58,7 @@ describe('Redux Reducer', () => {
     result = rootReducer(getState(), { type: 'ATO_LOADED', payload: getPayload() })
     expect(result).toEqual({ ...getState(), config: getPayload() })
     result = rootReducer(getState(), { type: 'ATO_USAGE_LOADED', payload: getPayload() })
-    expect(result).toEqual({ ...getState(), ato_usage: [undefined, 'foobar:data'] })
+    expect(result).toEqual({ ...getState(), ato_usage: { 1: 'foobar:data' } })
     result = rootReducer(getState(), { type: 'MACROS_LOADED', payload: getPayload() })
     expect(result).toEqual({ ...getState(), macros: getPayload() })
     result = rootReducer(getState(), { type: 'MACRO_USAGE_LOADED', payload: getPayload() })
@@ -130,5 +150,15 @@ describe('Redux Reducer', () => {
     result = rootReducer(getState(), { type: 'foo' })
     expect(result).toEqual(getState())
     expect(console.log.mock.calls.length).toBe(1)
+  })
+
+  it('does not mutate nested state objects', () => {
+    const state = getNestedState()
+
+    rootReducer(state, { type: 'ATO_USAGE_LOADED', payload: { id: 1, data: 'updated' } })
+    expect(state.ato_usage).toEqual({ existing: 'value' })
+
+    rootReducer(state, { type: 'CAMERA_CONFIG_LOADED', payload: { foo: 'bar' } })
+    expect(state.camera).toEqual({ config: { existing: true }, images: ['one'], latest: 'latest' })
   })
 })

--- a/front-end/src/redux/state.js
+++ b/front-end/src/redux/state.js
@@ -1,0 +1,57 @@
+export const createInitialState = () => ({
+  info: {
+    name: 'reef-pi'
+  },
+  errors: [],
+  drivers: [],
+  driverOptions: {},
+  equipment: [],
+  timers: [],
+  lights: [],
+  atos: [],
+  tcs: [],
+  phprobes: [],
+  macros: [],
+  dosers: [],
+  configuration: {},
+  capabilities: {
+    dev_mode: false
+  },
+  health_stats: {},
+  inlets: [],
+  jacks: [],
+  analog_inputs: [],
+  outlets: [],
+  settings: {
+    name: '',
+    interface: '',
+    address: '',
+    notification: false,
+    pprof: false,
+    prometheus: false,
+    cors: false,
+    rpi_pwm_freq: 100
+  },
+  dashboard: {},
+  display: {},
+  ato_usage: {},
+  doser_usage: {},
+  macro_usage: {},
+  tc_usage: {},
+  light_usage: {},
+  ph_readings: {},
+  ph_reading: {},
+  tc_sensors: [],
+  tc_reading: {},
+  journals: [],
+  journal_usage: {},
+  telemetry: {},
+  camera: {
+    config: {},
+    latest: undefined,
+    images: []
+  },
+  logs: [],
+  alerts: [],
+  instances: []
+})

--- a/front-end/src/redux/store.js
+++ b/front-end/src/redux/store.js
@@ -1,66 +1,22 @@
 import { createStore, applyMiddleware } from 'redux'
 import thunk from 'redux-thunk'
 import { rootReducer } from './reducer'
+import { createInitialState } from './state'
 
-const initialState = {
-  info: {
-    name: 'reef-pi'
-  },
-  errors: [],
-  drivers: [],
-  driverOptions: {},
-  equipment: [],
-  timers: [],
-  lights: [],
-  atos: [],
-  tcs: [],
-  phprobes: [],
-  macros: [],
-  dosers: [],
-  configuration: {},
-  capabilities: {
-    dev_mode: false
-  },
-  health_stats: {},
-  inlets: [],
-  jacks: [],
-  analog_inputs: [],
-  outlets: [],
-  settings: {
-    name: '',
-    interface: '',
-    address: '',
-    notification: false,
-    pprof: false,
-    prometheus: false,
-    cors: false,
-    rpi_pwm_freq: 100
-  },
-  dashboard: {},
-  display: {},
-  ato_usage: {},
-  doser_usage: {},
-  macro_usage: {},
-  tc_usage: {},
-  light_usage: {},
-  ph_readings: {},
-  ph_reading: [],
-  tc_sensors: [],
-  tc_reading: [],
-  journals: [],
-  journal_usage: {},
-  telemetry: {
-  },
-  camera: {
-    config: {},
-    latest: undefined,
-    images: []
-  },
-  logs: [],
-  alerts: [],
-  instances: []
+export const configureStore = (preloadedState = createInitialState()) => {
+  return createStore(rootReducer, preloadedState, applyMiddleware(thunk))
 }
-const store = createStore(rootReducer, initialState, applyMiddleware(thunk))
-export const configureStore = () => {
-  return store
+
+let appStore
+
+export const setStore = (store) => {
+  appStore = store
+  return appStore
+}
+
+export const getStore = () => {
+  if (!appStore) {
+    appStore = configureStore()
+  }
+  return appStore
 }

--- a/front-end/src/utils/alert.js
+++ b/front-end/src/utils/alert.js
@@ -1,4 +1,4 @@
-import { configureStore } from 'redux/store'
+import { getStore } from 'redux/store'
 import { setAlert } from 'notifications/statics'
 import { addAlert, delAlert} from 'redux/actions/alert'
 import { MsgLevel } from 'utils/enums'
@@ -20,12 +20,12 @@ export function showUpdateSuccessful () {
   let alert = _showAlert(MsgLevel.success, i18n.t("save_successful"))
   setTimeout(() => {
     // only show alert for a second to not block page content
-    configureStore().dispatch(delAlert(alert))
+    getStore().dispatch(delAlert(alert))
   }, 1000)
 }
 function _showAlert (type, msg) {
-  let alert = setAlert(type, msg) 
-  configureStore().dispatch(addAlert(alert))
+  let alert = setAlert(type, msg)
+  getStore().dispatch(addAlert(alert))
   return alert
 }
 export function showAlert (msg) {

--- a/front-end/src/utils/alert.test.js
+++ b/front-end/src/utils/alert.test.js
@@ -2,14 +2,14 @@ import { showInfo, showError, showSuccess, showWarning, showUpdateSuccessful, sh
 import * as store from 'redux/store'
 
 jest.mock('redux/store', () => ({
-  configureStore: jest.fn(() => ({
+  getStore: jest.fn(() => ({
     dispatch: jest.fn()
   }))
 }))
 
 describe('alert utils', () => {
   beforeEach(() => {
-    store.configureStore.mockReturnValue({ dispatch: jest.fn() })
+    store.getStore.mockReturnValue({ dispatch: jest.fn() })
     jest.useFakeTimers()
   })
 
@@ -19,27 +19,27 @@ describe('alert utils', () => {
 
   it('showInfo dispatches an action', () => {
     expect(() => showInfo('test info')).not.toThrow()
-    expect(store.configureStore).toHaveBeenCalled()
+    expect(store.getStore).toHaveBeenCalled()
   })
 
   it('showError dispatches an action', () => {
     expect(() => showError('test error')).not.toThrow()
-    expect(store.configureStore).toHaveBeenCalled()
+    expect(store.getStore).toHaveBeenCalled()
   })
 
   it('showSuccess dispatches an action', () => {
     expect(() => showSuccess('test success')).not.toThrow()
-    expect(store.configureStore).toHaveBeenCalled()
+    expect(store.getStore).toHaveBeenCalled()
   })
 
   it('showWarning dispatches an action', () => {
     expect(() => showWarning('test warning')).not.toThrow()
-    expect(store.configureStore).toHaveBeenCalled()
+    expect(store.getStore).toHaveBeenCalled()
   })
 
   it('showUpdateSuccessful dispatches and auto-dismisses', () => {
     const dispatch = jest.fn()
-    store.configureStore.mockReturnValue({ dispatch })
+    store.getStore.mockReturnValue({ dispatch })
     showUpdateSuccessful()
     expect(dispatch).toHaveBeenCalledTimes(1)
     jest.runAllTimers()


### PR DESCRIPTION
## Summary
- make  return a fresh Redux store so tests and isolated callers no longer share singleton state
- add explicit  and  helpers so runtime utility code can still dispatch against the app store without creating a new store
- remove reducer-side nested state mutation and add reducer coverage for fresh-store creation and immutable nested updates

## Testing
- Local frontend tests not run because this checkout does not have  installed
- CI will validate Jest and standard for this slice

Closes #2511