### PR TITLE
Slice 17: reduce noisy frontend test warnings

### DIFF
--- a/front-end/src/doser/doser.test.js
+++ b/front-end/src/doser/doser.test.js
@@ -35,7 +35,7 @@ jest.mock('utils/confirm', () => {
 describe('Doser ui', () => {
   it('<Main />', () => {
     const mock = {
-      dosers: [{ foo: 'bar', regiment: {} }]
+      dosers: [{ id: 1, name: 'doser', regiment: { enable: false } }]
     }
     const m = mount(
       <Provider store={mockStore(mock)}>

--- a/front-end/src/drivers/driver.test.js
+++ b/front-end/src/drivers/driver.test.js
@@ -25,6 +25,7 @@ describe('driver UI', () => {
         driver={driver}
         remove={() => true}
         update={() => true}
+        provision={() => true}
       />)
   })
 

--- a/front-end/src/journal/edit_journal.test.js
+++ b/front-end/src/journal/edit_journal.test.js
@@ -2,7 +2,7 @@ import React from 'react'
 import Enzyme, { mount } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import { Provider } from 'react-redux'
-import { Formik, Form } from 'formik'
+import { Formik } from 'formik'
 import EditJournal from './edit_journal'
 import * as Alert from 'utils/alert'
 import configureMockStore from 'redux-mock-store'
@@ -23,19 +23,17 @@ const render = (extraProps = {}) => {
     <Provider store={store}>
       <Formik initialValues={initialValues} onSubmit={submitForm}>
         {(formikProps) => (
-          <Form>
-            <EditJournal
-              values={formikProps.values}
-              errors={formikProps.errors}
-              touched={formikProps.touched}
-              submitForm={formikProps.submitForm}
-              handleBlur={formikProps.handleBlur}
-              isValid={formikProps.isValid}
-              dirty={formikProps.dirty}
-              readOnly={false}
-              {...extraProps}
-            />
-          </Form>
+          <EditJournal
+            values={formikProps.values}
+            errors={formikProps.errors}
+            touched={formikProps.touched}
+            submitForm={formikProps.submitForm}
+            handleBlur={formikProps.handleBlur}
+            isValid={formikProps.isValid}
+            dirty={formikProps.dirty}
+            readOnly={false}
+            {...extraProps}
+          />
         )}
       </Formik>
     </Provider>

--- a/front-end/src/summary.test.js
+++ b/front-end/src/summary.test.js
@@ -11,6 +11,7 @@ describe('Summary', () => {
     const m = shallow(
       <Summary
         info={{}}
+        devMode={false}
         fetch={() => true}
         errors={[]}
         timer={window.setInterval(() => true, 1800 * 1000)}


### PR DESCRIPTION
## Summary
- satisfy required props in targeted Summary and Driver tests
- use more realistic doser fixture data so the test does not trigger avoidable Collapsible warnings
- remove the extra Formik wrapper form in the EditJournal test harness

## Validation
- yarn jest front-end/src/summary.test.js front-end/src/drivers/driver.test.js front-end/src/doser/doser.test.js front-end/src/journal/edit_journal.test.js --runInBand
- yarn jest --runInBand

Closes #2566