### PR TITLE
Slice 10: clean up equipment module

### DIFF
--- a/front-end/src/equipment/chart.jsx
+++ b/front-end/src/equipment/chart.jsx
@@ -3,6 +3,7 @@ import { ResponsiveContainer, Tooltip, XAxis, BarChart, Bar } from 'recharts'
 import { fetchEquipment } from '../redux/actions/equipment'
 import { connect } from 'react-redux'
 import i18next from 'i18next'
+import { EQUIPMENT_POLL_INTERVAL_MS } from './utils'
 
 class CustomToolTip extends React.Component {
   render () {
@@ -23,12 +24,11 @@ class CustomToolTip extends React.Component {
 class chart extends React.Component {
   componentDidMount () {
     this.props.fetchEquipment()
-    const timer = window.setInterval(this.props.fetchEquipment, 10 * 1000)
-    this.setState({ timer: timer })
+    this.timer = window.setInterval(this.props.fetchEquipment, EQUIPMENT_POLL_INTERVAL_MS)
   }
 
   componentWillUnmount () {
-    window.clearInterval(this.state.timer)
+    window.clearInterval(this.timer)
   }
 
   render () {

--- a/front-end/src/equipment/ctrl_panel.jsx
+++ b/front-end/src/equipment/ctrl_panel.jsx
@@ -3,36 +3,26 @@ import { fetchEquipment, updateEquipment } from '../redux/actions/equipment'
 import { connect } from 'react-redux'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import Switch from 'react-toggle-switch'
-import { SortByName } from 'utils/sort_by_name'
+import { buildEquipmentPayload, EQUIPMENT_POLL_INTERVAL_MS, sortEquipment } from './utils'
 
 class CtrlPanel extends React.Component {
   constructor (props) {
     super(props)
-    this.state = {
-      timer: undefined
-    }
     this.toggleState = this.toggleState.bind(this)
   }
 
   componentDidMount () {
-    const timer = window.setInterval(this.props.fetchEquipment, 10 * 1000)
-    this.setState({ timer: timer })
+    this.timer = window.setInterval(this.props.fetchEquipment, EQUIPMENT_POLL_INTERVAL_MS)
   }
 
   componentWillUnmount () {
-    window.clearInterval(this.state.timer)
+    window.clearInterval(this.timer)
   }
 
-  toggleState (e, equipmentId, equipmentName, equipmentOn, equipmentOutlet, equipmentStayOffOnBoot) {
+  toggleState (e, equipment) {
     e.preventDefault()
-    const values = {
-      id: equipmentId,
-      name: equipmentName,
-      on: !equipmentOn,
-      outlet: equipmentOutlet,
-      stay_off_on_boot: equipmentStayOffOnBoot
-    }
-    this.props.updateEquipment(parseInt(equipmentId), values)
+    const values = buildEquipmentPayload(equipment, { on: !equipment.on })
+    this.props.updateEquipment(parseInt(equipment.id), values)
   }
 
   render () {
@@ -43,12 +33,12 @@ class CtrlPanel extends React.Component {
     return (
       <div className='container' style={{ marginBottom: '3px' }}>
         <div className='row'>
-          {this.props.equipment.sort((a, b) => SortByName(a, b))
+          {sortEquipment(this.props.equipment)
             .map(item => {
               return (
                 <div className='col-12 col-sm-6 col-md-2 col-lg-3 order-sm-3' key={'eq-' + item.id}>
                   <FormControlLabel
-                    control={<Switch on={item.on} onClick={(e) => { this.toggleState(e, item.id, item.name, item.on, item.outlet, item.stay_off_on_boot) }} />}
+                    control={<Switch on={item.on} onClick={(e) => { this.toggleState(e, item) }} />}
                     label={item.name}
                   />
                 </div>

--- a/front-end/src/equipment/equipment.test.js
+++ b/front-end/src/equipment/equipment.test.js
@@ -7,6 +7,7 @@ import EditEquipment from './edit_equipment'
 import EquipmentForm from './equipment_form'
 import Chart from './chart'
 import Main from './main'
+import { buildEquipmentPayload, SORT_NAME_AZ, SORT_NAME_ZA, SORT_ON_FIRST, SORT_OFF_FIRST, sortEquipment } from './utils'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import 'isomorphic-fetch'
@@ -41,6 +42,28 @@ describe('Equipment ui', () => {
   it('<Main />', () => {
     const m = shallow(<Main store={mockStore({ outlets: outlets, equipment: eqs })} />)
       .dive()
+  })
+
+  it('sortEquipment supports all sort modes without mutating input', () => {
+    const unsorted = [
+      { id: '1', name: 'Beta', on: false },
+      { id: '2', name: 'Alpha', on: true }
+    ]
+    expect(sortEquipment(unsorted, SORT_NAME_AZ).map(e => e.name)).toEqual(['Alpha', 'Beta'])
+    expect(sortEquipment(unsorted, SORT_NAME_ZA).map(e => e.name)).toEqual(['Beta', 'Alpha'])
+    expect(sortEquipment(unsorted, SORT_ON_FIRST).map(e => e.name)).toEqual(['Alpha', 'Beta'])
+    expect(sortEquipment(unsorted, SORT_OFF_FIRST).map(e => e.name)).toEqual(['Beta', 'Alpha'])
+    expect(unsorted.map(e => e.name)).toEqual(['Beta', 'Alpha'])
+  })
+
+  it('buildEquipmentPayload preserves existing fields and applies updates', () => {
+    expect(buildEquipmentPayload(eqs[0], { on: false })).toEqual({
+      id: '1',
+      name: 'Foo',
+      on: false,
+      outlet: '1',
+      stay_off_on_boot: undefined
+    })
   })
 
   it('<Equipment />', () => {

--- a/front-end/src/equipment/main.jsx
+++ b/front-end/src/equipment/main.jsx
@@ -4,27 +4,15 @@ import { updateEquipment, fetchEquipment, createEquipment, deleteEquipment } fro
 import { fetchOutlets } from 'redux/actions/outlets'
 import { connect } from 'react-redux'
 import EquipmentForm from './equipment_form'
-import { SortByName } from 'utils/sort_by_name'
+import { SORT_NAME_AZ, SORT_NAME_ZA, SORT_ON_FIRST, SORT_OFF_FIRST, sortEquipment } from './utils'
 import i18next from 'i18next'
 
-const SORT_NAME_AZ = 'name_az'
-const SORT_NAME_ZA = 'name_za'
-const SORT_ON_FIRST = 'on_first'
-const SORT_OFF_FIRST = 'off_first'
-
-function sortEquipment (equipment, mode) {
-  const copy = [...equipment]
-  switch (mode) {
-    case SORT_NAME_ZA:
-      return copy.sort((a, b) => SortByName(b, a))
-    case SORT_ON_FIRST:
-      return copy.sort((a, b) => (b.on ? 1 : 0) - (a.on ? 1 : 0) || SortByName(a, b))
-    case SORT_OFF_FIRST:
-      return copy.sort((a, b) => (a.on ? 1 : 0) - (b.on ? 1 : 0) || SortByName(a, b))
-    default:
-      return copy.sort((a, b) => SortByName(a, b))
-  }
-}
+const sortOptions = [
+  { value: SORT_NAME_AZ, label: 'equipment:sort_name_az' },
+  { value: SORT_NAME_ZA, label: 'equipment:sort_name_za' },
+  { value: SORT_ON_FIRST, label: 'equipment:sort_on_first' },
+  { value: SORT_OFF_FIRST, label: 'equipment:sort_off_first' }
+]
 
 class main extends React.Component {
   constructor (props) {
@@ -66,11 +54,11 @@ class main extends React.Component {
   }
 
   render () {
-    let nEq = <div />
-    if (this.state.addEquipment) {
-      nEq = <EquipmentForm outlets={this.props.outlets} actionLabel={i18next.t('add')} onSubmit={this.handleAddEquipment} />
-    }
     const sorted = sortEquipment(this.props.equipment, this.state.sortMode)
+    const newEquipmentForm = this.state.addEquipment
+      ? <EquipmentForm outlets={this.props.outlets} actionLabel={i18next.t('add')} onSubmit={this.handleAddEquipment} />
+      : <div />
+
     return (
       <ul className='list-group list-group-flush'>
         <li className='list-group-item'>
@@ -85,10 +73,9 @@ class main extends React.Component {
                 value={this.state.sortMode}
                 onChange={this.handleSortChange}
               >
-                <option value={SORT_NAME_AZ}>{i18next.t('equipment:sort_name_az')}</option>
-                <option value={SORT_NAME_ZA}>{i18next.t('equipment:sort_name_za')}</option>
-                <option value={SORT_ON_FIRST}>{i18next.t('equipment:sort_on_first')}</option>
-                <option value={SORT_OFF_FIRST}>{i18next.t('equipment:sort_off_first')}</option>
+                {sortOptions.map(option => (
+                  <option key={option.value} value={option.value}>{i18next.t(option.label)}</option>
+                ))}
               </select>
             </div>
           </div>
@@ -116,7 +103,7 @@ class main extends React.Component {
               />
             </div>
           </div>
-          {nEq}
+          {newEquipmentForm}
         </li>
       </ul>
     )

--- a/front-end/src/equipment/utils.js
+++ b/front-end/src/equipment/utils.js
@@ -1,0 +1,32 @@
+import { SortByName } from 'utils/sort_by_name'
+
+export const SORT_NAME_AZ = 'name_az'
+export const SORT_NAME_ZA = 'name_za'
+export const SORT_ON_FIRST = 'on_first'
+export const SORT_OFF_FIRST = 'off_first'
+export const EQUIPMENT_POLL_INTERVAL_MS = 10 * 1000
+
+export function sortEquipment (equipment = [], mode = SORT_NAME_AZ) {
+  const copy = [...equipment]
+  switch (mode) {
+    case SORT_NAME_ZA:
+      return copy.sort((a, b) => SortByName(b, a))
+    case SORT_ON_FIRST:
+      return copy.sort((a, b) => (b.on ? 1 : 0) - (a.on ? 1 : 0) || SortByName(a, b))
+    case SORT_OFF_FIRST:
+      return copy.sort((a, b) => (a.on ? 1 : 0) - (b.on ? 1 : 0) || SortByName(a, b))
+    default:
+      return copy.sort((a, b) => SortByName(a, b))
+  }
+}
+
+export function buildEquipmentPayload (equipment, updates = {}) {
+  return {
+    id: equipment.id,
+    name: equipment.name,
+    on: equipment.on,
+    outlet: equipment.outlet,
+    stay_off_on_boot: equipment.stay_off_on_boot,
+    ...updates
+  }
+}


### PR DESCRIPTION
## Summary
- extract shared equipment module helpers for sort modes, polling cadence, and equipment update payload construction
- stop mutating equipment props during control-panel sorting and simplify polling timers in the chart and control-panel views
- keep existing equipment behavior and UI intact while making the module internals easier to reuse and test

## Testing
- Local frontend tests not run because this checkout does not have node_modules installed
- CI will validate Jest and standard for this slice

Closes #2514