### PR TITLE
Slice 13: introduce semantic design tokens

### DIFF
--- a/front-end/assets/sass/_tokens.scss
+++ b/front-end/assets/sass/_tokens.scss
@@ -1,0 +1,19 @@
+@import './colors';
+
+$surface-auth-color: #edf8e8;
+$text-strong-color: #2e2e2e;
+$border-subtle-color: #cccccc;
+$border-strong-color: #000000;
+$shadow-color: rgba(31, 42, 31, 0.14);
+$nav-text-color: rgba(255, 255, 255, 0.84);
+$nav-text-muted-color: rgba(255, 255, 255, 0.82);
+$nav-overlay-color: rgba(255, 255, 255, 0.12);
+$nav-border-color: rgba(255, 255, 255, 0.4);
+$nav-text-strong-color: #ffffff;
+$space-xxs: 0.3125rem;
+$space-xs: 0.625rem;
+$space-sm: 0.75rem;
+$space-md: 1rem;
+$space-lg: 1.25rem;
+$radius-sm: 0.375rem;
+$radius-md: 0.625rem;

--- a/front-end/assets/sass/auth-page.scss
+++ b/front-end/assets/sass/auth-page.scss
@@ -1,4 +1,4 @@
-@import './colors';
+@import './tokens';
 
 body,html,#main-panel {
   &.auth-page{
@@ -7,11 +7,11 @@ body,html,#main-panel {
 }
 #main-panel {
   &.auth-page{
-    background-color: rgb(237, 248, 232);
+    background-color: $surface-auth-color;
   }
 }
 .auth-page{
   .reef-pi-title{
-    color: #2e2e2e;
+    color: $text-strong-color;
   }
 }

--- a/front-end/assets/sass/grid.scss
+++ b/front-end/assets/sass/grid.scss
@@ -1,7 +1,9 @@
+@import './tokens';
+
 .reef-pi-grid {
 
   .grid-row {
-    padding: 5px 5px 0 5px;
+    padding: $space-xxs $space-xxs 0 $space-xxs;
   }
 
   .grid-row>label {
@@ -9,13 +11,13 @@
   }
 
   .grid-cell-container {
-    padding: 0 5px 0 0;
+    padding: 0 $space-xxs 0 0;
   }
   
   .grid-cell {
-    border: 1px solid #000;
-    border-radius: 10px;
-    padding: 5px
+    border: 1px solid $border-strong-color;
+    border-radius: $radius-md;
+    padding: $space-xxs;
   }
 
 }

--- a/front-end/assets/sass/navbar.scss
+++ b/front-end/assets/sass/navbar.scss
@@ -1,12 +1,12 @@
-@import './colors';
+@import './tokens';
 
 .navbar-reefpi {
   background: linear-gradient(180deg, $main-color 0%, $main-alternate-color 100%);
-  box-shadow: 0 2px 8px rgba(31, 42, 31, 0.14);
+  box-shadow: 0 2px 8px $shadow-color;
 }
 
 .navbar-reefpi .navbar-brand {
-  color: #FFF;
+  color: $nav-text-strong-color;
 }
 
 .current-tab {
@@ -19,30 +19,30 @@
 }
 
 .navbar-reefpi .navbar-text {
-  color: rgba(255, 255, 255, 0.84);
+  color: $nav-text-color;
 }
 
 .navbar-reefpi .navbar-nav .nav-link {
-  color: rgba(255, 255, 255, 0.82);
-  border-radius: 0.375rem;
-  padding: 0.625rem 0.875rem;
+  color: $nav-text-muted-color;
+  border-radius: $radius-sm;
+  padding: $space-xs 0.875rem;
 }
 
 .navbar-reefpi .navbar-nav .nav-link:hover,
 .navbar-reefpi .navbar-nav .nav-link:focus {
-  background-color: rgba(255, 255, 255, 0.12);
-  color: #ffffff;
+  background-color: $nav-overlay-color;
+  color: $nav-text-strong-color;
 }
 
 .navbar-reefpi .nav-item.active .nav-link,
 .navbar-reefpi .nav-item:hover .nav-link {
-  color: #ffffff;
+  color: $nav-text-strong-color;
 }
 
 .navbar-reefpi .navbar-toggler {
-  border-color: rgba(255, 255, 255, 0.4);
+  border-color: $nav-border-color;
 }
 
 .navbar-reefpi .navbar-toggler:focus {
-  border-color: #ffffff;
+  border-color: $nav-text-strong-color;
 }

--- a/front-end/assets/sass/style.scss
+++ b/front-end/assets/sass/style.scss
@@ -1,5 +1,5 @@
 @import '~bootstrap/scss/bootstrap';
-@import './colors';
+@import './tokens';
 @import './auth-page';
 @import './navbar';
 @import './sign-in';
@@ -18,8 +18,25 @@
   --reefpi-color-text: #{$text-color};
   --reefpi-color-text-muted: #{$text-muted-color};
   --reefpi-color-focus: #{$focus-color};
-  --reefpi-shell-gutter: 0.75rem;
-  --reefpi-panel-gap: 1rem;
+  --reefpi-color-surface-auth: #{$surface-auth-color};
+  --reefpi-color-text-strong: #{$text-strong-color};
+  --reefpi-color-border-subtle: #{$border-subtle-color};
+  --reefpi-color-border-strong: #{$border-strong-color};
+  --reefpi-color-shadow: #{$shadow-color};
+  --reefpi-color-nav-text: #{$nav-text-color};
+  --reefpi-color-nav-text-muted: #{$nav-text-muted-color};
+  --reefpi-color-nav-overlay: #{$nav-overlay-color};
+  --reefpi-color-nav-border: #{$nav-border-color};
+  --reefpi-color-nav-text-strong: #{$nav-text-strong-color};
+  --reefpi-shell-gutter: #{$space-sm};
+  --reefpi-panel-gap: #{$space-md};
+  --reefpi-space-xxs: #{$space-xxs};
+  --reefpi-space-xs: #{$space-xs};
+  --reefpi-space-sm: #{$space-sm};
+  --reefpi-space-md: #{$space-md};
+  --reefpi-space-lg: #{$space-lg};
+  --reefpi-radius-sm: #{$radius-sm};
+  --reefpi-radius-md: #{$radius-md};
   --reefpi-tap-target-min: 2.75rem;
 }
 
@@ -32,7 +49,7 @@
 }
 
 .bottom-bar {
-  border-top: solid 1px #CCC;
+  border-top: solid 1px var(--reefpi-color-border-subtle);
 }
 
 html {
@@ -121,7 +138,7 @@ textarea:focus,
 
 @media screen and (min-width: 768px) {
   :root {
-    --reefpi-shell-gutter: 1rem;
+    --reefpi-shell-gutter: #{$space-md};
   }
 
   .body-panel {


### PR DESCRIPTION
## Summary
- add a small shared Sass token layer on top of the existing reef-pi palette
- replace remaining shared auth, navbar, grid, and shell literals with semantic tokens
- keep the current visual identity while making shared styling conventions more systematic

## Validation
- yarn build

Closes #2517