### PR TITLE
Slice 20: centralize frontend Enzyme setup

### DIFF
--- a/front-end/src/app.test.js
+++ b/front-end/src/app.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { mount, shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { mount, shallow } from 'enzyme'
 import App from './app'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
@@ -11,7 +10,6 @@ import SignIn from './sign_in'
 import fetchMock from 'fetch-mock'
 import {Provider} from 'react-redux'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 describe('App', () => {

--- a/front-end/src/ato/edit_ato.test.js
+++ b/front-end/src/ato/edit_ato.test.js
@@ -1,11 +1,9 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import EditAto from './edit_ato'
 import 'isomorphic-fetch'
 import * as Alert from '../utils/alert'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('<EditAto />', () => {
   let values = {}

--- a/front-end/src/ato/new.test.js
+++ b/front-end/src/ato/new.test.js
@@ -1,13 +1,11 @@
 import React from 'react'
 import 'isomorphic-fetch'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import New from './new'
 import configureMockStore from 'redux-mock-store'
 import renderer from 'react-test-renderer'
 import thunk from 'redux-thunk'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 describe('New ATO', () => {

--- a/front-end/src/camera/camera.test.js
+++ b/front-end/src/camera/camera.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import Main from './main'
 import Capture from './capture'
 import Config from './config'
@@ -10,7 +9,6 @@ import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import 'isomorphic-fetch'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 describe('Camera module', () => {

--- a/front-end/src/configuration/configuration.test.js
+++ b/front-end/src/configuration/configuration.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import configureMockStore from 'redux-mock-store'
 import Admin from './admin'
 import Capabilities from './capabilities'
@@ -15,7 +14,6 @@ import 'isomorphic-fetch'
 import fetchMock from 'fetch-mock'
 import SignIn from 'sign_in'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 describe('Configuration ui', () => {

--- a/front-end/src/connectors/connectors.test.js
+++ b/front-end/src/connectors/connectors.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { shallow, mount } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow, mount } from 'enzyme'
 import Main from './main'
 import Inlets from './inlets'
 import Inlet from './inlet'
@@ -18,7 +17,6 @@ import thunk from 'redux-thunk'
 import 'isomorphic-fetch'
 import { Provider } from 'react-redux'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 const stockDrivers = [
   { id: 'rpi', name: 'Rasoverry Pi',pinmap: {'digital-output': [1,2,3,4,5]}},

--- a/front-end/src/dashboard/dashboard.test.js
+++ b/front-end/src/dashboard/dashboard.test.js
@@ -1,15 +1,13 @@
 import React from 'react'
 import ComponentSelector from './component_selector'
 import Config from './config'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import configureMockStore from 'redux-mock-store'
 import Grid from './grid'
 import Main from './main'
 import 'isomorphic-fetch'
 import thunk from 'redux-thunk'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 describe('Dashboard', () => {

--- a/front-end/src/doser/calibration.test.js
+++ b/front-end/src/doser/calibration.test.js
@@ -1,12 +1,10 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import CalibrateForm, { Calibrate } from './calibrate'
 import CalibrationModal from './calibration_modal'
 import 'isomorphic-fetch'
 import * as Alert from '../utils/alert'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('Doser Calibration', () => {
   let values = { enable: true }

--- a/front-end/src/doser/doser.test.js
+++ b/front-end/src/doser/doser.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { shallow, mount } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow, mount } from 'enzyme'
 import Main from './main'
 import configureMockStore from 'redux-mock-store'
 import 'isomorphic-fetch'
@@ -8,7 +7,6 @@ import thunk from 'redux-thunk'
 import DoserForm from './doser_form'
 import { Provider } from 'react-redux'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 let fn = jest.fn()
 jest.mock('utils/confirm', () => {

--- a/front-end/src/doser/edit_doser.test.js
+++ b/front-end/src/doser/edit_doser.test.js
@@ -1,11 +1,9 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import EditDoser from './edit_doser'
 import 'isomorphic-fetch'
 import * as Alert from '../utils/alert'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('<EditPh />', () => {
   let values = { enable: true }

--- a/front-end/src/drivers/driver.test.js
+++ b/front-end/src/drivers/driver.test.js
@@ -1,11 +1,9 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
+import { shallow } from 'enzyme'
 import Driver from './driver'
-import Adapter from 'enzyme-adapter-react-16'
 import 'isomorphic-fetch'
 import DriverFrom from './driver_form'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('driver UI', () => {
 

--- a/front-end/src/drivers/edit_driver.test.js
+++ b/front-end/src/drivers/edit_driver.test.js
@@ -1,11 +1,9 @@
 import React from 'react'
 import * as Alert from '../utils/alert'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import EditDriver from './edit_driver'
 import 'isomorphic-fetch'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('<EditDriver />', () => {
   let values = {}

--- a/front-end/src/drivers/new.test.js
+++ b/front-end/src/drivers/new.test.js
@@ -1,13 +1,11 @@
 import React from 'react'
 import 'isomorphic-fetch'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import New from './new'
 import configureMockStore from 'redux-mock-store'
 import renderer from 'react-test-renderer'
 import thunk from 'redux-thunk'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 describe('New Driver', () => {

--- a/front-end/src/equipment/ctrl_panel.test.js
+++ b/front-end/src/equipment/ctrl_panel.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import { Provider } from 'react-redux'
 import EquipmentCtrlPanel from './ctrl_panel'
 import configureMockStore from 'redux-mock-store'
@@ -8,7 +7,6 @@ import thunk from 'redux-thunk'
 import fetchMock from 'fetch-mock'
 import 'isomorphic-fetch'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 const equipment = [

--- a/front-end/src/equipment/equipment.test.js
+++ b/front-end/src/equipment/equipment.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import Equipment from './equipment'
 import ViewEquipment from './view_equipment'
 import EditEquipment from './edit_equipment'
@@ -13,7 +12,6 @@ import thunk from 'redux-thunk'
 import 'isomorphic-fetch'
 import * as Alert from '../utils/alert'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 jest.mock('utils/confirm', () => {
   return {

--- a/front-end/src/health_chart.test.js
+++ b/front-end/src/health_chart.test.js
@@ -1,12 +1,10 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import HealthChart from './health_chart'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import 'isomorphic-fetch'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 describe('Health', () => {

--- a/front-end/src/instances/instances.test.js
+++ b/front-end/src/instances/instances.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import Main from './main'
 import Instance from './instance'
 import InstanceForm from './instance_form'
@@ -9,7 +8,6 @@ import configureMockStore from 'redux-mock-store'
 import 'isomorphic-fetch'
 import thunk from 'redux-thunk'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 jest.mock('utils/confirm', () => ({

--- a/front-end/src/jack_selector.test.jsx
+++ b/front-end/src/jack_selector.test.jsx
@@ -1,13 +1,11 @@
 import JackSelector from './jack_selector'
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import { Provider } from 'react-redux'
 const mockStore = configureMockStore([thunk])
 
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('JackSelector', () => {
   it('<JackSelector />', () => {

--- a/front-end/src/journal/chart.test.js
+++ b/front-end/src/journal/chart.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import { Provider } from 'react-redux'
 import Chart from './chart'
 import configureMockStore from 'redux-mock-store'
@@ -8,7 +7,6 @@ import thunk from 'redux-thunk'
 import fetchMock from 'fetch-mock'
 import 'isomorphic-fetch'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 const journal = { id: '1', name: 'pH', unit: 'pH' }

--- a/front-end/src/journal/edit_entry.test.js
+++ b/front-end/src/journal/edit_entry.test.js
@@ -1,10 +1,8 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import EditEntry from './edit_entry'
 import * as Alert from 'utils/alert'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 const defaultProps = {
   values: { value: 7.2, comment: '', timestamp: 'Jul-08-23:38, 2022' },

--- a/front-end/src/journal/edit_journal.test.js
+++ b/front-end/src/journal/edit_journal.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { mount } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { mount } from 'enzyme'
 import { Provider } from 'react-redux'
 import { Formik } from 'formik'
 import EditJournal from './edit_journal'
@@ -10,7 +9,6 @@ import thunk from 'redux-thunk'
 import fetchMock from 'fetch-mock'
 import 'isomorphic-fetch'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 const initialValues = { id: '1', name: 'pH', description: 'log', unit: 'pH' }

--- a/front-end/src/journal/entry_form.test.js
+++ b/front-end/src/journal/entry_form.test.js
@@ -1,9 +1,7 @@
 import React from 'react'
-import Enzyme, { mount } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { mount } from 'enzyme'
 import EntryForm from './entry_form'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('<EntryForm />', () => {
   afterEach(() => {

--- a/front-end/src/journal/form.test.js
+++ b/front-end/src/journal/form.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { mount } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { mount } from 'enzyme'
 import { Provider } from 'react-redux'
 import JournalForm from './form'
 import configureMockStore from 'redux-mock-store'
@@ -8,7 +7,6 @@ import thunk from 'redux-thunk'
 import fetchMock from 'fetch-mock'
 import 'isomorphic-fetch'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 describe('<JournalForm />', () => {

--- a/front-end/src/journal/journal.test.js
+++ b/front-end/src/journal/journal.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { shallow, mount } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow, mount } from 'enzyme'
 import { Provider } from 'react-redux'
 import Journal from './journal'
 import configureMockStore from 'redux-mock-store'
@@ -8,7 +7,6 @@ import thunk from 'redux-thunk'
 import fetchMock from 'fetch-mock'
 import 'isomorphic-fetch'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 const config = { id: '1', name: 'pH Log', description: 'daily', unit: 'pH' }

--- a/front-end/src/journal/main.test.js
+++ b/front-end/src/journal/main.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import { Provider } from 'react-redux'
 import Main from './main'
 import configureMockStore from 'redux-mock-store'
@@ -8,7 +7,6 @@ import thunk from 'redux-thunk'
 import fetchMock from 'fetch-mock'
 import 'isomorphic-fetch'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 jest.mock('utils/confirm', () => ({

--- a/front-end/src/journal/new.test.js
+++ b/front-end/src/journal/new.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import { Provider } from 'react-redux'
 import New from './new'
 import configureMockStore from 'redux-mock-store'
@@ -8,7 +7,6 @@ import thunk from 'redux-thunk'
 import fetchMock from 'fetch-mock'
 import 'isomorphic-fetch'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 describe('<New />', () => {

--- a/front-end/src/lighting/auto_profile.test.js
+++ b/front-end/src/lighting/auto_profile.test.js
@@ -1,12 +1,10 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import AutoProfile from './auto_profile'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import 'isomorphic-fetch'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 describe('Lighting ui - Auto Profile', () => {

--- a/front-end/src/lighting/charts/charts.test.js
+++ b/front-end/src/lighting/charts/charts.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import DiurnalChart from './diurnal'
 import FixedChart from './fixed'
 import IntervalChart from './interval'
@@ -9,7 +8,6 @@ import configureMockStore from 'redux-mock-store'
 import 'isomorphic-fetch'
 import thunk from 'redux-thunk'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 const baseChannel = {

--- a/front-end/src/lighting/lighting.test.js
+++ b/front-end/src/lighting/lighting.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import Channel from './channel'
 import Chart from './chart'
 import Main, {TestMain} from './main'
@@ -19,7 +18,6 @@ import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import 'isomorphic-fetch'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 jest.mock('utils/confirm', () => {
   return {

--- a/front-end/src/lighting/manual_light.test.js
+++ b/front-end/src/lighting/manual_light.test.js
@@ -1,12 +1,10 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import ManualLight from './manual_light'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import 'isomorphic-fetch'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 describe('Lighting ui - Manual Control', () => {

--- a/front-end/src/macro/edit_macro.test.js
+++ b/front-end/src/macro/edit_macro.test.js
@@ -1,12 +1,10 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import EditMacro from './edit_macro'
 import 'isomorphic-fetch'
 import * as Alert from '../utils/alert'
 import { FieldArray } from 'formik'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('<EditMacro />', () => {
   let values = {

--- a/front-end/src/macro/main.test.js
+++ b/front-end/src/macro/main.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { shallow, mount } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow, mount } from 'enzyme'
 import Main from './main'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
@@ -9,7 +8,6 @@ import fetchMock from 'fetch-mock'
 import MacroForm from './macro_form'
 import { Provider } from 'react-redux'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 jest.mock('utils/confirm', () => {
   return {

--- a/front-end/src/macro/steps.test.js
+++ b/front-end/src/macro/steps.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { shallow, mount } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow, mount } from 'enzyme'
 import { Provider } from 'react-redux'
 import { Formik, Form } from 'formik'
 import configureMockStore from 'redux-mock-store'
@@ -13,7 +12,6 @@ import GenericStep from './generic_step'
 import StepSelector from './step_selector'
 import SelectType from './select_type'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 const storeState = {

--- a/front-end/src/main_panel.test.js
+++ b/front-end/src/main_panel.test.js
@@ -1,13 +1,11 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import MainPanel from './main_panel'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import 'isomorphic-fetch'
 import fetchMock from 'fetch-mock'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 describe('MainPanel', () => {

--- a/front-end/src/notifications/notifications.test.js
+++ b/front-end/src/notifications/notifications.test.js
@@ -1,13 +1,11 @@
 import Alert from './alert'
 import AlertItem from './alert_item'
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import {Provider} from 'react-redux'
 const mockStore = configureMockStore([thunk])
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('Notifications', () => {
   it('<Alert />', () => {

--- a/front-end/src/ph/calibration.test.js
+++ b/front-end/src/ph/calibration.test.js
@@ -1,12 +1,10 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import CalibrateForm, { Calibrate } from './calibrate'
 import CalibrationWizard from './calibration_wizard'
 import 'isomorphic-fetch'
 import * as Alert from '../utils/alert'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('Ph Calibration', () => {
   let values = { enable: true }

--- a/front-end/src/ph/control_chart.test.js
+++ b/front-end/src/ph/control_chart.test.js
@@ -1,12 +1,10 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import ControlChart from './control_chart'
 import configureMockStore from 'redux-mock-store'
 import 'isomorphic-fetch'
 import thunk from 'redux-thunk'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 const probeConfig = {

--- a/front-end/src/ph/edit_ph.test.js
+++ b/front-end/src/ph/edit_ph.test.js
@@ -1,11 +1,9 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import EditPh from './edit_ph'
 import 'isomorphic-fetch'
 import * as Alert from '../utils/alert'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('<EditPh />', () => {
   let values = { enable: true, control: 'macro', chart: {color: '#000'} }

--- a/front-end/src/ph/ph.test.js
+++ b/front-end/src/ph/ph.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import PhForm from './ph_form'
 import Chart from './chart'
 import Main from './main'
@@ -8,7 +7,6 @@ import configureMockStore from 'redux-mock-store'
 import 'isomorphic-fetch'
 import thunk from 'redux-thunk'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 jest.mock('utils/confirm', () => {
   return {

--- a/front-end/src/select_equipment.test.jsx
+++ b/front-end/src/select_equipment.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import 'isomorphic-fetch'
@@ -8,7 +7,6 @@ import SelectEquipment from './select_equipment'
 import fetchMock from 'fetch-mock'
 import { Provider } from 'react-redux'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 describe('Equipment select', () => {

--- a/front-end/src/summary.test.js
+++ b/front-end/src/summary.test.js
@@ -1,10 +1,8 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import Summary from './summary'
 import 'isomorphic-fetch'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('Summary', () => {
   it('<Summary />', () => {

--- a/front-end/src/telemetry/telmetry.test.js
+++ b/front-end/src/telemetry/telmetry.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import configureMockStore from 'redux-mock-store'
 import Main from './main'
 import AdafruitIO from './adafruit_io'
@@ -9,7 +8,6 @@ import Notification from './notification'
 import thunk from 'redux-thunk'
 import 'isomorphic-fetch'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 describe('Telemetry UI', () => {

--- a/front-end/src/temperature/calibration.test.js
+++ b/front-end/src/temperature/calibration.test.js
@@ -1,11 +1,9 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import CalibrationModal, { CalibrationForm } from './calibration_modal'
 import 'isomorphic-fetch'
 import * as Alert from '../utils/alert'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('Temperature Calibration', () => {
   let values = { enable: true }

--- a/front-end/src/temperature/edit_temperature.test.js
+++ b/front-end/src/temperature/edit_temperature.test.js
@@ -1,13 +1,11 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import ControlChart from './control_chart'
 import EditTemperature from './edit_temperature'
 import ReadingsChart from './readings_chart'
 import 'isomorphic-fetch'
 import * as Alert from '../utils/alert'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('<EditTemperature />', () => {
   let values = {chart: {}}

--- a/front-end/src/temperature/temperature.test.js
+++ b/front-end/src/temperature/temperature.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import ControlChart from './control_chart'
 import Main from './main'
 import ReadingsChart from './readings_chart'
@@ -9,7 +8,6 @@ import 'isomorphic-fetch'
 import thunk from 'redux-thunk'
 import TemperatureForm from './temperature_form'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 jest.mock('utils/confirm', () => {
   return {

--- a/front-end/src/timers/edit_timer.test.js
+++ b/front-end/src/timers/edit_timer.test.js
@@ -1,11 +1,9 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import EditTimer from './edit_timer'
 import 'isomorphic-fetch'
 import * as Alert from '../utils/alert'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('<EditTimer />', () => {
   let values = { type: 'equipment' }

--- a/front-end/src/timers/timers.test.js
+++ b/front-end/src/timers/timers.test.js
@@ -1,13 +1,11 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import configureMockStore from 'redux-mock-store'
 import Main from './main'
 import TimerForm from './timer_form'
 import thunk from 'redux-thunk'
 import 'isomorphic-fetch'
 
-Enzyme.configure({ adapter: new Adapter() })
 const mockStore = configureMockStore([thunk])
 
 jest.mock('utils/confirm', () => {

--- a/front-end/src/ui_components/boolean_select.test.js
+++ b/front-end/src/ui_components/boolean_select.test.js
@@ -1,9 +1,7 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import BooleanSelect from './boolean_select'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('<BooleanSelect />', () => {
   it('<BooleanSelect /> should bind true', () => {

--- a/front-end/src/ui_components/collapsible.test.js
+++ b/front-end/src/ui_components/collapsible.test.js
@@ -1,10 +1,8 @@
 import React from 'react'
-import Enzyme, { shallow, mount } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow, mount } from 'enzyme'
 import CollapsibleList from './collapsible_list'
 import Collapsible from './collapsible'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('Collapsible', () => {
   const noop = () => {}

--- a/front-end/src/ui_components/collapsible_list.test.js
+++ b/front-end/src/ui_components/collapsible_list.test.js
@@ -1,9 +1,7 @@
 import React from 'react'
-import Enzyme, { mount } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { mount } from 'enzyme'
 import CollapsibleList from './collapsible_list'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 const Item = (props) => <div name={props.name}>{props.name}</div>
 

--- a/front-end/src/ui_components/color_picker.test.js
+++ b/front-end/src/ui_components/color_picker.test.js
@@ -1,10 +1,8 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
+import { shallow } from 'enzyme'
 import ColorPicker from './color_picker'
 import { SketchPicker } from 'react-color'
-import Adapter from 'enzyme-adapter-react-16'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('ColorPicker', () => {
   const ev = {

--- a/front-end/src/ui_components/cron.test.js
+++ b/front-end/src/ui_components/cron.test.js
@@ -1,9 +1,7 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import Cron from './cron'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 const defaultProps = {
   values: { month: '*', week: '*', day: '*', hour: '*', minute: '*', second: '0' },

--- a/front-end/src/ui_components/datepicker.test.js
+++ b/front-end/src/ui_components/datepicker.test.js
@@ -1,10 +1,8 @@
 import React from 'react'
-import Enzyme, { mount } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { mount } from 'enzyme'
 import { Form, Formik } from 'formik'
 import Datepicker from './datepicker'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 // eslint-disable-next-line react/prop-types
 const FormikWrapper = ({ children }) => (

--- a/front-end/src/ui_components/percent.test.js
+++ b/front-end/src/ui_components/percent.test.js
@@ -1,9 +1,7 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { shallow } from 'enzyme'
 import Percent from './percent'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 describe('Percent', () => {
   const noop = () => {}

--- a/front-end/src/ui_components/useDatepicker.test.js
+++ b/front-end/src/ui_components/useDatepicker.test.js
@@ -1,10 +1,8 @@
 import React from 'react'
-import Enzyme, { mount } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { mount } from 'enzyme'
 import { Form, Formik } from 'formik'
 import { useDatepicker } from './useDatepicker'
 
-Enzyme.configure({ adapter: new Adapter() })
 
 // Test component that exposes hook handlers via refs
 const TestComponent = ({ name, onHandlers }) => {

--- a/front-end/test/setup.js
+++ b/front-end/test/setup.js
@@ -1,5 +1,6 @@
 import Enzyme from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+
+const Adapter = require('@cfaester/enzyme-adapter-react-18').default
 
 Enzyme.configure({ adapter: new Adapter() })
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "csv-parse": "^5.6.0",
     "csv-stringify": "6.5.2",
     "enzyme": "3.11.0",
-    "enzyme-adapter-react-16": "npm:@cfaester/enzyme-adapter-react-18@0.8.0",
+    "@cfaester/enzyme-adapter-react-18": "0.8.0",
     "eslint": "9.26.0",
     "eslint-plugin-react": "7.33.2",
     "fetch-mock": "9.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1816,6 +1816,17 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@cfaester/enzyme-adapter-react-18@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cfaester/enzyme-adapter-react-18/-/enzyme-adapter-react-18-0.8.0.tgz#313814eb79658a6e74209f9f1743bcefff14a46f"
+  integrity sha512-3Z3ThTUouHwz8oIyhTYQljEMNRFtlVyc3VOOHCbxs47U6cnXs8K9ygi/c1tv49s7MBlTXeIcuN+Ttd9aPtILFQ==
+  dependencies:
+    enzyme-shallow-equal "^1.0.0"
+    function.prototype.name "^1.1.6"
+    has "^1.0.4"
+    react-is "^18.2.0"
+    react-shallow-renderer "^16.15.0"
+
 "@csstools/color-helpers@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@csstools/color-helpers/-/color-helpers-5.1.0.tgz#106c54c808cabfd1ab4c602d8505ee584c2996ef"
@@ -6230,17 +6241,6 @@ envinfo@^7.7.3:
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.8.1.tgz#06377e3e5f4d379fea7ac592d5ad8927e0c4d475"
   integrity sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==
-
-"enzyme-adapter-react-16@npm:@cfaester/enzyme-adapter-react-18@0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@cfaester/enzyme-adapter-react-18/-/enzyme-adapter-react-18-0.8.0.tgz#313814eb79658a6e74209f9f1743bcefff14a46f"
-  integrity sha512-3Z3ThTUouHwz8oIyhTYQljEMNRFtlVyc3VOOHCbxs47U6cnXs8K9ygi/c1tv49s7MBlTXeIcuN+Ttd9aPtILFQ==
-  dependencies:
-    enzyme-shallow-equal "^1.0.0"
-    function.prototype.name "^1.1.6"
-    has "^1.0.4"
-    react-is "^18.2.0"
-    react-shallow-renderer "^16.15.0"
 
 enzyme-shallow-equal@^1.0.0:
   version "1.0.7"


### PR DESCRIPTION
## Summary
- move the Enzyme adapter setup to the shared Jest setup file only
- remove per-test imports and duplicate Enzyme.configure calls across the frontend suite
- switch the shared setup to the React 18 adapter package directly

## Validation
- yarn jest front-end/src/app.test.js front-end/src/summary.test.js front-end/src/main_panel.test.js --runInBand
- yarn jest --runInBand

Closes #2571