### PR TITLE
fix: daemon TestAPI cleans up api-test.db to prevent BoltDB timeout

### DIFF
--- a/controller/daemon/api_test.go
+++ b/controller/daemon/api_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/reef-pi/reef-pi/controller/settings"
@@ -12,8 +13,15 @@ import (
 )
 
 func TestAPI(t *testing.T) {
-	store, err := storage.NewStore("api-test.db")
-	defer store.Close()
+	const dbFile = "api-test.db"
+	os.Remove(dbFile)
+	store, err := storage.NewStore(dbFile)
+	if store != nil {
+		defer func() {
+			store.Close()
+			os.Remove(dbFile)
+		}()
+	}
 
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
- `TestAPI` used a hard-coded `api-test.db` file with no cleanup
- If a previous run panicked mid-test, the BoltDB file stayed locked; the next `go test` run would open it, hit the 3-second `bolt.Options.Timeout`, call `t.Fatal`, and then crash with a nil-pointer panic in the deferred `store.Close()`
- Fix: `os.Remove` the file before opening (removes any stale lock), then defer both `store.Close()` and `os.Remove` so the file is always cleaned up

## Test plan
- [ ] `go test -v -run TestAPI ./controller/daemon/` — passes
- [ ] Running the test twice in a row — both passes, no leftover `api-test.db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)