### PR TITLE
[codex] Add stable smoke selector contract

### DIFF
--- a/front-end/src/ato/edit_ato.jsx
+++ b/front-end/src/ato/edit_ato.jsx
@@ -77,6 +77,7 @@ const EditAto = ({
             <label htmlFor='name'>{i18next.t('name')}</label>
             <Field
               name='name'
+              data-testid='smoke-ato-name'
               disabled={readOnly}
               className={classNames('form-control', {
                 'is-invalid': ShowError('name', touched, errors)
@@ -94,6 +95,7 @@ const EditAto = ({
             <Field
               name='inlet'
               component='select'
+              data-testid='smoke-ato-inlet'
               disabled={readOnly}
               className={classNames('custom-select', {
                 'is-invalid': ShowError('inlet', touched, errors)
@@ -114,6 +116,7 @@ const EditAto = ({
             <div className='input-group'>
               <Field
                 name='period'
+                data-testid='smoke-ato-period'
                 readOnly={readOnly}
                 type='number'
                 className={classNames('form-control', {
@@ -181,6 +184,7 @@ const EditAto = ({
             <Field
               name='control'
               component='select'
+              data-testid='smoke-ato-control'
               disabled={readOnly}
               className={classNames('custom-select', {
                 'is-invalid': ShowError('control', touched, errors)
@@ -200,6 +204,7 @@ const EditAto = ({
             <Field
               name='pump'
               component='select'
+              data-testid='smoke-ato-pump'
               disabled={readOnly || values.control === ''}
               className={classNames('custom-select', {
                 'is-invalid': ShowError('pump', touched, errors)
@@ -303,6 +308,7 @@ const EditAto = ({
         <div className='col-12'>
           <input
             type='submit'
+            data-testid='smoke-ato-submit'
             value={i18next.t('save')}
             disabled={readOnly}
             className='btn btn-sm btn-primary float-right mt-1'

--- a/front-end/src/ato/new.jsx
+++ b/front-end/src/ato/new.jsx
@@ -67,7 +67,7 @@ class newATO extends React.Component {
   render () {
     return (
       <div className='list-group-item add-ato'>
-        <input id='add_new_ato_sensor' type='button' value={this.state.add ? '-' : '+'} onClick={this.handleToggle} className='btn btn-outline-success' />
+        <input id='add_new_ato_sensor' data-testid='smoke-ato-add-toggle' type='button' value={this.state.add ? '-' : '+'} onClick={this.handleToggle} className='btn btn-outline-success' />
         {this.ui()}
       </div>
     )

--- a/front-end/src/connectors/analog_inputs.jsx
+++ b/front-end/src/connectors/analog_inputs.jsx
@@ -143,6 +143,7 @@ class analogInputs extends React.Component {
           <div className='col-12'>
             <input
               id='add_analog_input'
+              data-testid='smoke-analog-add-toggle'
               type='button'
               value={this.state.add ? '-' : '+'}
               onClick={this.handleAdd}
@@ -159,6 +160,7 @@ class analogInputs extends React.Component {
                   <input
                     type='text'
                     id='analog_inputName'
+                    data-testid='smoke-analog-name'
                     value={this.state.name}
                     onChange={this.handleNameChange}
                     className='form-control'
@@ -178,6 +180,7 @@ class analogInputs extends React.Component {
                   <label>{i18n.t('driver')}</label>
                   <select
                     name='driver'
+                    data-testid='smoke-analog-driver'
                     className='form-control custom-select'
                     onChange={this.handleSetDriver}
                     value={this.state.driver.id}
@@ -196,6 +199,7 @@ class analogInputs extends React.Component {
                 <input
                   type='button'
                   id='createAnalogInput'
+                  data-testid='smoke-analog-submit'
                   value={i18n.t('add')}
                   onClick={this.handleSave}
                   className='btn btn-outline-primary col-12 col-md-4'

--- a/front-end/src/connectors/inlets.jsx
+++ b/front-end/src/connectors/inlets.jsx
@@ -147,6 +147,7 @@ class inlets extends React.Component {
           <div className='col-12'>
             <input
               id='add_inlet'
+              data-testid='smoke-inlet-add-toggle'
               type='button'
               value={this.state.add ? '-' : '+'}
               onClick={this.handleAdd}
@@ -161,6 +162,7 @@ class inlets extends React.Component {
               <input
                 type='text'
                 id='inletName'
+                data-testid='smoke-inlet-name'
                 value={this.state.name}
                 onChange={this.handleNameChange}
                 className='form-control'
@@ -180,6 +182,7 @@ class inlets extends React.Component {
               <span className='input-group-addon'>{i18n.t('driver')}</span>
               <select
                 name='driver'
+                data-testid='smoke-inlet-driver'
                 className='form-control custom-select'
                 onChange={this.handleDriverChange}
                 value={this.state.driver.id}
@@ -210,6 +213,7 @@ class inlets extends React.Component {
             <input
               type='button'
               id='createInlet'
+              data-testid='smoke-inlet-submit'
               value={i18n.t('add')}
               onClick={this.handleSave}
               className='btn btn-outline-primary col-12 col-md-4'

--- a/front-end/src/connectors/jacks.jsx
+++ b/front-end/src/connectors/jacks.jsx
@@ -155,6 +155,7 @@ class jacks extends React.Component {
           <div className='col-12'>
             <input
               id='add_jack'
+              data-testid='smoke-jack-add-toggle'
               type='button'
               value={this.state.add ? '-' : '+'}
               onClick={this.handleAdd}
@@ -171,6 +172,7 @@ class jacks extends React.Component {
                   <input
                     type='text'
                     id='jackName'
+                    data-testid='smoke-jack-name'
                     value={this.state.JackName}
                     onChange={this.handleNameChange}
                     className='form-control'
@@ -195,6 +197,7 @@ class jacks extends React.Component {
                   <input
                     type='text'
                     id='jackPins'
+                    data-testid='smoke-jack-pins'
                     value={this.state.JackPins}
                     onChange={this.handlePinChange}
                     className='form-control'
@@ -207,6 +210,7 @@ class jacks extends React.Component {
                   <label>{i18n.t('driver')}</label>
                   <select
                     name='driver'
+                    data-testid='smoke-jack-driver'
                     className='form-control custom-select'
                     onChange={this.handleSetDriver}
                     value={this.state.JackDriver}
@@ -225,6 +229,7 @@ class jacks extends React.Component {
                 <input
                   type='button'
                   id='createJack'
+                  data-testid='smoke-jack-submit'
                   value={i18n.t('add')}
                   onClick={this.handleSave}
                   className='btn btn-outline-primary col-12 col-md-4'

--- a/front-end/src/connectors/outlets.jsx
+++ b/front-end/src/connectors/outlets.jsx
@@ -149,6 +149,7 @@ class outlets extends React.Component {
           <div className='col-12'>
             <input
               id='add_outlet'
+              data-testid='smoke-outlet-add-toggle'
               type='button'
               value={this.state.add ? '-' : '+'}
               onClick={this.handleAdd}
@@ -164,6 +165,7 @@ class outlets extends React.Component {
               <input
                 type='text'
                 id='outletName'
+                data-testid='smoke-outlet-name'
                 onChange={this.handleNameChange}
                 value={this.state.outName}
                 className='form-control'
@@ -183,6 +185,7 @@ class outlets extends React.Component {
               <span className='input-group-addon'>{i18n.t('driver')}</span>
               <select
                 name='driver'
+                data-testid='smoke-outlet-driver'
                 className='form-control custom-select'
                 onChange={this.handleDriverChange}
                 value={this.state.driver.id}
@@ -213,6 +216,7 @@ class outlets extends React.Component {
             <input
               type='button'
               id='createOutlet'
+              data-testid='smoke-outlet-submit'
               value={i18n.t('add')}
               onClick={this.handleSave}
               className='btn btn-outline-primary col-12 col-md-4'

--- a/front-end/src/dashboard/config.jsx
+++ b/front-end/src/dashboard/config.jsx
@@ -135,7 +135,7 @@ class config extends React.Component {
         </div>
         <div className='row'>
           <div className='col-xs-12'>
-            <input type='button' className={updateButtonClass} onClick={this.handleSave} id='save_dashboard' value={i18next.t('update')} />
+            <input type='button' className={updateButtonClass} onClick={this.handleSave} id='save_dashboard' data-testid='smoke-dashboard-save' value={i18next.t('update')} />
           </div>
         </div>
       </div>

--- a/front-end/src/dashboard/main.jsx
+++ b/front-end/src/dashboard/main.jsx
@@ -208,7 +208,7 @@ class dashboard extends React.Component {
           </div>
           <div className='row' key='configure'>
             <div className='col-12'>
-              <button className='btn btn-outline-dark btn-sm' onClick={this.handleToggle} id='configure-dashboard'>
+              <button className='btn btn-outline-dark btn-sm' onClick={this.handleToggle} id='configure-dashboard' data-testid='smoke-dashboard-configure'>
                 {lbl}
               </button>
             </div>

--- a/front-end/src/doser/edit_dcpump.jsx
+++ b/front-end/src/doser/edit_dcpump.jsx
@@ -55,6 +55,7 @@ const EditDcPump = ({
           <Field
             name='jack'
             component='select'
+            data-testid='smoke-doser-jack'
             onChange={jackChanged}
             disabled={readOnly}
             className={classNames('custom-select', {
@@ -74,6 +75,7 @@ const EditDcPump = ({
           <Field
             name='pin'
             component='select'
+            data-testid='smoke-doser-pin'
             disabled={readOnly}
             className={classNames('custom-select', {
               'is-invalid': ShowError('pin', touched, errors)
@@ -146,9 +148,10 @@ const EditDcPump = ({
             <div className='form-group'>
               <label htmlFor='duration'>{i18n.t('doser:duration')}</label>
               <div className='input-group'>
-                <Field
-                  name='duration'
-                  readOnly={readOnly}
+              <Field
+                name='duration'
+                data-testid='smoke-doser-duration'
+                readOnly={readOnly}
                   type='number'
                   className={classNames('form-control', {
                     'is-invalid': ShowError('duration', touched, errors)
@@ -173,6 +176,7 @@ const EditDcPump = ({
           <div className='input-group'>
             <Percent
               type='number'
+              data-testid='smoke-doser-speed'
               className={classNames('form-control', {
                 'is-invalid': ShowError('speed', touched, errors)
               })}
@@ -198,6 +202,7 @@ const EditDcPump = ({
           <div className='input-group'>
             <Field
               name='soft_start'
+              data-testid='smoke-doser-soft-start'
               readOnly={readOnly}
               type='number'
               min='0'

--- a/front-end/src/doser/edit_doser.jsx
+++ b/front-end/src/doser/edit_doser.jsx
@@ -78,6 +78,7 @@ const EditDoser = ({
             <label htmlFor='name'>{i18next.t('name')}</label>
             <Field
               name='name'
+              data-testid='smoke-doser-name'
               disabled={readOnly}
               className={classNames('form-control', {
                 'is-invalid': ShowError('name', touched, errors)
@@ -108,6 +109,7 @@ const EditDoser = ({
             <Field
               name='type'
               component='select'
+              data-testid='smoke-doser-type'
               disabled={readOnly}
               className={classNames('custom-select', {
                 'is-invalid': ShowError('type', touched, errors)
@@ -142,6 +144,7 @@ const EditDoser = ({
         <div className='col-12'>
           <input
             type='submit'
+            data-testid='smoke-doser-submit'
             value={i18next.t('save')}
             disabled={readOnly}
             className='btn btn-sm btn-primary float-right mt-1'

--- a/front-end/src/doser/main.jsx
+++ b/front-end/src/doser/main.jsx
@@ -150,6 +150,7 @@ class doser extends React.Component {
               <input
                 type='button'
                 id='add_doser'
+                data-testid='smoke-doser-add-toggle'
                 value={this.state.addDoser ? '-' : '+'}
                 onClick={this.handleToggleAddDoserDiv}
                 className='btn btn-outline-success'

--- a/front-end/src/drivers/edit_driver.jsx
+++ b/front-end/src/drivers/edit_driver.jsx
@@ -89,6 +89,7 @@ const EditDriver = ({
             <label htmlFor='name'>{i18n.t('name')}</label>
             <Field
               name='name'
+              data-testid='smoke-driver-name'
               disabled={readOnly}
               className={classNames('form-control', {
                 'is-invalid': ShowError('name', touched, errors)
@@ -105,6 +106,7 @@ const EditDriver = ({
             <Field
               name='type'
               component='select'
+              data-testid='smoke-driver-type'
               onChange={driverTypeChangeHandler}
               disabled={mode === 'edit' || readOnly}
               className={classNames('custom-select', {
@@ -125,6 +127,7 @@ const EditDriver = ({
         <div className='col-12'>
           <input
             type='submit'
+            data-testid='smoke-driver-submit'
             value={i18n.t('save')}
             disabled={readOnly}
             className='btn btn-sm btn-primary float-right mt-1'

--- a/front-end/src/drivers/new.jsx
+++ b/front-end/src/drivers/new.jsx
@@ -63,7 +63,7 @@ export default class New extends React.Component {
   render () {
     return (
       <div className='container add-driver'>
-        <input id='add_new_driver' type='button' value={this.state.add ? '-' : '+'} onClick={this.handleToggle} className='btn btn-outline-success' />
+        <input id='add_new_driver' data-testid='smoke-driver-add-toggle' type='button' value={this.state.add ? '-' : '+'} onClick={this.handleToggle} className='btn btn-outline-success' />
         {this.ui()}
       </div>
     )

--- a/front-end/src/equipment/edit_equipment.jsx
+++ b/front-end/src/equipment/edit_equipment.jsx
@@ -50,6 +50,7 @@ const EditEquipment = ({
           <input
             type='text'
             name='name'
+            data-testid='smoke-equipment-name'
             onChange={handleChange}
             onBlur={handleBlur}
             className={classNames('form-control', { 'is-invalid': ShowError('name', touched, errors) })}
@@ -61,6 +62,7 @@ const EditEquipment = ({
           <label className='mr-2'>{i18next.t('outlet')}</label>
           <select
             name='outlet'
+            data-testid='smoke-equipment-outlet'
             onChange={handleChange}
             onBlur={handleBlur}
             className={classNames('form-control', { 'is-invalid': ShowError('outlet', touched, errors) })}
@@ -95,7 +97,7 @@ const EditEquipment = ({
           <ErrorFor errors={errors} touched={touched} name='stay_off_on_boot' />
         </div>
         <div className='p-2 mr-auto'>
-          <button type='submit' id='add_equipment'>
+          <button type='submit' id='add_equipment' data-testid='smoke-equipment-submit'>
             {FaSave()}
           </button>
         </div>

--- a/front-end/src/equipment/main.jsx
+++ b/front-end/src/equipment/main.jsx
@@ -96,6 +96,7 @@ class main extends React.Component {
             <div className='col'>
               <input
                 id='add_equipment'
+                data-testid='smoke-equipment-add-toggle'
                 type='button'
                 value={this.state.addEquipment ? '-' : '+'}
                 onClick={this.handleToggleAddEquipmentDiv}

--- a/front-end/src/lighting/main.jsx
+++ b/front-end/src/lighting/main.jsx
@@ -263,7 +263,7 @@ class main extends React.Component {
           <label htmlFor='lightName'>{i18n.t('name')}</label>
         </div>
         <div className='col-12 col-sm-9 col-md-3 col-lg-3 mb-1'>
-          <input type='text' id='lightName' className='form-control' required />
+          <input type='text' id='lightName' data-testid='smoke-light-name' className='form-control' required />
         </div>
         <div className='col-12 col-sm-3 col-md-1 col-lg-1'>
           <label htmlFor='jack'>{i18n.t('jack')}</label>
@@ -274,6 +274,7 @@ class main extends React.Component {
               className='btn btn-secondary dropdown-toggle w-100'
               type='button'
               id='jack'
+              data-testid='smoke-light-jack'
               data-toggle='dropdown'
               aria-haspopup='true'
               aria-expanded='false'
@@ -289,6 +290,7 @@ class main extends React.Component {
           <input
             type='button'
             id='createLight'
+            data-testid='smoke-light-submit'
             value={i18n.t('add')}
             onClick={this.handleAddLight}
             className='btn btn-outline-primary'
@@ -313,6 +315,7 @@ class main extends React.Component {
             <div className='col'>
               <input
                 id='add_light'
+                data-testid='smoke-light-add-toggle'
                 type='button'
                 value={this.state.addLight ? '-' : '+'}
                 onClick={this.handleToggleAddLightDiv}

--- a/front-end/src/macro/edit_macro.jsx
+++ b/front-end/src/macro/edit_macro.jsx
@@ -154,6 +154,7 @@ const EditMacro = ({
                     value='+'
                     onClick={() => arrayHelpers.push({ duration: '', id: '', on: '', title: '', message: '' })}
                     id='add-step'
+                    data-testid='smoke-macro-add-step'
                   >
                     +
                   </button>
@@ -168,6 +169,7 @@ const EditMacro = ({
         <div className='col-12'>
           <input
             type='submit'
+            data-testid='smoke-macro-submit'
             value={i18n.t('save')}
             disabled={readOnly}
             className='btn btn-sm btn-primary float-right mt-1'

--- a/front-end/src/macro/main.jsx
+++ b/front-end/src/macro/main.jsx
@@ -175,6 +175,7 @@ class main extends React.Component {
               <input
                 type='button'
                 id='add_macro'
+                data-testid='smoke-macro-add-toggle'
                 value={this.state.addMacro ? '-' : '+'}
                 onClick={this.handleToggleAddMacroDiv}
                 className='btn btn-outline-success'

--- a/front-end/src/main_panel.jsx
+++ b/front-end/src/main_panel.jsx
@@ -74,7 +74,7 @@ class mainPanel extends React.Component {
       .filter(route => currentCaps[route.key] !== undefined && currentCaps[route.key])
       .map(route => (
         <li className='nav-item' key={'li-tab-' + route.key}>
-          <NavLink to={route.path || ''} id={'tab-' + route.key} className="nav-link">
+          <NavLink to={route.path || ''} id={'tab-' + route.key} data-testid={'smoke-tab-' + route.key} className="nav-link">
             {route.label}
           </NavLink>
         </li>
@@ -89,10 +89,10 @@ class mainPanel extends React.Component {
 
     return (
       <BrowserRouter>
-        <div id='content'>
+          <div id='content' data-testid='smoke-shell-root'>
           <nav className='navbar navbar-dark navbar-reefpi navbar-expand-lg'>
-            <span className='navbar-brand mb-0 h1'>{this.props.info.name}</span>
-            <span className='navbar-brand mb-0 h1 navbar-toggler current-tab'><CurrentPageHeader /></span>
+            <span className='navbar-brand mb-0 h1' data-testid='smoke-brand'>{this.props.info.name}</span>
+            <span className='navbar-brand mb-0 h1 navbar-toggler current-tab' data-testid='smoke-current-tab'><CurrentPageHeader /></span>
             <button
               className='navbar-toggler'
               type='button'
@@ -107,6 +107,7 @@ class mainPanel extends React.Component {
             <div
               className='collapse navbar-collapse navHeaderCollapse'
               id='navbarNav'
+              data-testid='smoke-nav'
               data-toggle='collapse'
               data-target='.navbar-collapse'
             >

--- a/front-end/src/ph/main.jsx
+++ b/front-end/src/ph/main.jsx
@@ -196,6 +196,7 @@ class ph extends React.Component {
                 <input
                   type='button'
                   id='add_probe'
+                  data-testid='smoke-ph-add-toggle'
                   value={this.state.addProbe ? '-' : '+'}
                   onClick={this.handleToggleAddProbeDiv}
                   className='btn btn-outline-success'

--- a/front-end/src/sign_in.jsx
+++ b/front-end/src/sign_in.jsx
@@ -79,7 +79,7 @@ export default class SignIn extends React.Component {
       <div className='container d-flex h-100'>
         <div className='align-self-center w-100'>
           <div className='col-md-12 col-lg-6 mx-auto'>
-            <form id='sign-in-form'>
+            <form id='sign-in-form' data-testid='smoke-sign-in-form'>
               <div className='form'>
                 <h1 className='h3 mb-3 font-weight-normal reef-pi-title'>reef-pi</h1>
                 {this.state.invalidCredentials ? (
@@ -96,6 +96,7 @@ export default class SignIn extends React.Component {
                   onChange={this.handleUserChange}
                   type='text'
                   id='reef-pi-user'
+                  data-testid='smoke-sign-in-user'
                   className='form-control'
                   name='username'
                   placeholder={i18n.t('signin:username')}
@@ -109,6 +110,7 @@ export default class SignIn extends React.Component {
                   onChange={this.handlePasswordChange}
                   type='password'
                   id='reef-pi-pass'
+                  data-testid='smoke-sign-in-pass'
                   className='form-control'
                   name='password'
                   placeholder={i18n.t('signin:password')}
@@ -120,6 +122,7 @@ export default class SignIn extends React.Component {
                   onClick={this.handleLogin}
                   type='submit'
                   id='btnSaveCreds'
+                  data-testid='smoke-sign-in-submit'
                 >
                   {i18n.t('signin:signin')}
                 </button>

--- a/front-end/src/temperature/main.jsx
+++ b/front-end/src/temperature/main.jsx
@@ -230,6 +230,7 @@ class main extends React.Component {
                 <input
                   type='button'
                   id='add_probe'
+                  data-testid='smoke-temperature-add-toggle'
                   value={this.state.addProbe ? '-' : '+'}
                   onClick={this.handleToggleAddProbeDiv}
                   className='btn btn-outline-success'

--- a/front-end/src/timers/edit_timer.jsx
+++ b/front-end/src/timers/edit_timer.jsx
@@ -82,6 +82,7 @@ const EditTimer = ({
             <label htmlFor='name'>{i18n.t('name')}</label>
             <Field
               name='name'
+              data-testid='smoke-timer-name'
               disabled={readOnly}
               className={classNames('form-control', {
                 'is-invalid': ShowError('name', touched, errors)
@@ -117,6 +118,7 @@ const EditTimer = ({
             <Field
               name='type'
               component='select'
+              data-testid='smoke-timer-type'
               disabled={readOnly}
               onChange={handleConfigChange}
               className={classNames('custom-select', {
@@ -169,6 +171,7 @@ const EditTimer = ({
         <div className='col-12'>
           <input
             type='submit'
+            data-testid='smoke-timer-submit'
             value={i18n.t('save')}
             disabled={readOnly}
             className='btn btn-sm btn-primary float-right mt-1'

--- a/front-end/src/timers/main.jsx
+++ b/front-end/src/timers/main.jsx
@@ -122,6 +122,7 @@ class Main extends React.Component {
               <input
                 type='button'
                 id='add_timer'
+                data-testid='smoke-timer-add-toggle'
                 value={this.state.addTimer ? '-' : '+'}
                 onClick={this.handleToggleAddTimerDiv}
                 className='btn btn-outline-success'

--- a/front-end/src/ui_components/cron.jsx
+++ b/front-end/src/ui_components/cron.jsx
@@ -13,6 +13,7 @@ const Cron = ({ values, errors, touched, readOnly }) => {
         <label htmlFor='month'>{i18next.t('cron:month')}</label>
         <Field
           name='month'
+          data-testid='smoke-cron-month'
           disabled={readOnly}
           className={classNames('col form-control', {
             'is-invalid': ShowError('month', touched, errors)
@@ -25,6 +26,7 @@ const Cron = ({ values, errors, touched, readOnly }) => {
         <label htmlFor='week'>{i18next.t('cron:week')}</label>
         <Field
           name='week'
+          data-testid='smoke-cron-week'
           disabled={readOnly}
           className={classNames('col form-control', {
             'is-invalid': ShowError('week', touched, errors)
@@ -37,6 +39,7 @@ const Cron = ({ values, errors, touched, readOnly }) => {
         <label htmlFor='day'>{i18next.t('cron:day_of_month')}</label>
         <Field
           name='day'
+          data-testid='smoke-cron-day'
           disabled={readOnly}
           className={classNames('col form-control', {
             'is-invalid': ShowError('day', touched, errors)
@@ -49,6 +52,7 @@ const Cron = ({ values, errors, touched, readOnly }) => {
         <label htmlFor='hour'>{i18next.t('cron:hour')}</label>
         <Field
           name='hour'
+          data-testid='smoke-cron-hour'
           disabled={readOnly}
           className={classNames('col form-control', {
             'is-invalid': ShowError('hour', touched, errors)
@@ -61,6 +65,7 @@ const Cron = ({ values, errors, touched, readOnly }) => {
         <label htmlFor='minute'>{i18next.t('cron:minute')}</label>
         <Field
           name='minute'
+          data-testid='smoke-cron-minute'
           disabled={readOnly}
           className={classNames('col form-control', {
             'is-invalid': ShowError('minute', touched, errors)
@@ -73,6 +78,7 @@ const Cron = ({ values, errors, touched, readOnly }) => {
         <label htmlFor='second'>{i18next.t('cron:second')}</label>
         <Field
           name='second'
+          data-testid='smoke-cron-second'
           disabled={readOnly}
           className={classNames('col form-control', {
             'is-invalid': ShowError('second', touched, errors)

--- a/front-end/test/analog.js
+++ b/front-end/test/analog.js
@@ -1,6 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { select } from './helpers'
-import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
+import { assertNoFatalError, bodyContains, expectBodyContains, tid } from './runtime'
 
 class Analog {
 
@@ -27,12 +27,12 @@ class Analog {
     }
 
     await t
-    .click('input#add_analog_input')
-    .typeText('input#analog_inputName', name)
+    .click(tid('smoke-analog-add-toggle'))
+    .typeText(tid('smoke-analog-name'), name)
 
     await select(this.driverSelect, driver)
     await select(this.pinSelect, pin)
-    await t.click('input#createAnalogInput')
+    await t.click(tid('smoke-analog-submit'))
     await expectBodyContains(name)
     await assertNoFatalError()
   }

--- a/front-end/test/ato.js
+++ b/front-end/test/ato.js
@@ -1,6 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { select, clear, setText } from './helpers'
-import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
+import { assertNoFatalError, bodyContains, expectBodyContains, tid } from './runtime'
 
 class Ato {
 
@@ -34,24 +34,24 @@ class Ato {
     }
 
     await t
-    .click('input#add_new_ato_sensor')
-    .typeText('.add-ato [name*="name"]', name)
+    .click(tid('smoke-ato-add-toggle'))
+    .typeText(tid('smoke-ato-name'), name)
 
-    await select(this.inlet, inlet)
-    await setText(this.period, period)
+    await select(Selector(tid('smoke-ato-inlet')), inlet)
+    await setText(Selector(tid('smoke-ato-period')), period)
     await select(this.enable, enable)
 
-    await t.click('input[type*="submit"]')
+    await t.click(tid('smoke-ato-submit'))
     await expectBodyContains(name)
     await assertNoFatalError()
   }
 
   async editAto(period, enable, control, pump) {
-    await setText(this.period, period)
+    await setText(Selector(tid('smoke-ato-period')), period)
     await select(this.enable, enable)
-    await select(this.control, control)
-    await select(this.pump, pump)
-    await t.click('input[type*="submit"]')
+    await select(Selector(tid('smoke-ato-control')), control)
+    await select(Selector(tid('smoke-ato-pump')), pump)
+    await t.click(tid('smoke-ato-submit'))
     await expectBodyContains('Biocube29')
     await assertNoFatalError()
   }

--- a/front-end/test/dashboard.js
+++ b/front-end/test/dashboard.js
@@ -1,6 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { select, clear, setText } from './helpers'
-import { assertNoFatalError, expectExists } from './runtime'
+import { assertNoFatalError, expectExists, tid } from './runtime'
 
 class Dashboard {
 
@@ -13,7 +13,7 @@ class Dashboard {
 
   async configure() {
     await t.click('a#tab-dashboard')
-    .click('button#configure-dashboard')
+    .click(tid('smoke-dashboard-configure'))
 
     await setText(this.rows, 3)
     await setText(this.columns, 2)
@@ -48,9 +48,9 @@ class Dashboard {
       .click('button#select-component-2-1')
       .click('span#component-2-1-current')
 
-      .click('input#save_dashboard')
-      .click('button#configure-dashboard')
-    await expectExists('button#configure-dashboard')
+      .click(tid('smoke-dashboard-save'))
+      .click(tid('smoke-dashboard-configure'))
+    await expectExists(tid('smoke-dashboard-configure'))
     await assertNoFatalError()
   }
 }

--- a/front-end/test/doser.js
+++ b/front-end/test/doser.js
@@ -1,19 +1,19 @@
 import { Selector, t } from 'testcafe'
 import { select, setText } from './helpers'
-import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
+import { assertNoFatalError, bodyContains, expectBodyContains, tid } from './runtime'
 
 class Doser {
 
   constructor(){
-    this.name = Selector('.add-doser input[name="name"]')
-    this.jackSelect = Selector('.add-doser [name="jack"]')
-    this.pinSelect = Selector('.add-doser [name="pin"]')
-    this.hour = Selector('.add-doser [name="hour"]')
-    this.minute = Selector('.add-doser [name="minute"]')
-    this.second = Selector('.add-doser [name="second"]')
-    this.duration = Selector('.add-doser [name="duration"]')
-    this.speed = Selector('.add-doser [name="speed"]')
-    this.submit = Selector('.add-doser input[type*="submit"]')
+    this.name = Selector(tid('smoke-doser-name'))
+    this.jackSelect = Selector(tid('smoke-doser-jack'))
+    this.pinSelect = Selector(tid('smoke-doser-pin'))
+    this.hour = Selector(tid('smoke-cron-hour'))
+    this.minute = Selector(tid('smoke-cron-minute'))
+    this.second = Selector(tid('smoke-cron-second'))
+    this.duration = Selector(tid('smoke-doser-duration'))
+    this.speed = Selector(tid('smoke-doser-speed'))
+    this.submit = Selector(tid('smoke-doser-submit'))
   }
 
   async create() {
@@ -29,7 +29,7 @@ class Doser {
     }
 
     await t
-      .click('input#add_doser')
+      .click(tid('smoke-doser-add-toggle'))
       .typeText(this.name, name)
 
     await select(this.jackSelect, jack)

--- a/front-end/test/driver.js
+++ b/front-end/test/driver.js
@@ -1,11 +1,11 @@
 import { Selector, t } from 'testcafe'
 import { select } from './helpers'
-import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
+import { assertNoFatalError, bodyContains, expectBodyContains, tid } from './runtime'
 
 class Driver {
 
   constructor(){
-    this.driverSelect = Selector('.add-driver [name*="type"]')
+    this.driverSelect = Selector(tid('smoke-driver-type'))
   }
 
   async create() {
@@ -26,8 +26,8 @@ class Driver {
     }
 
     await t
-    .click('input#add_new_driver')
-    .typeText('.add-driver [name*="name"]', name)
+    .click(tid('smoke-driver-add-toggle'))
+    .typeText(tid('smoke-driver-name'), name)
 
     await select(this.driverSelect, type)
 
@@ -44,7 +44,7 @@ class Driver {
     }
 
     await t
-    .click('.add-driver input[type*="submit"]')
+    .click(tid('smoke-driver-submit'))
     await expectBodyContains(name)
     await assertNoFatalError()
 

--- a/front-end/test/equipment.js
+++ b/front-end/test/equipment.js
@@ -1,6 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { select } from './helpers'
-import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
+import { assertNoFatalError, bodyContains, expectBodyContains, tid } from './runtime'
 
 class Equipment {
 
@@ -29,13 +29,13 @@ class Equipment {
     }
 
     await t
-    .click('input#add_equipment')
-    .typeText('.add-equipment [name*="name"]', name)
+    .click(tid('smoke-equipment-add-toggle'))
+    .typeText(tid('smoke-equipment-name'), name)
 
     await select(this.outletSelect, outlet)
 
     await t
-    .click('.add-equipment button[type*="submit"]')
+    .click(tid('smoke-equipment-submit'))
     await expectBodyContains(name)
     await assertNoFatalError()
   }

--- a/front-end/test/inlet.js
+++ b/front-end/test/inlet.js
@@ -1,6 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { select } from './helpers'
-import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
+import { assertNoFatalError, bodyContains, expectBodyContains, tid } from './runtime'
 
 class Inlet {
 
@@ -27,11 +27,11 @@ class Inlet {
     }
 
     await t
-    .click('input#add_inlet')
-    .typeText('input#inletName', name)
+    .click(tid('smoke-inlet-add-toggle'))
+    .typeText(tid('smoke-inlet-name'), name)
 
     await select(this.pinSelect, pin)
-    await t.click('input#createInlet')
+    await t.click(tid('smoke-inlet-submit'))
     await expectBodyContains(name)
     await assertNoFatalError()
   }

--- a/front-end/test/jack.js
+++ b/front-end/test/jack.js
@@ -1,5 +1,5 @@
 import { Selector, t } from 'testcafe'
-import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
+import { assertNoFatalError, bodyContains, expectBodyContains, tid } from './runtime'
 
 class Jack {
 
@@ -26,10 +26,10 @@ class Jack {
     }
 
     await t
-    .click('input#add_jack')
-    .typeText(this.name, name)
-    .typeText(this.pins, pins)
-    .click('input#createJack')
+    .click(tid('smoke-jack-add-toggle'))
+    .typeText(tid('smoke-jack-name'), name)
+    .typeText(tid('smoke-jack-pins'), pins)
+    .click(tid('smoke-jack-submit'))
     await expectBodyContains(name)
     await assertNoFatalError()
   }

--- a/front-end/test/light.js
+++ b/front-end/test/light.js
@@ -1,6 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { clear, select } from './helpers'
-import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
+import { assertNoFatalError, bodyContains, expectBodyContains, tid } from './runtime'
 
 class Light {
 
@@ -21,11 +21,11 @@ class Light {
     }
 
     await t
-    .click('input#add_light')
-    .typeText('input#lightName', name)
-    .click('button#jack')
+    .click(tid('smoke-light-add-toggle'))
+    .typeText(tid('smoke-light-name'), name)
+    .click(tid('smoke-light-jack'))
     .click('span#select-jack-J0')
-    .click('input#createLight')
+    .click(tid('smoke-light-submit'))
     .click('button#edit-light-1')
 
     await clear(this.name)

--- a/front-end/test/macro.js
+++ b/front-end/test/macro.js
@@ -1,6 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { clear, select } from './helpers'
-import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
+import { assertNoFatalError, bodyContains, expectBodyContains, tid } from './runtime'
 
 class Macro {
 
@@ -51,20 +51,20 @@ class Macro {
     }
 
     await t
-    .click('input#add_macro')
+    .click(tid('smoke-macro-add-toggle'))
     .typeText('.add-macro input[name="name"]', macro.name)
 
     for (var idx = 0; idx < macro.steps.length; idx++) {
       await this.addStep(idx, macro.steps[idx])
     }
 
-    await t.click('.add-macro input[type*="submit"]')
+    await t.click(tid('smoke-macro-submit'))
     await expectBodyContains(macro.name)
     await assertNoFatalError()
   }
 
   async addStep(idx, step) {
-    await t.click('.add-macro button#add-step')
+    await t.click(tid('smoke-macro-add-step'))
     await select(Selector(this.type(idx)), step.type)
     if (step.system !== undefined) {
       await select(Selector(this.system(idx)), step.system)

--- a/front-end/test/outlet.js
+++ b/front-end/test/outlet.js
@@ -1,6 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { select } from './helpers'
-import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
+import { assertNoFatalError, bodyContains, expectBodyContains, tid } from './runtime'
 
 class Outlet {
 
@@ -34,11 +34,11 @@ class Outlet {
     }
 
     await t
-    .click('input#add_outlet')
-    .typeText('input#outletName', name)
+    .click(tid('smoke-outlet-add-toggle'))
+    .typeText(tid('smoke-outlet-name'), name)
 
     await select(this.pinSelect, pin)
-    await t.click('input#createOutlet')
+    await t.click(tid('smoke-outlet-submit'))
     await expectBodyContains(name)
     await assertNoFatalError()
   }

--- a/front-end/test/ph.js
+++ b/front-end/test/ph.js
@@ -1,6 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { select } from './helpers'
-import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
+import { assertNoFatalError, bodyContains, expectBodyContains, tid } from './runtime'
 
 class Ph {
 
@@ -22,7 +22,7 @@ class Ph {
     }
 
     await t
-    .click('input#add_probe')
+    .click(tid('smoke-ph-add-toggle'))
     .typeText('.add-probe input[name="name"]', name)
     .typeText('.add-probe input[name="period"]', period, {replace: true})
 

--- a/front-end/test/runtime.js
+++ b/front-end/test/runtime.js
@@ -1,19 +1,21 @@
 import { Selector, t } from 'testcafe'
 
-const shellRoot = Selector('#content')
+export const tid = (name) => `[data-testid="${name}"]`
+
+const shellRoot = Selector(tid('smoke-shell-root'))
 const fatalError = Selector('.fatal-error-container')
 
 export async function login () {
   await t
-    .typeText('#reef-pi-user', 'reef-pi', { replace: true })
-    .typeText('#reef-pi-pass', 'reef-pi', { replace: true })
-    .click('#btnSaveCreds')
+    .typeText(tid('smoke-sign-in-user'), 'reef-pi', { replace: true })
+    .typeText(tid('smoke-sign-in-pass'), 'reef-pi', { replace: true })
+    .click(tid('smoke-sign-in-submit'))
 }
 
 export async function waitForShell () {
   await t
     .expect(shellRoot.exists).ok({ timeout: 15000 })
-    .expect(Selector('#tab-dashboard').exists).ok({ timeout: 15000 })
+    .expect(Selector(tid('smoke-tab-dashboard')).exists).ok({ timeout: 15000 })
 }
 
 export async function assertNoFatalError () {

--- a/front-end/test/smoke.js
+++ b/front-end/test/smoke.js
@@ -13,7 +13,7 @@ import ato from './ato'
 import doser from './doser'
 import tc from './tc'
 import dashboard from './dashboard'
-import { assertNoFatalError, login, waitForShell } from './runtime'
+import { assertNoFatalError, login, tid, waitForShell } from './runtime'
 
 fixture `Smoke`
     .page `http://localhost:8080/`
@@ -21,7 +21,7 @@ fixture `Smoke`
 test('sign in and load shell', async t => {
   await login()
   await waitForShell()
-  await t.expect(Selector('#tab-dashboard').innerText).eql('Dashboard')
+  await t.expect(Selector(tid('smoke-tab-dashboard')).innerText).eql('Dashboard')
   await assertNoFatalError()
 })
 

--- a/front-end/test/tc.js
+++ b/front-end/test/tc.js
@@ -1,6 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { select, setText } from './helpers'
-import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
+import { assertNoFatalError, bodyContains, expectBodyContains, tid } from './runtime'
 
 class Tc {
 
@@ -40,7 +40,7 @@ class Tc {
     }
 
     await t
-      .click('input#add_probe')
+      .click(tid('smoke-temperature-add-toggle'))
       .typeText(this.name, tc.name)
 
     await select(this.sensor, tc.sensor)

--- a/front-end/test/timer.js
+++ b/front-end/test/timer.js
@@ -1,6 +1,6 @@
 import { Selector, t } from 'testcafe'
 import { clear, select } from './helpers'
-import { assertNoFatalError, bodyContains, expectBodyContains } from './runtime'
+import { assertNoFatalError, bodyContains, expectBodyContains, tid } from './runtime'
 
 class Timer {
 
@@ -8,9 +8,9 @@ class Timer {
     this.equipmentSelect = Selector('.add-timer [name="target.id"]')
     this.revertSelect = Selector('.add-timer [name="target.revert"]')
     this.duration = Selector('.add-timer [name="target.duration"]')
-    this.hour = Selector('.add-timer [name="hour"]')
-    this.minute = Selector('.add-timer [name="minute"]')
-    this.second = Selector('.add-timer [name="second"]')
+    this.hour = Selector(tid('smoke-cron-hour'))
+    this.minute = Selector(tid('smoke-cron-minute'))
+    this.second = Selector(tid('smoke-cron-second'))
   }
 
   async create() {
@@ -26,8 +26,8 @@ class Timer {
     }
 
     await t
-    .click('input#add_timer')
-    .typeText('.add-timer input[name="name"]', name)
+    .click(tid('smoke-timer-add-toggle'))
+    .typeText(tid('smoke-timer-name'), name)
 
     await select(this.equipmentSelect, equipment)
     await select(this.revertSelect, revert)
@@ -44,7 +44,7 @@ class Timer {
     await clear(this.second)
     await t
     .typeText(this.second, second)
-    .click('.add-timer input[type*="submit"]')
+    .click(tid('smoke-timer-submit'))
     await expectBodyContains(name)
     await assertNoFatalError()
   }


### PR DESCRIPTION
## Summary

- add `data-testid` hooks to smoke-driven login, shell, dashboard, and key add/save form controls
- migrate the smoke helpers to target those stable selectors instead of incidental class/name structure
- keep the selector contract intentionally narrow to the smoke-critical UI paths touched by the current suite

## Why

This is the second slice in the smoke-testing roadmap tracked in #2580 and it builds on PR #2577.

Note: GitHub rejected a stacked PR against `codex/smoke-suite-hardening` through automation even though the branch relationship is correct, so this draft targets `main` and should be reviewed after or together with #2577.

The smoke suite is more structured after PR #2577, but it was still coupled to DOM layout and generic field names in several high-churn forms. This change gives the suite an explicit UI contract without doing a repo-wide test-attribute sweep.

## Impact

- smoke tests are less sensitive to layout refactors in login, navigation, and representative add/edit flows
- the selector contract is explicit and easy to extend as future smoke coverage grows
- no user-facing behavior changes

## Validation

- `rtk make ui`
- `rtk bash scripts/wait-http.sh http://127.0.0.1:8080/ 10`
- `rtk yarn run ci-smoke`
