### PR TITLE
Slice 18: Go 1.26.2 toolchain migration

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
       if: matrix.language == 'go'
       uses: actions/setup-go@v6
       with:
-        go-version-file: go.mod
+        go-version: '1.26.2'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -24,7 +24,7 @@ jobs:
           ruby-version: 3.2.0
       - uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: '1.26.2'
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: '1.26.2'
       - name: Run coverage
         run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
       - name: Upload coverage to Codecov

--- a/.github/workflows/smoke_.yml
+++ b/.github/workflows/smoke_.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: '1.26.2'
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/docs/ci-reproduction.md
+++ b/docs/ci-reproduction.md
@@ -6,6 +6,8 @@ This file captures the local command equivalents for the repository workflows so
 
 Workflow: `.github/workflows/go.yml`
 
+Use Go `1.26.2` for local reproduction.
+
 ```bash
 go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 go install golang.org/x/tools/cmd/goimports@latest

--- a/docs/github-issues/meta-library-migration-program.md
+++ b/docs/github-issues/meta-library-migration-program.md
@@ -1,0 +1,35 @@
+# Meta: Modernize core library stack without behavior drift
+
+## Goal
+
+Update the project's core runtime and test libraries to current stable versions without changing reef-pi's function, API schema, or UI behavior.
+
+## Scope
+
+- Go toolchain modernization
+- React runtime modernization
+- Jest alignment and upgrade
+- necessary compatibility work in adjacent React tooling
+
+## Non-goals
+
+- no product redesign
+- no API redesign
+- no opportunistic architecture rewrite beyond what is required for compatibility
+
+## Success criteria
+
+- supported CI remains green
+- local development remains documented and reproducible
+- frontend behavior remains unchanged
+- backend behavior remains unchanged
+- core libraries are on supported stable versions
+
+## Planned slices
+
+- Slice 18: Go 1.26.2 toolchain migration
+- Slice 19: React 18.3 preflight and render API migration
+- Slice 20: test decoupling from React 16 and Enzyme-only assumptions
+- Slice 21: Jest 30.2.0 alignment
+- Slice 22: React 19.2.x migration
+- Slice 23: React ecosystem compatibility cleanup

--- a/docs/github-issues/slice-18-go-1.26-toolchain.md
+++ b/docs/github-issues/slice-18-go-1.26-toolchain.md
@@ -1,0 +1,31 @@
+# Slice 18: Go 1.26.2 toolchain migration
+
+## Goal
+
+Move the backend toolchain to Go 1.26.2 while preserving runtime behavior.
+
+## Scope
+
+- update CI and local documentation to Go 1.26.2
+- update the `go.mod` directive as needed
+- verify backend tests and packaging
+
+## Non-goals
+
+- no backend refactor beyond compatibility fixes
+
+## Risks
+
+- transitive dependency incompatibilities
+- hardware-facing integration regressions
+
+## Validation
+
+- `go test ./...`
+- package builds
+- smoke checks if available
+
+## Completion criteria
+
+- CI and local docs consistently target Go 1.26.2
+- backend and packaging remain green

--- a/docs/github-issues/slice-19-react-18-preflight.md
+++ b/docs/github-issues/slice-19-react-18-preflight.md
@@ -1,0 +1,33 @@
+# Slice 19: React 18.3 preflight and render API migration
+
+## Goal
+
+Remove the most immediate React 19 blockers by first aligning the runtime on React 18.3 and migrating legacy render entrypoints.
+
+## Scope
+
+- align `react`, `react-dom`, and `react-test-renderer`
+- replace legacy `ReactDOM.render` entrypoints
+- update confirm/modal rendering to root-based APIs
+- remove function-component `defaultProps` that block later migration
+
+## Non-goals
+
+- no full React 19 jump in this slice
+- no broad component rewrite
+
+## Risks
+
+- modal and bootstrap-like interaction regressions
+- entrypoint and hydration-style regressions
+
+## Validation
+
+- `yarn jest --runInBand`
+- `yarn build`
+- smoke checks for modal-heavy flows
+
+## Completion criteria
+
+- no remaining legacy root render APIs in app entrypoints
+- React runtime is aligned on 18.3.x

--- a/docs/github-issues/slice-20-test-decoupling.md
+++ b/docs/github-issues/slice-20-test-decoupling.md
@@ -1,0 +1,30 @@
+# Slice 20: Reduce test coupling to React 16 and Enzyme-only assumptions
+
+## Goal
+
+Lower the risk of the React and Jest upgrades by shrinking the most central Enzyme-only dependency surface.
+
+## Scope
+
+- migrate shared-path tests away from React 16-only assumptions
+- stop relying on `enzyme-adapter-react-16`
+- prefer direct assertions or Testing Library for touched tests
+
+## Non-goals
+
+- no wholesale migration of every frontend test
+
+## Risks
+
+- high test churn if scope expands
+- accidental weakening of assertions
+
+## Validation
+
+- targeted Jest runs for touched suites
+- `yarn jest --runInBand`
+
+## Completion criteria
+
+- shared-path tests no longer depend on the React 16 Enzyme adapter
+- no new Enzyme-only setup is introduced

--- a/docs/github-issues/slice-21-jest-30-alignment.md
+++ b/docs/github-issues/slice-21-jest-30-alignment.md
@@ -1,0 +1,29 @@
+# Slice 21: Jest 30.2.0 alignment
+
+## Goal
+
+Bring the Jest stack to one consistent current version line.
+
+## Scope
+
+- align `jest`, `babel-jest`, and `jest-environment-jsdom` on 30.2.0
+- fix any environment or config drift exposed by the upgrade
+
+## Non-goals
+
+- no unrelated test rewrites
+
+## Risks
+
+- jsdom behavior drift
+- snapshot churn from environment differences
+
+## Validation
+
+- `yarn jest --runInBand`
+- CI Jest job
+
+## Completion criteria
+
+- no Jest package version skew remains
+- full frontend Jest suite is green

--- a/docs/github-issues/slice-22-react-19-migration.md
+++ b/docs/github-issues/slice-22-react-19-migration.md
@@ -1,0 +1,31 @@
+# Slice 22: React 19.2.x migration
+
+## Goal
+
+Move the application runtime from the React 18 compatibility baseline to the current React 19 stable line.
+
+## Scope
+
+- upgrade `react` and `react-dom` to 19.2.x
+- resolve runtime and test incompatibilities exposed by the move
+- keep app behavior unchanged
+
+## Non-goals
+
+- no unrelated frontend redesign
+
+## Risks
+
+- library incompatibilities in older React-adjacent packages
+- changed semantics around test utilities and rendering
+
+## Validation
+
+- `yarn jest --runInBand`
+- `yarn build`
+- smoke checks for main app flows
+
+## Completion criteria
+
+- app builds and tests cleanly on React 19.2.x
+- no legacy React 16 or 18 compatibility shims remain where they are no longer needed

--- a/docs/github-issues/slice-23-react-ecosystem-cleanup.md
+++ b/docs/github-issues/slice-23-react-ecosystem-cleanup.md
@@ -1,0 +1,31 @@
+# Slice 23: React ecosystem compatibility cleanup
+
+## Goal
+
+Modernize adjacent frontend libraries only where required to keep the React 19 stack healthy and maintainable.
+
+## Scope
+
+- verify and update companion libraries such as routing, Redux bindings, form helpers, charts, and UI kits where required
+- remove obsolete compatibility workarounds introduced during the upgrade path
+
+## Non-goals
+
+- no speculative dependency churn
+- no full frontend rearchitecture
+
+## Risks
+
+- transitive UI behavior changes from third-party packages
+- unnecessary churn if versions are bumped without a compatibility reason
+
+## Validation
+
+- `yarn jest --runInBand`
+- `yarn build`
+- smoke checks
+
+## Completion criteria
+
+- React-adjacent dependencies are on versions compatible with the new core runtime
+- temporary upgrade shims can be removed or documented clearly

--- a/docs/library-migration-plan.md
+++ b/docs/library-migration-plan.md
@@ -4,7 +4,7 @@ This document extends the refactor program with a version modernization track fo
 
 ## Current stack
 
-- Go: `1.24.0`
+- Go: `1.26.0` directive, `1.26.2` toolchain target
 - Node in CI: `22`
 - React: `16.14.0`
 - React DOM: `16.12.0`

--- a/docs/library-migration-plan.md
+++ b/docs/library-migration-plan.md
@@ -1,0 +1,78 @@
+# Library Migration Plan
+
+This document extends the refactor program with a version modernization track for the core toolchain and frontend stack.
+
+## Current stack
+
+- Go: `1.24.0`
+- Node in CI: `22`
+- React: `16.14.0`
+- React DOM: `16.12.0`
+- React test renderer: `16.14.0`
+- Jest: `29.7.0`
+- Babel Jest: `30.2.0`
+- Jest jsdom environment: `30.3.0`
+
+## Target stack
+
+- Go: `1.26.2`
+- React: `19.2.x`
+- React DOM: `19.2.x`
+- Jest: `30.2.0`
+
+## Key repo-specific blockers
+
+### React
+
+- `enzyme-adapter-react-16` is still present and widely used in frontend tests.
+- `ReactDOM.render` and `unmountComponentAtNode` are still used in:
+  - `front-end/src/entry.js`
+  - `front-end/src/utils/confirm.js`
+- function-component `defaultProps` still exist in several lighting profile components.
+
+### Jest
+
+- the repo already has version skew between:
+  - `jest`
+  - `babel-jest`
+  - `jest-environment-jsdom`
+- the suite is stable locally, but still carries a large Enzyme legacy surface.
+
+### Go
+
+- backend CI already follows `go.mod`, so toolchain migration is mainly a compatibility and dependency verification problem.
+- hardware-facing integrations and reef-pi companion modules still need full regression validation.
+
+## Migration order
+
+1. Slice 18: Go 1.26.2 toolchain migration
+2. Slice 19: React 18.3 preflight and render API migration
+3. Slice 20: shared test decoupling from React 16 and Enzyme-only assumptions
+4. Slice 21: Jest 30.2.0 alignment
+5. Slice 22: React 19.2.x migration
+6. Slice 23: React ecosystem compatibility cleanup
+
+## Why this order
+
+- Go is the least coupled to the frontend stack.
+- React 19 is blocked by legacy render APIs and Enzyme.
+- Jest 30 is safer after some test decoupling work.
+- ecosystem cleanup should follow the core React move, not precede it.
+
+## Validation expectations
+
+For every slice:
+
+- start from fresh `main`
+- keep API and UI behavior unchanged unless explicitly called out
+- run the narrowest local validation first
+- run the broad suite before opening or promoting the PR
+- treat CI failures as plan feedback and add follow-up checks or notes when a new failure class is discovered
+
+## Official references
+
+- React versions: <https://react.dev/versions>
+- React 19 upgrade guide: <https://react.dev/blog/2024/04/25/react-19-upgrade-guide>
+- React 19 release: <https://react.dev/blog/2024/12/05/react-19>
+- Jest 30 release: <https://jestjs.io/blog/2025/06/04/jest-30>
+- Go release notes index: <https://go.dev/doc/devel/release>

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/reef-pi/reef-pi
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible


### PR DESCRIPTION
## Summary
- raise the repo Go directive to 1.26.0 and target Go 1.26.2 in CI workflows
- update Go-related workflows to use the explicit 1.26.2 toolchain
- refresh local CI reproduction guidance for the new Go version

## Validation
- go test ./...

Closes #2568