### PR TITLE
Slice 11: harden frontend design tokens

### DIFF
--- a/front-end/assets/sass/_colors.scss
+++ b/front-end/assets/sass/_colors.scss
@@ -1,3 +1,9 @@
 $main-alternate-color: #1c7e19;
 $main-color: #27a822;
 $main-dark-color: #267723;
+$surface-color: #f5faf3;
+$surface-elevated-color: #ffffff;
+$border-color: #d6e5d0;
+$text-color: #1f2a1f;
+$text-muted-color: #4e5f4e;
+$focus-color: #174d16;

--- a/front-end/assets/sass/navbar.scss
+++ b/front-end/assets/sass/navbar.scss
@@ -1,26 +1,48 @@
 @import './colors';
 
 .navbar-reefpi {
-  background-color: $main-color;
+  background: linear-gradient(180deg, $main-color 0%, $main-alternate-color 100%);
+  box-shadow: 0 2px 8px rgba(31, 42, 31, 0.14);
 }
+
 .navbar-reefpi .navbar-brand {
   color: #FFF;
 }
-.current-tab{
-  border:none;
-  cursor:default;
+
+.current-tab {
+  border: none;
+  cursor: default;
+  max-width: calc(100vw - 7rem);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
-/* change the brand and text color */
-.navbar-reefpi
+
 .navbar-reefpi .navbar-text {
-  color: rgba(255,255,255,.8);
+  color: rgba(255, 255, 255, 0.84);
 }
-/* change the link color */
+
 .navbar-reefpi .navbar-nav .nav-link {
-  color: rgba(255,255,255,.5);
+  color: rgba(255, 255, 255, 0.82);
+  border-radius: 0.375rem;
+  padding: 0.625rem 0.875rem;
 }
-/* change the color of active or hovered links */
+
+.navbar-reefpi .navbar-nav .nav-link:hover,
+.navbar-reefpi .navbar-nav .nav-link:focus {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: #ffffff;
+}
+
 .navbar-reefpi .nav-item.active .nav-link,
 .navbar-reefpi .nav-item:hover .nav-link {
   color: #ffffff;
+}
+
+.navbar-reefpi .navbar-toggler {
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.navbar-reefpi .navbar-toggler:focus {
+  border-color: #ffffff;
 }

--- a/front-end/assets/sass/style.scss
+++ b/front-end/assets/sass/style.scss
@@ -8,6 +8,20 @@
 @import './alert';
 @import './fatal_error';
 
+:root {
+  --reefpi-color-brand: #{$main-color};
+  --reefpi-color-brand-dark: #{$main-dark-color};
+  --reefpi-color-brand-alt: #{$main-alternate-color};
+  --reefpi-color-surface: #{$surface-color};
+  --reefpi-color-surface-elevated: #{$surface-elevated-color};
+  --reefpi-color-border: #{$border-color};
+  --reefpi-color-text: #{$text-color};
+  --reefpi-color-text-muted: #{$text-muted-color};
+  --reefpi-color-focus: #{$focus-color};
+  --reefpi-shell-gutter: 0.75rem;
+  --reefpi-panel-gap: 1rem;
+  --reefpi-tap-target-min: 2.75rem;
+}
 
 .reef_pi_panel {
   border-style: none;
@@ -25,18 +39,58 @@ html {
   font-family: 'Century Gothic', CenturyGothic, Geneva, AppleGothic, sans-serif;
 }
 
+body {
+  background-color: var(--reefpi-color-surface);
+  color: var(--reefpi-color-text);
+}
+
+#main-panel {
+  min-height: 100vh;
+}
+
+.container-fluid {
+  padding-left: var(--reefpi-shell-gutter);
+  padding-right: var(--reefpi-shell-gutter);
+}
+
 .body-panel {
   margin-top: 10px;
   margin-bottom: 20px;
   padding-bottom: 70px;
+  row-gap: var(--reefpi-panel-gap);
 }
 
 .nav-item {
   cursor: pointer;
 }
 
+.list-group-item,
+.reef_pi_panel,
+.conf-nav,
+.navbar-reefpi {
+  border-color: var(--reefpi-color-border);
+}
+
+.list-group-item {
+  background-color: var(--reefpi-color-surface-elevated);
+}
+
 .conf-nav {
   margin-bottom: 10px;
+  row-gap: 0.25rem;
+}
+
+.conf-nav .nav-link,
+.navbar-reefpi .nav-link,
+.btn {
+  min-height: var(--reefpi-tap-target-min);
+  display: inline-flex;
+  align-items: center;
+}
+
+.text-muted,
+small.text-muted {
+  color: var(--reefpi-color-text-muted) !important;
 }
 
 div.dropdown-menu {
@@ -53,7 +107,23 @@ input[type=number].no-spinner::-webkit-outer-spin-button {
   width: 100%;
 }
 
+a:focus,
+button:focus,
+input:focus,
+select:focus,
+textarea:focus,
+.nav-link:focus,
+.btn:focus {
+  outline: 2px solid var(--reefpi-color-focus);
+  outline-offset: 2px;
+  box-shadow: none !important;
+}
+
 @media screen and (min-width: 768px) {
+  :root {
+    --reefpi-shell-gutter: 1rem;
+  }
+
   .body-panel {
     margin-bottom: 85px;
   }
@@ -62,6 +132,24 @@ input[type=number].no-spinner::-webkit-outer-spin-button {
     -webkit-transition:none;
     -moz-transition:none;
     overflow:visible;
+  }
+}
+
+@media screen and (max-width: 767.98px) {
+  .body-panel {
+    padding-bottom: 90px;
+  }
+
+  .conf-nav {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    white-space: nowrap;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .conf-nav .nav-link {
+    white-space: nowrap;
   }
 }
 


### PR DESCRIPTION
## Summary
- add shared shell-level design tokens for the existing reef-pi color palette, surfaces, borders, text, and focus states
- improve navbar contrast, focus visibility, and tap-target sizing while preserving the current visual identity
- add small responsive hardening for shell spacing and configuration-tab overflow on narrow screens without changing page structure

## Testing
- Local frontend tests not run because this checkout does not have node_modules installed
- CI will validate Jest and standard for this slice

Closes #2515