### PR TITLE
Slice 12: modernize frontend test setup

### DIFF
--- a/front-end/src/dashboard/blank_panel.test.js
+++ b/front-end/src/dashboard/blank_panel.test.js
@@ -1,22 +1,19 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import renderer from 'react-test-renderer'
 import BlankPanel from './blank_panel'
-
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('<BlankPanel />', () => {
   it('renders without throwing', () => {
-    expect(() => shallow(<BlankPanel height={200} />)).not.toThrow()
+    expect(() => renderer.create(<BlankPanel height={200} />)).not.toThrow()
   })
 
   it('renders a container div', () => {
-    const wrapper = shallow(<BlankPanel height={200} />)
-    expect(wrapper.find('.container')).toHaveLength(1)
+    const tree = renderer.create(<BlankPanel height={200} />).toJSON()
+    expect(tree.props.className).toBe('container')
   })
 
   it('handles componentWillUnmount gracefully', () => {
-    const wrapper = shallow(<BlankPanel height={200} />)
-    expect(() => wrapper.unmount()).not.toThrow()
+    const component = renderer.create(<BlankPanel height={200} />)
+    expect(() => component.unmount()).not.toThrow()
   })
 })

--- a/front-end/src/dashboard/blank_panel.test.js
+++ b/front-end/src/dashboard/blank_panel.test.js
@@ -2,6 +2,10 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import BlankPanel from './blank_panel'
 
+jest.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }) => <div className='responsive-container'>{children}</div>
+}))
+
 describe('<BlankPanel />', () => {
   it('renders without throwing', () => {
     expect(() => renderer.create(<BlankPanel height={200} />)).not.toThrow()

--- a/front-end/src/fatal_error.test.js
+++ b/front-end/src/fatal_error.test.js
@@ -9,31 +9,44 @@ function mountClassComponent (Component) {
   return instance
 }
 
+async function flushPromises () {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
 describe('FatalError', () => {
   afterEach(() => {
     jest.resetAllMocks()
     jest.useRealTimers()
   })
 
-  it('polls health and updates state', async () => {
-    jest.useFakeTimers()
+  it('updates state from successful and failed health checks', async () => {
     const instance = mountClassComponent(FatalError)
 
     global.fetch = jest.fn()
       .mockResolvedValueOnce({ ok: true, status: 200 })
-      .mockRejectedValueOnce(Error)
+      .mockRejectedValueOnce(new Error('network error'))
+
+    instance.checkHealth()
+    await flushPromises()
+    expect(instance.state.up).toBe(true)
+
+    instance.checkHealth()
+    await flushPromises()
+    expect(instance.state.up).toBe(false)
+  })
+
+  it('starts and clears the polling timer', () => {
+    jest.useFakeTimers()
+    const setIntervalSpy = jest.spyOn(global, 'setInterval')
+    const clearIntervalSpy = jest.spyOn(window, 'clearInterval')
+    const instance = mountClassComponent(FatalError)
 
     instance.componentDidMount()
-    expect(instance.state.up).toBe(true)
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+    expect(instance.timer).toBeDefined()
 
-    jest.advanceTimersByTime(10000)
-    await Promise.resolve()
-    expect(instance.state.up).toBe(true)
-
-    jest.advanceTimersByTime(10000)
-    await Promise.resolve()
-    expect(instance.state.up).toBe(false)
-
-    expect(() => instance.componentWillUnmount()).not.toThrow()
+    instance.componentWillUnmount()
+    expect(clearIntervalSpy).toHaveBeenCalledWith(instance.timer)
   })
 })

--- a/front-end/src/fatal_error.test.js
+++ b/front-end/src/fatal_error.test.js
@@ -1,39 +1,39 @@
 import FatalError from './fatal_error'
-import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
-// import configureMockStore from 'redux-mock-store'
-// import thunk from 'redux-thunk'
-// const mockStore = configureMockStore([thunk])
-Enzyme.configure({ adapter: new Adapter() })
 
-describe('Sign_In', () => {
-  beforeEach(() => {})
+function mountClassComponent (Component) {
+  const instance = new Component({})
+  instance.setState = update => {
+    const patch = typeof update === 'function' ? update(instance.state, instance.props) : update
+    instance.state = { ...instance.state, ...patch }
+  }
+  return instance
+}
+
+describe('FatalError', () => {
   afterEach(() => {
     jest.resetAllMocks()
+    jest.useRealTimers()
   })
-  it('<FatalError />', async () => {
+
+  it('polls health and updates state', async () => {
     jest.useFakeTimers()
-    global.fetch = jest.fn().mockImplementation(() => {
-      let p = new Promise(resolve => {
-        resolve({
-          ok: true,
-          status: 200
-        })
-      })
-      return p
-    })
-    const m = shallow(<FatalError />).instance()
-    expect(m.state.up).toBe(true)
-    jest.advanceTimersByTime(5000)
-    expect(m.state.up).toBe(true)
-    global.fetch = jest.fn().mockImplementation(() => {
-      let p = new Promise((resolve, reject) => {
-        reject(Error)
-      })
-      return p
-    })
-    jest.advanceTimersByTime(5000)
-    m.componentWillUnmount()
+    const instance = mountClassComponent(FatalError)
+
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({ ok: true, status: 200 })
+      .mockRejectedValueOnce(Error)
+
+    instance.componentDidMount()
+    expect(instance.state.up).toBe(true)
+
+    jest.advanceTimersByTime(10000)
+    await Promise.resolve()
+    expect(instance.state.up).toBe(true)
+
+    jest.advanceTimersByTime(10000)
+    await Promise.resolve()
+    expect(instance.state.up).toBe(false)
+
+    expect(() => instance.componentWillUnmount()).not.toThrow()
   })
 })

--- a/front-end/src/sign_in.test.js
+++ b/front-end/src/sign_in.test.js
@@ -1,75 +1,64 @@
 import SignIn from './sign_in'
-import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
-const mockStore = configureMockStore([thunk])
-Enzyme.configure({ adapter: new Adapter() })
+
+function mountClassComponent (Component) {
+  const instance = new Component({})
+  instance.setState = update => {
+    const patch = typeof update === 'function' ? update(instance.state, instance.props) : update
+    instance.state = { ...instance.state, ...patch }
+  }
+  return instance
+}
 
 describe('SignIn', () => {
   beforeEach(() => {
-    SignIn.refreshPage = jest.fn().mockImplementation(() => {
-      return true
-    })
-    global.fetch = jest.fn().mockImplementation(() => {
-      let p = new Promise((resolve) => {
-        resolve({
-          ok: true,
-          status: 200
-        })
-      })
-      return p
+    SignIn.refreshPage = jest.fn().mockImplementation(() => true)
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200
     })
   })
+
   afterEach(() => {
     jest.resetAllMocks()
   })
-  it('<SignIn />', async () => {
-    const m = shallow(<SignIn store={mockStore()} />).instance()
-    m.handleUserChange({ target: { value: 'foo' } })
-    m.handlePasswordChange({ target: { value: 'bar' } })
-    await m.handleLogin({
-      preventDefault: function () {
-        return true
-      }
-    })
-    expect(SignIn.refreshPage.mock.calls.length).toBe(1)
-    global.fetch = jest.fn().mockImplementation(() => {
-      let p = new Promise((resolve, reject) => {
-        resolve({
-          ok: false,
-          status: 500
-        })
-      })
-      return p
-    })
-    await m.handleLogin({
-      preventDefault: function () {
-        return true
-      }
-    })
-    expect(SignIn.refreshPage.mock.calls.length).toBe(1)
 
-    global.fetch = jest.fn().mockImplementation(() => {
-      let p = new Promise((resolve, reject) => {
-        resolve({
-          ok: false,
-          status: 401
-        })
-      })
-      return p
+  it('handles login status transitions', async () => {
+    const instance = mountClassComponent(SignIn)
+
+    instance.handleUserChange({ target: { value: 'foo' } })
+    instance.handlePasswordChange({ target: { value: 'bar' } })
+
+    await instance.handleLogin({
+      preventDefault: () => true
     })
-    await m.handleLogin({
-      preventDefault: function () {
-        return true
-      }
+    expect(SignIn.refreshPage).toHaveBeenCalledTimes(1)
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500
     })
-    expect(SignIn.refreshPage.mock.calls.length).toBe(1)
+    await instance.handleLogin({
+      preventDefault: () => true
+    })
+    expect(SignIn.refreshPage).toHaveBeenCalledTimes(1)
+    expect(instance.state.invalidCredentials).toBe(false)
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401
+    })
+    await instance.handleLogin({
+      preventDefault: () => true
+    })
+    expect(SignIn.refreshPage).toHaveBeenCalledTimes(1)
+    expect(instance.state.invalidCredentials).toBe(true)
   })
-  it('SignIn statics', async () => {
+
+  it('exercises sign-in statics', async () => {
     await SignIn.logout()
-    expect(SignIn.refreshPage.mock.calls.length).toBe(1)
-    SignIn.isSignedIn()
+    expect(SignIn.refreshPage).toHaveBeenCalledTimes(1)
+
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 })
+    await expect(SignIn.isSignedIn()).resolves.toBe(true)
   })
 })

--- a/front-end/test/setup.js
+++ b/front-end/test/setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+
+Enzyme.configure({ adapter: new Adapter() })

--- a/front-end/test/setup.js
+++ b/front-end/test/setup.js
@@ -2,3 +2,11 @@ import Enzyme from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 
 Enzyme.configure({ adapter: new Adapter() })
+
+class ResizeObserver {
+  observe () {}
+  unobserve () {}
+  disconnect () {}
+}
+
+global.ResizeObserver = ResizeObserver

--- a/package.json
+++ b/package.json
@@ -118,6 +118,9 @@
     ]
   },
   "jest": {
+    "setupFilesAfterEnv": [
+      "<rootDir>/front-end/test/setup.js"
+    ],
     "moduleDirectories": [
       "node_modules",
       "front-end/src/",


### PR DESCRIPTION
## Summary
- add a shared Jest setup file for frontend tests so Enzyme adapter wiring no longer has to be repeated in every test file
- rewrite a few small frontend tests to use lighter direct class-instance or react-test-renderer checks instead of Enzyme-only patterns
- keep the rest of the existing frontend test stack intact while starting to reduce Enzyme-era assumptions in the lowest-risk places

## Testing
- Local frontend tests not run because this checkout does not have node_modules installed
- CI will validate Jest and standard for this slice

Closes #2516