### PR TITLE
Slice 08: unify frontend API actions

### DIFF
--- a/front-end/src/redux/actions/api.js
+++ b/front-end/src/redux/actions/api.js
@@ -1,0 +1,51 @@
+import { reduxDelete, reduxGet, reduxPost, reduxPut } from 'utils/ajax'
+
+export const apiPath = (...parts) => {
+  const path = parts
+    .reduce((all, part) => {
+      if (Array.isArray(part)) {
+        return all.concat(part)
+      }
+      all.push(part)
+      return all
+    }, [])
+    .filter(part => part !== undefined && part !== null && part !== '')
+    .map(part => String(part).replace(/^\/+|\/+$/g, ''))
+    .join('/')
+
+  return '/api/' + path
+}
+
+export const getAction = (parts, success, options = {}) => {
+  return reduxGet({
+    ...options,
+    url: apiPath(parts),
+    success
+  })
+}
+
+export const putAction = (parts, data, success, options = {}) => {
+  return reduxPut({
+    ...options,
+    url: apiPath(parts),
+    data,
+    success
+  })
+}
+
+export const postAction = (parts, data, success, options = {}) => {
+  return reduxPost({
+    ...options,
+    url: apiPath(parts),
+    data,
+    success
+  })
+}
+
+export const deleteAction = (parts, success, options = {}) => {
+  return reduxDelete({
+    ...options,
+    url: apiPath(parts),
+    success
+  })
+}

--- a/front-end/src/redux/actions/ato.js
+++ b/front-end/src/redux/actions/ato.js
@@ -1,4 +1,4 @@
-import { reduxPut, reduxDelete, reduxGet, reduxPost } from 'utils/ajax'
+import { deleteAction, getAction, postAction, putAction } from './api'
 
 export const atoUpdated = () => {
   return ({
@@ -14,10 +14,7 @@ export const atosLoaded = (s) => {
 }
 
 export const fetchATOs = () => {
-  return (reduxGet({
-    url: '/api/atos',
-    success: atosLoaded
-  }))
+  return getAction('atos', atosLoaded)
 }
 
 export const atoLoaded = (s) => {
@@ -28,10 +25,7 @@ export const atoLoaded = (s) => {
 }
 
 export const fetchATO = (id) => {
-  return (reduxGet({
-    url: '/api/atos/' + id,
-    success: atoLoaded
-  }))
+  return getAction(['atos', id], atoLoaded)
 }
 
 export const atoUsageLoaded = (id) => {
@@ -44,38 +38,21 @@ export const atoUsageLoaded = (id) => {
 }
 
 export const fetchATOUsage = (id) => {
-  return (reduxGet({
-    url: '/api/atos/' + id + '/usage',
-    success: atoUsageLoaded(id)
-  }))
+  return getAction(['atos', id, 'usage'], atoUsageLoaded(id))
 }
 
 export const createATO = (a) => {
-  return (reduxPut({
-    url: '/api/atos',
-    data: a,
-    success: fetchATOs
-  }))
+  return putAction('atos', a, fetchATOs)
 }
 
 export const updateATO = (id, a) => {
-  return (reduxPost({
-    url: '/api/atos/' + id,
-    data: a,
-    success: fetchATOs
-  }))
+  return postAction(['atos', id], a, fetchATOs)
 }
 
 export const deleteATO = (id) => {
-  return (reduxDelete({
-    url: '/api/atos/' + id,
-    success: fetchATOs
-  }))
+  return deleteAction(['atos', id], fetchATOs)
 }
 
 export const resetATO = (id) => {
-  return (reduxPost({
-    url: '/api/atos/' + id + '/reset',
-    success: fetchATOs
-  }))
+  return postAction(['atos', id, 'reset'], undefined, fetchATOs)
 }

--- a/front-end/src/redux/actions/camera.js
+++ b/front-end/src/redux/actions/camera.js
@@ -1,4 +1,4 @@
-import { reduxGet, reduxPost } from '../../utils/ajax'
+import { getAction, postAction } from './api'
 
 export const configLoaded = (s) => {
   return ({
@@ -22,38 +22,21 @@ export const imagesLoaded = (s) => {
 }
 
 export const fetchConfig = () => {
-  return (reduxGet({
-    url: '/api/camera/config',
-    success: configLoaded
-  }))
+  return getAction(['camera', 'config'], configLoaded)
 }
 
 export const updateConfig = (a) => {
-  return (reduxPost({
-    url: '/api/camera/config',
-    data: a,
-    success: fetchConfig
-  }))
+  return postAction(['camera', 'config'], a, fetchConfig)
 }
 
 export const takeImage = () => {
-  return (reduxPost({
-    url: '/api/camera/shoot',
-    data: {},
-    success: listImages
-  }))
+  return postAction(['camera', 'shoot'], {}, listImages)
 }
 
 export const getLatestImage = () => {
-  return (reduxGet({
-    url: '/api/camera/latest',
-    success: latestImageLoaded
-  }))
+  return getAction(['camera', 'latest'], latestImageLoaded)
 }
 
 export const listImages = () => {
-  return (reduxGet({
-    url: '/api/camera/images',
-    success: imagesLoaded
-  }))
+  return getAction(['camera', 'images'], imagesLoaded)
 }

--- a/front-end/src/redux/actions/instances.js
+++ b/front-end/src/redux/actions/instances.js
@@ -1,4 +1,4 @@
-import { reduxPut, reduxDelete, reduxGet, reduxPost } from 'utils/ajax'
+import { deleteAction, getAction, postAction, putAction } from './api'
 
 export const instanceUpdated = () => {
   return ({
@@ -14,10 +14,7 @@ export const instancesLoaded = (s) => {
 }
 
 export const fetchInstances = () => {
-  return (reduxGet({
-    url: '/api/instances',
-    success: instancesLoaded
-  }))
+  return getAction('instances', instancesLoaded)
 }
 
 export const instanceLoaded = (s) => {
@@ -28,31 +25,17 @@ export const instanceLoaded = (s) => {
 }
 
 export const fetchInstance = (id) => {
-  return (reduxGet({
-    url: '/api/instances/' + id,
-    success: instanceLoaded
-  }))
+  return getAction(['instances', id], instanceLoaded)
 }
 
 export const createInstance = (a) => {
-  return (reduxPut({
-    url: '/api/instances',
-    data: a,
-    success: fetchInstances
-  }))
+  return putAction('instances', a, fetchInstances)
 }
 
 export const updateInstance = (id, a) => {
-  return (reduxPost({
-    url: '/api/instances/' + id,
-    data: a,
-    success: fetchInstances
-  }))
+  return postAction(['instances', id], a, fetchInstances)
 }
 
 export const deleteInstance = (id) => {
-  return (reduxDelete({
-    url: '/api/instances/' + id,
-    success: fetchInstances
-  }))
+  return deleteAction(['instances', id], fetchInstances)
 }

--- a/front-end/src/redux/actions/timer.js
+++ b/front-end/src/redux/actions/timer.js
@@ -1,4 +1,4 @@
-import { reduxPut, reduxDelete, reduxGet, reduxPost } from '../../utils/ajax'
+import { deleteAction, getAction, postAction, putAction } from './api'
 
 export const timersLoaded = (s) => {
   return ({
@@ -14,31 +14,17 @@ export const timerDeleted = () => {
 }
 
 export const fetchTimers = () => {
-  return (reduxGet({
-    url: '/api/timers',
-    success: timersLoaded
-  }))
+  return getAction('timers', timersLoaded)
 }
 
 export const createTimer = (a) => {
-  return (reduxPut({
-    url: '/api/timers',
-    data: a,
-    success: fetchTimers
-  }))
+  return putAction('timers', a, fetchTimers)
 }
 
 export const updateTimer = (id, a) => {
-  return (reduxPost({
-    url: '/api/timers/' + id,
-    data: a,
-    success: fetchTimers
-  }))
+  return postAction(['timers', id], a, fetchTimers)
 }
 
 export const deleteTimer = (id) => {
-  return (reduxDelete({
-    url: '/api/timers/' + id,
-    success: fetchTimers
-  }))
+  return deleteAction(['timers', id], fetchTimers)
 }

--- a/front-end/src/utils/ajax.js
+++ b/front-end/src/utils/ajax.js
@@ -1,121 +1,106 @@
 import { showError } from 'utils/alert'
+
 function makeHeaders () {
   const headers = new Headers()
   headers.append('Content-Type', 'application/json')
   return headers
 }
 
-export function reduxGet (params) {
-  return dispatch => {
-    return fetch(params.url, {
-      method: 'GET',
-      credentials: 'same-origin',
-      headers: makeHeaders()
-    })
-      .then(response => {
-        if (!response.ok) {
-          if (response.status === 401) {
-            showError('Authentication failure')
-            return
-          }
-          if (params.suppressError) {
-            return
-          }
-          response.text().then(err => {
-            showError(err + ' | HTTP ' + response.status)
-          })
-        }
-        return response
-      })
-      .then(response => response.json())
-      .then(data => dispatch(params.success(data)))
-      .catch(() => {
-        dispatch({ type: 'API_FAILURE', params: params })
-      })
+function buildRequestOptions (params) {
+  const options = {
+    method: params.method,
+    credentials: 'same-origin'
   }
+
+  if (params.raw) {
+    options.body = params.raw
+    return options
+  }
+
+  if (params.method === 'GET' || params.method === 'DELETE') {
+    options.headers = makeHeaders()
+    return options
+  }
+
+  options.headers = makeHeaders()
+  options.body = JSON.stringify(params.data)
+  return options
 }
 
-export function reduxDelete (params) {
-  return dispatch => {
-    return fetch(params.url, {
-      method: 'DELETE',
-      credentials: 'same-origin',
-      headers: makeHeaders()
-    })
-      .then(response => {
-        if (!response.ok) {
-          if (params.suppressError) {
-            return
-          }
-          response.text().then(err => {
-            showError(err + ' | HTTP ' + response.status)
-          })
-        }
-        return response
-      })
-      .then(() => dispatch(params.success()))
-      .catch(() => {
-        dispatch({ type: 'API_FAILURE', params: params })
-      })
+function handleErrorResponse (response, params) {
+  if (response.status === 401) {
+    showError('Authentication failure')
+    return
   }
-}
-
-export function reduxPut (params) {
-  return dispatch => {
-    return fetch(params.url, {
-      method: 'PUT',
-      credentials: 'same-origin',
-      headers: makeHeaders(),
-      body: JSON.stringify(params.data)
-    })
-      .then(response => {
-        if (!response.ok) {
-          if (params.suppressError) {
-            return
-          }
-          response.text().then(err => {
-            showError(err + ' | HTTP ' + response.status)
-          })
-        }
-        return response
-      })
-      .then(() => dispatch(params.success()))
-      .catch(() => {
-        dispatch({ type: 'API_FAILURE', params: params })
-      })
+  if (params.suppressError) {
+    return response
   }
-}
 
-export function reduxPost (params) {
-  return dispatch => {
-    const fParams = {
-      method: 'POST',
-      credentials: 'same-origin'
+  response.text().then(err => {
+    if (params.failure) {
+      params.failure(response)
+      return
     }
-    if (params.raw) {
-      fParams.body = params.raw
-    } else {
-      fParams.body = JSON.stringify(params.data)
-      fParams.headers = makeHeaders()
-    }
-    return fetch(params.url, fParams).then(response => {
+    showError(err + ' | HTTP ' + response.status)
+  })
+
+  return response
+}
+
+function parseResponse (response, params) {
+  if (response === undefined) {
+    return Promise.resolve(undefined)
+  }
+  if (!params.parseJSON) {
+    return Promise.resolve(response)
+  }
+  return response.json()
+}
+
+function request (params, dispatch) {
+  return fetch(params.url, buildRequestOptions(params))
+    .then(response => {
       if (!response.ok) {
-        if (params.suppressError) {
-          return
-        }
-        response.text().then(err => {
-          if (params.failure) {
-            params.failure(response)
-            return
-          }
-          showError(err + ' | HTTP ' + response.status)
-        })
+        return handleErrorResponse(response, params)
       }
       return response
     })
-      .then(data => dispatch(params.success(data)))
-      .catch(() => {
-        dispatch({ type: 'API_FAILURE', params: params })
-      })
-  }
+    .then(response => parseResponse(response, params))
+    .then(data => dispatch(params.success(data)))
+    .catch(() => {
+      dispatch({ type: 'API_FAILURE', params: params })
+    })
+}
+
+function makeReduxRequest (params) {
+  return dispatch => request(params, dispatch)
+}
+
+export function reduxGet (params) {
+  return makeReduxRequest({
+    ...params,
+    method: 'GET',
+    parseJSON: true
+  })
+}
+
+export function reduxDelete (params) {
+  return makeReduxRequest({
+    ...params,
+    method: 'DELETE'
+  })
+}
+
+export function reduxPut (params) {
+  return makeReduxRequest({
+    ...params,
+    method: 'PUT'
+  })
+}
+
+export function reduxPost (params) {
+  return makeReduxRequest({
+    ...params,
+    method: 'POST'
+  })
 }


### PR DESCRIPTION
## Summary
- centralize request construction and response handling in the existing frontend ajax helper
- add shared API path and request helpers for Redux actions so actions stop hand-building common /api endpoints
- migrate representative action modules for ATO, timer, instances, and camera to the shared helper pattern without changing API behavior

## Testing
- Local frontend tests not run because this checkout does not have node_modules installed
- CI will validate Jest and standard for this slice

Closes #2512