### PR TITLE
Slice 16: migrate low-risk tests off Enzyme

### DIFF
--- a/front-end/src/auth.jsx
+++ b/front-end/src/auth.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 import { showUpdateSuccessful } from 'utils/alert'
 import i18n from 'utils/i18n'
 
-class auth extends React.Component {
+export class auth extends React.Component {
   constructor (props) {
     super(props)
     this.state = {

--- a/front-end/src/auth.test.js
+++ b/front-end/src/auth.test.js
@@ -1,33 +1,43 @@
-import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
-import Auth from './auth'
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
-import 'isomorphic-fetch'
+import { auth as Auth } from './auth'
+import { mountClassComponent, flushPromises } from '../test/class_component'
 
-Enzyme.configure({ adapter: new Adapter() })
-const mockStore = configureMockStore([thunk])
-global.fetch = jest.fn().mockImplementation(() => {
-  let p = new Promise((resolve) => {
-    resolve({
+describe('Auth', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       status: 200
     })
   })
-  return p
-})
-describe('Auth', () => {
-  it('<Auth />', () => {
-    const m = shallow(<Auth store={mockStore()} />)
-      .dive()
-      .instance()
-    m.handleUserChange({ target: { value: 'foo' } })
-    m.handlePasswordChange({ target: { value: 'bar' } })
-    m.handleUpdateCreds()
-    m.handleUserChange({ target: { value: '' } })
-    m.handlePasswordChange({ target: { value: '' } })
-    m.handleUpdateCreds()
-    m.props.updateCreds({})
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('validates creds before posting updates', async () => {
+    const updateCreds = jest.fn()
+    const instance = mountClassComponent(Auth, { updateCreds })
+
+    instance.handleUserChange({ target: { value: 'foo' } })
+    instance.handlePasswordChange({ target: { value: 'bar' } })
+    instance.handleUpdateCreds()
+    await flushPromises()
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/credentials', expect.objectContaining({
+      method: 'POST',
+      credentials: 'same-origin'
+    }))
+    expect(instance.state.usernameError).toBe(false)
+    expect(instance.state.passwordError).toBe(false)
+
+    global.fetch.mockClear()
+    instance.handleUserChange({ target: { value: '' } })
+    instance.handlePasswordChange({ target: { value: '' } })
+    instance.handleUpdateCreds()
+
+    expect(global.fetch).not.toHaveBeenCalled()
+    expect(instance.state.usernameError).toBe(true)
+    expect(instance.state.passwordError).toBe(true)
+    updateCreds({})
+    expect(updateCreds).toHaveBeenCalledWith({})
   })
 })

--- a/front-end/src/ui_components/error_boundary.test.js
+++ b/front-end/src/ui_components/error_boundary.test.js
@@ -1,34 +1,30 @@
-import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
 import ErrorBoundary from './error_boundary'
-
-Enzyme.configure({ adapter: new Adapter() })
+import { mountClassComponent } from '../../test/class_component'
 
 describe('ErrorBoundary', () => {
-  it('should show child when there are no errors', () => {
-    const wrapper = shallow(<ErrorBoundary><span>Child</span></ErrorBoundary>)
-    expect(wrapper.find('span').length).toBe(1)
-    expect(wrapper.find('details').length).toBe(0)
+  it('renders children when there is no error', () => {
+    const instance = mountClassComponent(ErrorBoundary, { children: 'Child' })
+    expect(instance.render()).toBe('Child')
   })
 
-  it('should show the error when there is an error', () => {
-    const wrapper = shallow(<ErrorBoundary><span>Child</span></ErrorBoundary>)
-    wrapper.instance().componentDidCatch('error', { componentStack: 'stackTrace' })
+  it('renders error details after componentDidCatch', () => {
+    const instance = mountClassComponent(ErrorBoundary, { children: 'Child' })
+    instance.componentDidCatch(new Error('error'), { componentStack: 'stackTrace' })
+    const rendered = instance.render()
 
-    expect(wrapper.find('span').length).toBe(0)
-    expect(wrapper.find('details').length).toBe(1)
+    expect(rendered.props.children[0].type).toBe('h2')
+    expect(rendered.props.children[1].type).toBe('details')
   })
 
-  it('should reset once tab is changed', () => {
-    const wrapper = shallow(<ErrorBoundary tab='tab1'><span>Child</span></ErrorBoundary>)
-    wrapper.instance().componentDidCatch('error', { componentStack: 'stackTrace' })
+  it('resets state when the tab prop changes', () => {
+    const instance = mountClassComponent(ErrorBoundary, { tab: 'tab1', children: 'Child' })
+    instance.componentDidCatch(new Error('error'), { componentStack: 'stackTrace' })
 
-    expect(wrapper.find('span').length).toBe(0)
-    expect(wrapper.find('details').length).toBe(1)
+    const nextState = ErrorBoundary.getDerivedStateFromProps({ tab: 'tab2' }, instance.state)
+    instance.state = nextState
 
-    wrapper.setProps({ tab: 'tab2' })
-    expect(wrapper.find('span').length).toBe(1)
-    expect(wrapper.find('details').length).toBe(0)
+    expect(instance.state.error).toBeNull()
+    expect(instance.state.errorInfo).toBeNull()
+    expect(instance.render()).toBe('Child')
   })
 })

--- a/front-end/src/utils/validation_helper.test.js
+++ b/front-end/src/utils/validation_helper.test.js
@@ -1,9 +1,6 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
+import renderer from 'react-test-renderer'
 import * as v from './validation_helper'
-import Adapter from 'enzyme-adapter-react-16'
-
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('Validation Helper', () => {
   it('NameFor', () => {
@@ -60,13 +57,15 @@ describe('Validation Helper', () => {
     const errors = { field1: [null, null, 'some error', 'error 2'] }
     const touched = { field1: true }
 
-    shallow(<v.ErrorFor name='field1' touched={touched} errors={errors} />)
+    const tree = renderer.create(<v.ErrorFor name='field1' touched={touched} errors={errors} />).toJSON()
+    expect(tree.children).toContain('some error')
   })
 
   it('<ErrorFor /> without error', () => {
     const errors = { field2: [null, null, 'some error', 'error 2'] }
     const touched = { field1: true }
 
-    shallow(<v.ErrorFor name='field1' touched={touched} errors={errors} />)
+    const tree = renderer.create(<v.ErrorFor name='field1' touched={touched} errors={errors} />).toJSON()
+    expect(tree).toBe('')
   })
 })


### PR DESCRIPTION
## Summary
- export the raw Auth component for direct unit testing without changing runtime wiring
- migrate low-risk Auth, validation helper, and ErrorBoundary tests away from Enzyme-specific patterns
- keep the rest of the Enzyme-heavy suite unchanged for now to avoid broad churn

## Validation
- yarn jest front-end/src/auth.test.js front-end/src/utils/validation_helper.test.js front-end/src/ui_components/error_boundary.test.js --runInBand
- yarn jest --runInBand

This is the optional test migration track described in the refactor plan.