### PR TITLE
Slice 15: stabilize frontend test ergonomics

### DIFF
--- a/front-end/src/fatal_error.test.js
+++ b/front-end/src/fatal_error.test.js
@@ -1,18 +1,5 @@
 import FatalError from './fatal_error'
-
-function mountClassComponent (Component) {
-  const instance = new Component({})
-  instance.setState = update => {
-    const patch = typeof update === 'function' ? update(instance.state, instance.props) : update
-    instance.state = { ...instance.state, ...patch }
-  }
-  return instance
-}
-
-async function flushPromises () {
-  await Promise.resolve()
-  await Promise.resolve()
-}
+import { mountClassComponent, flushPromises } from '../test/class_component'
 
 describe('FatalError', () => {
   afterEach(() => {

--- a/front-end/src/sign_in.test.js
+++ b/front-end/src/sign_in.test.js
@@ -1,13 +1,5 @@
 import SignIn from './sign_in'
-
-function mountClassComponent (Component) {
-  const instance = new Component({})
-  instance.setState = update => {
-    const patch = typeof update === 'function' ? update(instance.state, instance.props) : update
-    instance.state = { ...instance.state, ...patch }
-  }
-  return instance
-}
+import { mountClassComponent } from '../test/class_component'
 
 describe('SignIn', () => {
   beforeEach(() => {

--- a/front-end/test/README.md
+++ b/front-end/test/README.md
@@ -1,0 +1,15 @@
+# Frontend test notes
+
+## Snapshot policy
+
+- Prefer explicit assertions over snapshots when a test is checking a small piece of behavior.
+- Use snapshots only for stable presentational output where the rendered tree is the thing under review.
+- Keep snapshots narrow. Snapshot a small component subtree instead of a whole page whenever possible.
+- Update snapshots only when the rendered markup change is intentional and reviewed in the diff.
+- If a snapshot changes because of refactor noise rather than product behavior, rewrite the test to use targeted assertions instead.
+
+## Local commands
+
+- `yarn jest --runInBand`
+- `yarn jest front-end/src/configuration/capabilities.test.js --runInBand`
+- `yarn jest-update-snapshot`

--- a/front-end/test/class_component.js
+++ b/front-end/test/class_component.js
@@ -1,0 +1,13 @@
+export function mountClassComponent (Component, props = {}) {
+  const instance = new Component(props)
+  instance.setState = update => {
+    const patch = typeof update === 'function' ? update(instance.state, instance.props) : update
+    instance.state = { ...instance.state, ...patch }
+  }
+  return instance
+}
+
+export async function flushPromises () {
+  await Promise.resolve()
+  await Promise.resolve()
+}


### PR DESCRIPTION
## Summary
- extract the shared class-component test harness used by the recent frontend refactor tests
- document a narrow snapshot policy next to the frontend Jest setup
- keep the touched tests behavior-focused without broad framework churn

## Validation
- yarn jest front-end/src/fatal_error.test.js front-end/src/sign_in.test.js front-end/src/configuration/capabilities.test.js --runInBand
- yarn jest --runInBand

Closes #2519