### PR TITLE
[codex] Add smoke API reset workflow

### DIFF
--- a/controller/daemon/api.go
+++ b/controller/daemon/api.go
@@ -161,6 +161,10 @@ func (r *ReefPi) AuthenticatedAPI(router *mux.Router) {
 	// 	200:
 	router.HandleFunc("/api/me", r.a.Me).Methods("GET")
 
+	if r.settings.Capabilities.DevMode {
+		router.HandleFunc("/api/dev/smoke/reset", r.ResetSmokeState).Methods("POST")
+	}
+
 	if r.h != nil {
 		router.HandleFunc("/api/health_stats", r.h.GetStats).Methods("GET")
 	}

--- a/controller/daemon/api_test.go
+++ b/controller/daemon/api_test.go
@@ -103,6 +103,9 @@ func TestAPI(t *testing.T) {
 	if err := tr.Do("DELETE", "/api/errors/clear", new(bytes.Buffer), nil); err != nil {
 		t.Error("Failed to clear errors using api. Error:", err)
 	}
+	if err := tr.Do("POST", "/api/dev/smoke/reset", new(bytes.Buffer), nil); err != nil {
+		t.Error("Failed to reset smoke state using api. Error:", err)
+	}
 	if err := tr.Do("POST", "/api/telemetry/test_message", new(bytes.Buffer), nil); err != nil {
 		t.Error("Failed to send test message using api. Error:", err)
 	}

--- a/controller/daemon/smoke_reset.go
+++ b/controller/daemon/smoke_reset.go
@@ -1,0 +1,58 @@
+package daemon
+
+import (
+	"net/http"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+	"github.com/reef-pi/reef-pi/controller/utils"
+)
+
+var smokeResetBuckets = []string{
+	storage.ATOBucket,
+	storage.ATOUsageBucket,
+	storage.AnalogInputBucket,
+	storage.DoserBucket,
+	storage.DoserUsageBucket,
+	storage.DriverBucket,
+	storage.EquipmentBucket,
+	storage.ErrorBucket,
+	storage.InletBucket,
+	storage.JackBucket,
+	storage.LightingBucket,
+	storage.LightingUsageBucket,
+	storage.MacroBucket,
+	storage.MacroUsageBucket,
+	storage.OutletBucket,
+	storage.PhBucket,
+	storage.PhCalibrationBucket,
+	storage.PhReadingsBucket,
+	storage.TemperatureBucket,
+	storage.TemperatureCalibrationBucket,
+	storage.TemperatureUsageBucket,
+	storage.TimerBucket,
+}
+
+func (r *ReefPi) ResetSmokeState(w http.ResponseWriter, req *http.Request) {
+	if !r.settings.Capabilities.DevMode {
+		utils.ErrorResponse(http.StatusNotFound, "dev smoke reset unavailable", w)
+		return
+	}
+
+	for _, bucket := range smokeResetBuckets {
+		if err := r.store.DeleteBucket(bucket); err != nil {
+			utils.ErrorResponse(http.StatusInternalServerError, "Failed to reset smoke bucket. Error: "+err.Error(), w)
+			return
+		}
+		if err := r.store.CreateBucket(bucket); err != nil {
+			utils.ErrorResponse(http.StatusInternalServerError, "Failed to initialize smoke bucket. Error: "+err.Error(), w)
+			return
+		}
+	}
+
+	if err := r.store.Update(Bucket, "dashboard", DefaultDashboard); err != nil {
+		utils.ErrorResponse(http.StatusInternalServerError, "Failed to reset dashboard. Error: "+err.Error(), w)
+		return
+	}
+
+	utils.JSONResponse(nil, w, req)
+}

--- a/controller/device_manager/drivers/api_test.go
+++ b/controller/device_manager/drivers/api_test.go
@@ -107,3 +107,31 @@ func TestDrivers_API(t *testing.T) {
 		t.Error("Failed to list options")
 	}
 }
+
+func TestDrivers_DeleteAllowsIDReuseAfterBucketReset(t *testing.T) {
+	d, s := newDrivers(t)
+	defer s.Close()
+
+	if err := d.Delete("1"); err != nil {
+		t.Fatal("Failed to delete driver. Error:", err)
+	}
+	if err := s.DeleteBucket(storage.DriverBucket); err != nil {
+		t.Fatal("Failed to delete driver bucket. Error:", err)
+	}
+	if err := s.CreateBucket(storage.DriverBucket); err != nil {
+		t.Fatal("Failed to recreate driver bucket. Error:", err)
+	}
+
+	err := d.Create(Driver{
+		Name:   "bar",
+		Type:   "pca9685",
+		Config: []byte(`{}`),
+		Parameters: map[string]interface{}{
+			"Address":   0x41,
+			"Frequency": 1200,
+		},
+	})
+	if err != nil {
+		t.Fatal("Expected driver create to succeed after delete and bucket reset. Error:", err)
+	}
+}

--- a/controller/device_manager/drivers/drivers.go
+++ b/controller/device_manager/drivers/drivers.go
@@ -177,9 +177,12 @@ func (d *Drivers) Delete(id string) error {
 	if id == _rpi {
 		return fmt.Errorf("rpi driver is readonly")
 	}
+	d.Lock()
+	defer d.Unlock()
 	driver, ok := d.drivers[id]
 	if ok {
 		driver.Close()
+		delete(d.drivers, id)
 	}
 	return d.store.Delete(DriverBucket, id)
 }

--- a/controller/storage/boltdb.go
+++ b/controller/storage/boltdb.go
@@ -63,6 +63,15 @@ func (s *store) CreateBucket(bucket string) error {
 	})
 }
 
+func (s *store) DeleteBucket(bucket string) error {
+	return s.db.Update(func(tx *bolt.Tx) error {
+		if tx.Bucket([]byte(bucket)) == nil {
+			return nil
+		}
+		return tx.DeleteBucket([]byte(bucket))
+	})
+}
+
 func (s *store) RawGet(bucket, id string) ([]byte, error) {
 	var data []byte
 	err := s.db.View(func(tx *bolt.Tx) error {

--- a/controller/storage/store.go
+++ b/controller/storage/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Buckets() ([]string, error)
 	SubBucket(string, string) ObjectStore
 	CreateBucket(string) error
+	DeleteBucket(string) error
 	Path() string
 }
 

--- a/controller/storage/store_test.go
+++ b/controller/storage/store_test.go
@@ -79,6 +79,12 @@ func TestStore(t *testing.T) {
 	if !found {
 		t.Error("Expected test bucket in Buckets() output")
 	}
+	if err := store.DeleteBucket(testBucket); err != nil {
+		t.Fatal("DeleteBucket() failed:", err)
+	}
+	if err := store.List(testBucket, lsFn); err == nil {
+		t.Fatal("Expected deleted bucket to be unavailable")
+	}
 
 	// Path
 	if p := store.Path(); p == "" {

--- a/front-end/test/README.md
+++ b/front-end/test/README.md
@@ -4,7 +4,7 @@
 
 - Purpose: verify the app shell, login flow, and a small set of end-to-end subsystem paths without trying to exhaustively validate every form combination.
 - Current structure: `front-end/test/smoke.js` groups the suite into multiple TestCafe tests and reuses helper modules for each subsystem flow.
-- Runtime helpers: shared login, shell readiness, and fatal-error assertions live in `front-end/test/runtime.js`.
+- Runtime helpers: shared login, shell readiness, fatal-error assertions, and API-backed smoke reset helpers live in `front-end/test/runtime.js`.
 
 ## Smoke local run
 
@@ -15,6 +15,7 @@
 - `make smoke`
 
 The CI workflow waits for `http://127.0.0.1:8080/` before running smoke. If a local run fails before the login form appears, verify the backend is still starting and inspect the server log output.
+Each grouped smoke test clears the prior TestCafe-created data through the authenticated REST API before it starts creating fixtures, so reruns no longer depend on a manually cleaned development database.
 
 ## Smoke debugging
 

--- a/front-end/test/driver.js
+++ b/front-end/test/driver.js
@@ -1,11 +1,15 @@
 import { Selector, t } from 'testcafe'
 import { select } from './helpers'
-import { assertNoFatalError, bodyContains, expectBodyContains, tid } from './runtime'
+import { assertNoFatalError, expectBodyContains, tid } from './runtime'
 
 class Driver {
 
   constructor(){
     this.driverSelect = Selector(tid('smoke-driver-type'))
+  }
+
+  driverName(name) {
+    return Selector('.row.border-bottom.py-1 .col-4').withExactText(name)
   }
 
   async create() {
@@ -19,8 +23,8 @@ class Driver {
   }
 
   async addDriver(type, name, config) {
-    if (await bodyContains(name)) {
-      await expectBodyContains(name)
+    if (await this.driverName(name).exists) {
+      await t.expect(this.driverName(name).exists).ok()
       await assertNoFatalError()
       return
     }

--- a/front-end/test/runtime.js
+++ b/front-end/test/runtime.js
@@ -4,6 +4,89 @@ export const tid = (name) => `[data-testid="${name}"]`
 
 const shellRoot = Selector(tid('smoke-shell-root'))
 const fatalError = Selector('.fatal-error-container')
+const smokeApiBase = 'http://127.0.0.1:8080'
+const resetCollections = [
+  'tcs',
+  'doser/pumps',
+  'atos',
+  'phprobes',
+  'macros',
+  'lights',
+  'timers',
+  'equipment',
+  'analog_inputs',
+  'jacks',
+  'inlets',
+  'outlets',
+  'drivers'
+]
+
+async function smokeRequest (method, path, cookie, payload) {
+  const options = {
+    method,
+    headers: {
+      Accept: 'application/json',
+      Cookie: cookie
+    }
+  }
+
+  if (payload !== undefined) {
+    options.body = JSON.stringify(payload)
+    options.headers['Content-Type'] = 'application/json'
+  }
+
+  const response = await fetch(`${smokeApiBase}/api/${path}`, options)
+  const text = await response.text()
+
+  if (!response.ok) {
+    throw new Error(`Smoke API ${method} /api/${path} failed: ${response.status} ${text}`)
+  }
+
+  if (text.length === 0) {
+    return null
+  }
+
+  try {
+    return JSON.parse(text)
+  } catch (_) {
+    return text
+  }
+}
+
+async function signInForReset () {
+  const response = await fetch(`${smokeApiBase}/auth/signin`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ user: 'reef-pi', password: 'reef-pi' })
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(`Smoke auth failed: ${response.status} ${text}`)
+  }
+
+  const cookie = response.headers.get('set-cookie')
+  if (!cookie) {
+    throw new Error('Smoke auth failed: missing session cookie')
+  }
+  return cookie.split(';', 1)[0]
+}
+
+async function deleteCollection (path, cookie) {
+  const items = await smokeRequest('GET', path, cookie)
+  if (!Array.isArray(items) || items.length === 0) {
+    return
+  }
+
+  for (const item of items) {
+    if (item && item.id && item.id !== 'rpi' && !item.readonly) {
+      await smokeRequest('DELETE', `${path}/${item.id}`, cookie)
+    }
+  }
+}
 
 export async function login () {
   await t
@@ -37,4 +120,22 @@ export async function expectBodyContains (text) {
 
 export async function bodyContains (text) {
   return Selector('body').withText(text).exists
+}
+
+export async function resetSmokeState () {
+  const cookie = await signInForReset()
+
+  for (const path of resetCollections) {
+    await deleteCollection(path, cookie)
+  }
+
+  await smokeRequest('POST', 'dev/smoke/reset', cookie)
+}
+
+export async function prepareCleanSession () {
+  await resetSmokeState()
+  await t.navigateTo('http://localhost:8080/')
+  await login()
+  await waitForShell()
+  await assertNoFatalError()
 }

--- a/front-end/test/smoke.js
+++ b/front-end/test/smoke.js
@@ -13,7 +13,7 @@ import ato from './ato'
 import doser from './doser'
 import tc from './tc'
 import dashboard from './dashboard'
-import { assertNoFatalError, login, tid, waitForShell } from './runtime'
+import { assertNoFatalError, login, prepareCleanSession, tid, waitForShell } from './runtime'
 
 fixture `Smoke`
     .page `http://localhost:8080/`
@@ -26,8 +26,7 @@ test('sign in and load shell', async t => {
 })
 
 test('create configuration dependencies', async () => {
-  await login()
-  await waitForShell()
+  await prepareCleanSession()
   await driver.create()
   await outlet.create()
   await inlet.create()
@@ -36,8 +35,7 @@ test('create configuration dependencies', async () => {
 })
 
 test('create subsystem entities', async () => {
-  await login()
-  await waitForShell()
+  await prepareCleanSession()
   await driver.create()
   await outlet.create()
   await inlet.create()
@@ -55,8 +53,7 @@ test('create subsystem entities', async () => {
 })
 
 test('configure dashboard', async () => {
-  await login()
-  await waitForShell()
+  await prepareCleanSession()
   await driver.create()
   await outlet.create()
   await inlet.create()
@@ -64,7 +61,9 @@ test('configure dashboard', async () => {
   await analog.create()
   await equipment.create()
   await light.create()
+  await macro.create()
   await ph.create()
   await ato.create()
+  await tc.create()
   await dashboard.configure()
 })


### PR DESCRIPTION
## Summary
- add a dev-only `/api/dev/smoke/reset` endpoint that drops and recreates the smoke-owned buckets and restores the default dashboard
- move the smoke harness onto that reset path so each grouped TestCafe test starts from a clean application state
- fix driver deletion to evict the in-memory driver registry entry so clean-room resets can recreate drivers without stale ID collisions

## Why
This is the third slice in the smoke roadmap tracked in #2580 and builds on #2577 and #2581.

PR 1 split and stabilized the smoke suite.
PR 2 added a stable selector contract.
This slice adds the first real reset seam so smoke coverage no longer depends on a manually cleaned dev database or stale browser-created state.

While wiring that reset path, the work exposed a backend bug: deleting a driver removed it from Bolt but left it registered in memory. That made fresh driver creation fail after a reset even though the DB was clean. This PR fixes that behavior and adds a regression test.

## Validation
- `rtk go test ./controller/storage/...`
- `rtk go test ./controller/daemon/...`
- `rtk go test ./controller/device_manager/drivers/...`
- `rtk yarn run ci-smoke`

## Review Notes
- This branch is intended to stack on #2581 (`codex/smoke-selector-contract`). GitHub is currently rejecting stacked PR creation for these codex branches, so this draft targets `main` and should be reviewed after or together with #2581.
