### PR TITLE
[codex] Harden smoke test structure and startup

### DIFF
--- a/.github/workflows/smoke_.yml
+++ b/.github/workflows/smoke_.yml
@@ -22,5 +22,11 @@ jobs:
       - run: make go
       - run: make ui
       - run: |
-          make start-dev &
+          set -euo pipefail
+          trap 'if [ -f smoke-server.pid ]; then kill "$(cat smoke-server.pid)" || true; fi' EXIT
+          make start-dev > smoke-server.log 2>&1 &
+          echo $! > smoke-server.pid
+          bash scripts/wait-http.sh http://127.0.0.1:8080/ 60
           make smoke
+      - if: failure()
+        run: tail -n 200 smoke-server.log || true

--- a/front-end/test/README.md
+++ b/front-end/test/README.md
@@ -1,5 +1,27 @@
 # Frontend test notes
 
+## Smoke suite
+
+- Purpose: verify the app shell, login flow, and a small set of end-to-end subsystem paths without trying to exhaustively validate every form combination.
+- Current structure: `front-end/test/smoke.js` groups the suite into multiple TestCafe tests and reuses helper modules for each subsystem flow.
+- Runtime helpers: shared login, shell readiness, and fatal-error assertions live in `front-end/test/runtime.js`.
+
+## Smoke local run
+
+- `make install`
+- `make go`
+- `make ui`
+- `make start-dev`
+- `make smoke`
+
+The CI workflow waits for `http://127.0.0.1:8080/` before running smoke. If a local run fails before the login form appears, verify the backend is still starting and inspect the server log output.
+
+## Smoke debugging
+
+- If the UI never loads, reproduce the CI order exactly instead of starting with `yarn run ci-smoke` alone.
+- If a grouped smoke test fails, fix the subsystem helper that owns that flow instead of extending later steps around it.
+- In CI, inspect `smoke-server.log` from the workflow output when boot or login fails.
+
 ## Snapshot policy
 
 - Prefer explicit assertions over snapshots when a test is checking a small piece of behavior.

--- a/front-end/test/analog.js
+++ b/front-end/test/analog.js
@@ -1,5 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { select } from './helpers'
+import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
 
 class Analog {
 
@@ -19,6 +20,12 @@ class Analog {
   }
 
   async addAnalog(name, pin, driver) {
+    if (await bodyContains(name)) {
+      await expectBodyContains(name)
+      await assertNoFatalError()
+      return
+    }
+
     await t
     .click('input#add_analog_input')
     .typeText('input#analog_inputName', name)
@@ -26,6 +33,8 @@ class Analog {
     await select(this.driverSelect, driver)
     await select(this.pinSelect, pin)
     await t.click('input#createAnalogInput')
+    await expectBodyContains(name)
+    await assertNoFatalError()
   }
 }
 

--- a/front-end/test/ato.js
+++ b/front-end/test/ato.js
@@ -1,5 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { select, clear, setText } from './helpers'
+import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
 
 class Ato {
 
@@ -26,6 +27,12 @@ class Ato {
   }
 
   async addAto(name, inlet, period, enable) {
+    if (await bodyContains(name)) {
+      await expectBodyContains(name)
+      await assertNoFatalError()
+      return
+    }
+
     await t
     .click('input#add_new_ato_sensor')
     .typeText('.add-ato [name*="name"]', name)
@@ -35,6 +42,8 @@ class Ato {
     await select(this.enable, enable)
 
     await t.click('input[type*="submit"]')
+    await expectBodyContains(name)
+    await assertNoFatalError()
   }
 
   async editAto(period, enable, control, pump) {
@@ -43,6 +52,8 @@ class Ato {
     await select(this.control, control)
     await select(this.pump, pump)
     await t.click('input[type*="submit"]')
+    await expectBodyContains('Biocube29')
+    await assertNoFatalError()
   }
 }
 export default new Ato()

--- a/front-end/test/dashboard.js
+++ b/front-end/test/dashboard.js
@@ -1,5 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { select, clear, setText } from './helpers'
+import { assertNoFatalError, expectExists } from './runtime'
 
 class Dashboard {
 
@@ -49,6 +50,8 @@ class Dashboard {
 
       .click('input#save_dashboard')
       .click('button#configure-dashboard')
+    await expectExists('button#configure-dashboard')
+    await assertNoFatalError()
   }
 }
 

--- a/front-end/test/doser.js
+++ b/front-end/test/doser.js
@@ -1,5 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { select, setText } from './helpers'
+import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
 
 class Doser {
 
@@ -21,6 +22,12 @@ class Doser {
   }
 
   async addDoser(name, jack, pin, hour, minute, second, duration, speed) {
+    if (await bodyContains(name)) {
+      await expectBodyContains(name)
+      await assertNoFatalError()
+      return
+    }
+
     await t
       .click('input#add_doser')
       .typeText(this.name, name)
@@ -34,6 +41,8 @@ class Doser {
     await setText(this.speed, speed)
 
     await t.click(this.submit)
+    await expectBodyContains(name)
+    await assertNoFatalError()
   }
 }
 

--- a/front-end/test/driver.js
+++ b/front-end/test/driver.js
@@ -1,5 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { select } from './helpers'
+import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
 
 class Driver {
 
@@ -18,6 +19,12 @@ class Driver {
   }
 
   async addDriver(type, name, config) {
+    if (await bodyContains(name)) {
+      await expectBodyContains(name)
+      await assertNoFatalError()
+      return
+    }
+
     await t
     .click('input#add_new_driver')
     .typeText('.add-driver [name*="name"]', name)
@@ -38,6 +45,8 @@ class Driver {
 
     await t
     .click('.add-driver input[type*="submit"]')
+    await expectBodyContains(name)
+    await assertNoFatalError()
 
   }
 }

--- a/front-end/test/equipment.js
+++ b/front-end/test/equipment.js
@@ -1,5 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { select } from './helpers'
+import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
 
 class Equipment {
 
@@ -21,6 +22,12 @@ class Equipment {
   }
 
   async addEquipment(name, outlet) {
+    if (await bodyContains(name)) {
+      await expectBodyContains(name)
+      await assertNoFatalError()
+      return
+    }
+
     await t
     .click('input#add_equipment')
     .typeText('.add-equipment [name*="name"]', name)
@@ -29,6 +36,8 @@ class Equipment {
 
     await t
     .click('.add-equipment button[type*="submit"]')
+    await expectBodyContains(name)
+    await assertNoFatalError()
   }
 }
 

--- a/front-end/test/inlet.js
+++ b/front-end/test/inlet.js
@@ -1,5 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { select } from './helpers'
+import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
 
 class Inlet {
 
@@ -19,12 +20,20 @@ class Inlet {
   }
 
   async addInlet(name, pin) {
+    if (await bodyContains(name)) {
+      await expectBodyContains(name)
+      await assertNoFatalError()
+      return
+    }
+
     await t
     .click('input#add_inlet')
     .typeText('input#inletName', name)
 
     await select(this.pinSelect, pin)
     await t.click('input#createInlet')
+    await expectBodyContains(name)
+    await assertNoFatalError()
   }
 }
 

--- a/front-end/test/jack.js
+++ b/front-end/test/jack.js
@@ -1,4 +1,5 @@
 import { Selector, t } from 'testcafe'
+import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
 
 class Jack {
 
@@ -18,11 +19,19 @@ class Jack {
   }
 
   async addJack(name, pins) {
+    if (await bodyContains(name)) {
+      await expectBodyContains(name)
+      await assertNoFatalError()
+      return
+    }
+
     await t
     .click('input#add_jack')
     .typeText(this.name, name)
     .typeText(this.pins, pins)
     .click('input#createJack')
+    await expectBodyContains(name)
+    await assertNoFatalError()
   }
 }
 

--- a/front-end/test/light.js
+++ b/front-end/test/light.js
@@ -1,5 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { clear, select } from './helpers'
+import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
 
 class Light {
 
@@ -13,6 +14,12 @@ class Light {
   }
 
   async addLight(name) {
+    if (await bodyContains('Kessil A360')) {
+      await expectBodyContains('Kessil A360')
+      await assertNoFatalError()
+      return
+    }
+
     await t
     .click('input#add_light')
     .typeText('input#lightName', name)
@@ -28,6 +35,8 @@ class Light {
     .typeText('#form-light-1 input[name="config.channels.0.profile.config.start"]', '10:00:00')
     .typeText('#form-light-1 input[name="config.channels.0.profile.config.end"]', '14:00:00')
     .click('input#save-light-1')
+    await expectBodyContains('Kessil A360')
+    await assertNoFatalError()
   }
 }
 

--- a/front-end/test/macro.js
+++ b/front-end/test/macro.js
@@ -1,5 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { clear, select } from './helpers'
+import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
 
 class Macro {
 
@@ -43,6 +44,12 @@ class Macro {
   }
 
   async addMacro(macro) {
+    if (await bodyContains(macro.name)) {
+      await expectBodyContains(macro.name)
+      await assertNoFatalError()
+      return
+    }
+
     await t
     .click('input#add_macro')
     .typeText('.add-macro input[name="name"]', macro.name)
@@ -52,6 +59,8 @@ class Macro {
     }
 
     await t.click('.add-macro input[type*="submit"]')
+    await expectBodyContains(macro.name)
+    await assertNoFatalError()
   }
 
   async addStep(idx, step) {

--- a/front-end/test/outlet.js
+++ b/front-end/test/outlet.js
@@ -1,5 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { select } from './helpers'
+import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
 
 class Outlet {
 
@@ -26,12 +27,20 @@ class Outlet {
   }
 
   async addOutlet(name, pin) {
+    if (await bodyContains(name)) {
+      await expectBodyContains(name)
+      await assertNoFatalError()
+      return
+    }
+
     await t
     .click('input#add_outlet')
     .typeText('input#outletName', name)
 
     await select(this.pinSelect, pin)
     await t.click('input#createOutlet')
+    await expectBodyContains(name)
+    await assertNoFatalError()
   }
 }
 

--- a/front-end/test/ph.js
+++ b/front-end/test/ph.js
@@ -1,5 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { select } from './helpers'
+import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
 
 class Ph {
 
@@ -14,6 +15,11 @@ class Ph {
   }
 
   async addPh(name, period, analogInput, control, lowerThreshold, upperThreshold, lowerFunction, upperFunction) {
+    if (await bodyContains(name)) {
+      await expectBodyContains(name)
+      await assertNoFatalError()
+      return
+    }
 
     await t
     .click('input#add_probe')
@@ -31,6 +37,8 @@ class Ph {
     .typeText('.add-probe input[name="upperThreshold"]', upperThreshold, { replace: true })
 
     await t.click('.add-probe input[type*="submit"]')
+    await expectBodyContains(name)
+    await assertNoFatalError()
 
   }
 }

--- a/front-end/test/runtime.js
+++ b/front-end/test/runtime.js
@@ -1,0 +1,38 @@
+import { Selector, t } from 'testcafe'
+
+const shellRoot = Selector('#content')
+const fatalError = Selector('.fatal-error-container')
+
+export async function login () {
+  await t
+    .typeText('#reef-pi-user', 'reef-pi', { replace: true })
+    .typeText('#reef-pi-pass', 'reef-pi', { replace: true })
+    .click('#btnSaveCreds')
+}
+
+export async function waitForShell () {
+  await t
+    .expect(shellRoot.exists).ok({ timeout: 15000 })
+    .expect(Selector('#tab-dashboard').exists).ok({ timeout: 15000 })
+}
+
+export async function assertNoFatalError () {
+  await t.expect(fatalError.exists).notOk()
+}
+
+export async function openTab (selector) {
+  await t.click(selector)
+  await assertNoFatalError()
+}
+
+export async function expectExists (selector) {
+  await t.expect(Selector(selector).exists).ok()
+}
+
+export async function expectBodyContains (text) {
+  await t.expect(Selector('body').innerText).contains(text)
+}
+
+export async function bodyContains (text) {
+  return Selector('body').withText(text).exists
+}

--- a/front-end/test/smoke.js
+++ b/front-end/test/smoke.js
@@ -13,17 +13,31 @@ import ato from './ato'
 import doser from './doser'
 import tc from './tc'
 import dashboard from './dashboard'
+import { assertNoFatalError, login, waitForShell } from './runtime'
 
-fixture `Getting Started`
+fixture `Smoke`
     .page `http://localhost:8080/`
 
-test('Smoke Test', async t => {
+test('sign in and load shell', async t => {
+  await login()
+  await waitForShell()
+  await t.expect(Selector('#tab-dashboard').innerText).eql('Dashboard')
+  await assertNoFatalError()
+})
 
-  await t
-    .typeText('#reef-pi-user', 'reef-pi')
-    .typeText('#reef-pi-pass', 'reef-pi')
-    .click('#btnSaveCreds')
-    .expect(Selector('#tab-dashboard').innerText).eql('Dashboard')
+test('create configuration dependencies', async () => {
+  await login()
+  await waitForShell()
+  await driver.create()
+  await outlet.create()
+  await inlet.create()
+  await jack.create()
+  await analog.create()
+})
+
+test('create subsystem entities', async () => {
+  await login()
+  await waitForShell()
   await driver.create()
   await outlet.create()
   await inlet.create()
@@ -38,5 +52,19 @@ test('Smoke Test', async t => {
   await doser.create()
   await tc.create()
   await ato.edit()
+})
+
+test('configure dashboard', async () => {
+  await login()
+  await waitForShell()
+  await driver.create()
+  await outlet.create()
+  await inlet.create()
+  await jack.create()
+  await analog.create()
+  await equipment.create()
+  await light.create()
+  await ph.create()
+  await ato.create()
   await dashboard.configure()
 })

--- a/front-end/test/tc.js
+++ b/front-end/test/tc.js
@@ -1,5 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { select, setText } from './helpers'
+import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
 
 class Tc {
 
@@ -32,6 +33,12 @@ class Tc {
   }
 
   async addTc(tc) {
+    if (await bodyContains(tc.name)) {
+      await expectBodyContains(tc.name)
+      await assertNoFatalError()
+      return
+    }
+
     await t
       .click('input#add_probe')
       .typeText(this.name, tc.name)
@@ -45,6 +52,8 @@ class Tc {
     await setText(this.max, tc.max)
 
     await t.click(this.submit)
+    await expectBodyContains(tc.name)
+    await assertNoFatalError()
   }
 }
 

--- a/front-end/test/timer.js
+++ b/front-end/test/timer.js
@@ -1,5 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { clear, select } from './helpers'
+import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
 
 class Timer {
 
@@ -18,6 +19,12 @@ class Timer {
   }
 
   async addTimer(name, equipment, revert, duration, hour, minute, second) {
+    if (await bodyContains(name)) {
+      await expectBodyContains(name)
+      await assertNoFatalError()
+      return
+    }
+
     await t
     .click('input#add_timer')
     .typeText('.add-timer input[name="name"]', name)
@@ -38,6 +45,8 @@ class Timer {
     await t
     .typeText(this.second, second)
     .click('.add-timer input[type*="submit"]')
+    await expectBodyContains(name)
+    await assertNoFatalError()
   }
 }
 

--- a/scripts/wait-http.sh
+++ b/scripts/wait-http.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 <url> <timeout-seconds>" >&2
+  exit 2
+fi
+
+url="$1"
+timeout="$2"
+
+for _ in $(seq 1 "$timeout"); do
+  status="$(curl -fsS -o /dev/null -w '%{http_code}' "$url" || true)"
+  case "$status" in
+    200|204|301|302|401|403)
+      exit 0
+      ;;
+  esac
+  sleep 1
+done
+
+echo "timed out waiting for $url after ${timeout}s" >&2
+exit 1


### PR DESCRIPTION
## Summary
- split the single TestCafe smoke chain into grouped tests with shared runtime helpers
- add explicit per-flow assertions and make smoke helpers idempotent against an already-populated dev database
- harden the smoke workflow with HTTP readiness polling, server log capture, and process cleanup

## Why
The existing smoke gate was one monolithic test with only one explicit assertion, which made failures hard to localize and pushed product code toward smoke-specific compromises. This change keeps the current TestCafe stack but makes the suite diagnosable and easier to evolve before a future migration.

## Impact
- smoke failures now identify the failing subsystem group instead of surfacing later as unrelated selector misses
- CI waits for reef-pi to start before launching TestCafe
- smoke documentation now describes the runtime structure and local debug path

## Validation
- `rtk make go`
- `rtk make ui`
- `rtk bash scripts/wait-http.sh http://127.0.0.1:8080/ 10`
- `rtk yarn run ci-smoke`
