### PR TITLE
[codex] Add Playwright smoke bootstrap

### DIFF
--- a/.github/workflows/playwright_smoke.yml
+++ b/.github/workflows/playwright_smoke.yml
@@ -1,0 +1,33 @@
+name: Playwright Smoke
+on: [push, pull_request]
+jobs:
+  playwright-smoke:
+    name: Playwright Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.2'
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - uses: actions/cache@v4.3.0
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node_modules-
+      - run: make install
+      - run: npx playwright install --with-deps chromium
+      - run: make go
+      - run: make ui
+      - run: yarn pw-smoke
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts
+          path: |
+            playwright-report
+            test-results/playwright
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ coverage
 front-end/src/utils/translations/*.json
 test-data
 .vendor-new/*
+playwright-report
+test-results
+front-end/e2e/.auth

--- a/front-end/e2e/auth.setup.js
+++ b/front-end/e2e/auth.setup.js
@@ -1,0 +1,14 @@
+const fs = require('fs')
+const { test: setup, expect } = require('@playwright/test')
+const { authDir, authFile } = require('./fixtures/authFile')
+
+setup('authenticate smoke user', async ({ page }) => {
+  fs.mkdirSync(authDir, { recursive: true })
+
+  await page.goto('/')
+  await page.getByTestId('smoke-sign-in-user').fill('reef-pi')
+  await page.getByTestId('smoke-sign-in-pass').fill('reef-pi')
+  await page.getByTestId('smoke-sign-in-submit').click()
+  await expect(page.getByTestId('smoke-shell-root')).toBeVisible()
+  await page.context().storageState({ path: authFile })
+})

--- a/front-end/e2e/fixtures/apiSeed.js
+++ b/front-end/e2e/fixtures/apiSeed.js
@@ -1,0 +1,156 @@
+const { request: playwrightRequest, expect } = require('@playwright/test')
+const { authFile } = require('./authFile')
+const resetCollections = [
+  '/api/tcs',
+  '/api/doser/pumps',
+  '/api/atos',
+  '/api/phprobes',
+  '/api/macros',
+  '/api/lights',
+  '/api/timers',
+  '/api/equipment',
+  '/api/analog_inputs',
+  '/api/jacks',
+  '/api/inlets',
+  '/api/outlets',
+  '/api/drivers'
+]
+
+async function createSmokeApi(baseURL = 'http://127.0.0.1:8080') {
+  return playwrightRequest.newContext({
+    baseURL,
+    storageState: authFile,
+    extraHTTPHeaders: {
+      Accept: 'application/json'
+    }
+  })
+}
+
+async function jsonRequest(api, method, path, payload) {
+  const response = await api.fetch(path, {
+    method,
+    data: payload
+  })
+
+  expect(response.ok(), `${method} ${path} should succeed`).toBeTruthy()
+
+  const text = await response.text()
+  if (!text) {
+    return null
+  }
+
+  try {
+    return JSON.parse(text)
+  } catch (_) {
+    return text
+  }
+}
+
+async function resetSmokeState(api) {
+  for (const path of resetCollections) {
+    const items = await listItems(api, path)
+    for (const item of items) {
+      if (item && item.id && item.id !== 'rpi' && !item.readonly) {
+        await jsonRequest(api, 'DELETE', `${path}/${item.id}`)
+      }
+    }
+  }
+
+  await jsonRequest(api, 'POST', '/api/dev/smoke/reset')
+}
+
+async function listItems(api, path) {
+  const items = await jsonRequest(api, 'GET', path)
+  return Array.isArray(items) ? items : []
+}
+
+async function createDriver(api, driver) {
+  await jsonRequest(api, 'PUT', '/api/drivers', driver)
+  const drivers = await listItems(api, '/api/drivers')
+  return drivers.find(item => item.name === driver.name)
+}
+
+async function createOutlet(api, outlet) {
+  await jsonRequest(api, 'PUT', '/api/outlets', outlet)
+  const outlets = await listItems(api, '/api/outlets')
+  return outlets.find(item => item.name === outlet.name)
+}
+
+async function createEquipment(api, equipment) {
+  await jsonRequest(api, 'PUT', '/api/equipment', equipment)
+  const equipmentItems = await listItems(api, '/api/equipment')
+  return equipmentItems.find(item => item.name === equipment.name)
+}
+
+async function updateDashboard(api, payload) {
+  await jsonRequest(api, 'POST', '/api/dashboard', payload)
+}
+
+async function seedConfiguration(api) {
+  await resetSmokeState(api)
+
+  const pca9685 = await createDriver(api, {
+    name: 'pca9685',
+    type: 'pca9685',
+    config: {
+      address: 64,
+      frequency: 1100
+    }
+  })
+  await createDriver(api, {
+    name: 'ph',
+    type: 'ph-board',
+    config: {
+      address: 69
+    }
+  })
+  await createDriver(api, {
+    name: 'hs103',
+    type: 'hs103',
+    config: {
+      address: '192.168.1.1:9999'
+    }
+  })
+
+  const outlets = []
+  for (const outlet of [
+    { name: 'O1', pin: 6, driver: 'rpi', reverse: false },
+    { name: 'O2', pin: 12, driver: 'rpi', reverse: false }
+  ]) {
+    outlets.push(await createOutlet(api, outlet))
+  }
+
+  const equipment = []
+  equipment.push(await createEquipment(api, { name: 'Return', outlet: outlets[0].id }))
+  equipment.push(await createEquipment(api, { name: 'Light', outlet: outlets[1].id }))
+
+  return {
+    drivers: {
+      pca9685
+    },
+    outlets,
+    equipment
+  }
+}
+
+async function seedDashboard(api) {
+  const seeded = await seedConfiguration(api)
+  await updateDashboard(api, {
+    row: 1,
+    column: 2,
+    width: 500,
+    height: 300,
+    grid_details: [[
+      { type: 'equipment_ctrlpanel', id: 'current' },
+      { type: 'health', id: 'current' }
+    ]]
+  })
+  return seeded
+}
+
+module.exports = {
+  createSmokeApi,
+  resetSmokeState,
+  seedConfiguration,
+  seedDashboard
+}

--- a/front-end/e2e/fixtures/authFile.js
+++ b/front-end/e2e/fixtures/authFile.js
@@ -1,0 +1,9 @@
+const path = require('path')
+
+const authDir = path.join(__dirname, '..', '.auth')
+const authFile = path.join(authDir, 'user.json')
+
+module.exports = {
+  authDir,
+  authFile
+}

--- a/front-end/e2e/pages/loginPage.js
+++ b/front-end/e2e/pages/loginPage.js
@@ -1,0 +1,25 @@
+const { expect } = require('@playwright/test')
+
+class LoginPage {
+  constructor(page) {
+    this.page = page
+    this.user = page.getByTestId('smoke-sign-in-user')
+    this.password = page.getByTestId('smoke-sign-in-pass')
+    this.submit = page.getByTestId('smoke-sign-in-submit')
+  }
+
+  async goto() {
+    await this.page.goto('/')
+  }
+
+  async login(user = 'reef-pi', password = 'reef-pi') {
+    await this.user.fill(user)
+    await this.password.fill(password)
+    await this.submit.click()
+    await expect(this.page.getByTestId('smoke-shell-root')).toBeVisible()
+  }
+}
+
+module.exports = {
+  LoginPage
+}

--- a/front-end/e2e/pages/navBar.js
+++ b/front-end/e2e/pages/navBar.js
@@ -1,0 +1,26 @@
+const { expect } = require('@playwright/test')
+
+class NavBar {
+  constructor(page) {
+    this.page = page
+    this.root = page.getByTestId('smoke-nav')
+  }
+
+  tab(name) {
+    return this.page.getByTestId(`smoke-tab-${name}`)
+  }
+
+  async expectShell() {
+    await expect(this.page.getByTestId('smoke-shell-root')).toBeVisible()
+    await expect(this.page.getByTestId('smoke-brand')).toBeVisible()
+    await expect(this.tab('dashboard')).toBeVisible()
+  }
+
+  async open(name) {
+    await this.tab(name).click()
+  }
+}
+
+module.exports = {
+  NavBar
+}

--- a/front-end/e2e/specs/auth-and-shell.spec.js
+++ b/front-end/e2e/specs/auth-and-shell.spec.js
@@ -1,0 +1,18 @@
+const { test, expect } = require('@playwright/test')
+const { LoginPage } = require('../pages/loginPage')
+const { NavBar } = require('../pages/navBar')
+
+test.use({ storageState: { cookies: [], origins: [] } })
+
+test('sign in loads the shell and enabled tabs', async ({ page }) => {
+  const loginPage = new LoginPage(page)
+  const navBar = new NavBar(page)
+
+  await loginPage.goto()
+  await loginPage.login()
+  await navBar.expectShell()
+
+  await expect(navBar.tab('equipment')).toBeVisible()
+  await expect(navBar.tab('configuration')).toBeVisible()
+  await expect(page.getByText('Something went wrong')).toHaveCount(0)
+})

--- a/front-end/e2e/specs/dashboard-and-responsive.spec.js
+++ b/front-end/e2e/specs/dashboard-and-responsive.spec.js
@@ -1,0 +1,43 @@
+const { test, expect } = require('@playwright/test')
+const { createSmokeApi, seedDashboard } = require('../fixtures/apiSeed')
+const { NavBar } = require('../pages/navBar')
+
+test('seeded dashboard survives reload', async ({ page, baseURL }) => {
+  const api = await createSmokeApi(baseURL)
+  const navBar = new NavBar(page)
+
+  try {
+    await seedDashboard(api)
+  } finally {
+    await api.dispose()
+  }
+
+  await page.goto('/')
+  await navBar.expectShell()
+  await expect(page.locator('body')).toContainText('Return')
+
+  await page.reload()
+  await expect(page.locator('body')).toContainText('Return')
+  await expect(page.getByTestId('smoke-dashboard-configure')).toBeVisible()
+})
+
+test.describe('mobile shell', () => {
+  test.use({ viewport: { width: 390, height: 844 } })
+
+  test('keeps the navbar usable', async ({ page, baseURL }) => {
+    const api = await createSmokeApi(baseURL)
+
+    try {
+      await seedDashboard(api)
+    } finally {
+      await api.dispose()
+    }
+
+    await page.goto('/')
+    await expect(page.getByTestId('smoke-shell-root')).toBeVisible()
+    await expect(page.getByTestId('smoke-brand')).toBeVisible()
+    await expect(page.getByTestId('smoke-current-tab')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Toggle navigation' })).toBeVisible()
+    await expect(page.getByTestId('smoke-dashboard-configure')).toBeVisible()
+  })
+})

--- a/front-end/e2e/specs/seeded-configuration.spec.js
+++ b/front-end/e2e/specs/seeded-configuration.spec.js
@@ -1,0 +1,31 @@
+const { test, expect } = require('@playwright/test')
+const { createSmokeApi, seedConfiguration } = require('../fixtures/apiSeed')
+const { NavBar } = require('../pages/navBar')
+
+test('seeded configuration entities render in the UI', async ({ page, baseURL }) => {
+  const api = await createSmokeApi(baseURL)
+  const navBar = new NavBar(page)
+
+  try {
+    await seedConfiguration(api)
+  } finally {
+    await api.dispose()
+  }
+
+  await page.goto('/')
+  await navBar.expectShell()
+  await navBar.open('configuration')
+
+  await page.locator('#config-drivers').click()
+  await expect(page.locator('body')).toContainText('pca9685')
+  await expect(page.locator('body')).toContainText('ph')
+  await expect(page.locator('body')).toContainText('hs103')
+
+  await page.locator('#config-connectors').click()
+  await expect(page.locator('body')).toContainText('O1')
+  await expect(page.locator('body')).toContainText('O2')
+
+  await navBar.open('equipment')
+  await expect(page.locator('body')).toContainText('Return')
+  await expect(page.locator('body')).toContainText('Light')
+})

--- a/front-end/test/README.md
+++ b/front-end/test/README.md
@@ -5,6 +5,7 @@
 - Purpose: verify the app shell, login flow, and a small set of end-to-end subsystem paths without trying to exhaustively validate every form combination.
 - Current structure: `front-end/test/smoke.js` groups the suite into multiple TestCafe tests and reuses helper modules for each subsystem flow.
 - Runtime helpers: shared login, shell readiness, fatal-error assertions, and API-backed smoke reset helpers live in `front-end/test/runtime.js`.
+- Parallel migration track: `front-end/e2e/` contains the first Playwright smoke slice. It currently covers auth, seeded configuration visibility, dashboard persistence, and a mobile-shell sanity check without replacing the TestCafe gate yet.
 
 ## Smoke local run
 
@@ -36,3 +37,6 @@ Each grouped smoke test clears the prior TestCafe-created data through the authe
 - `yarn jest --runInBand`
 - `yarn jest front-end/src/configuration/capabilities.test.js --runInBand`
 - `yarn jest-update-snapshot`
+- `npx playwright install chromium`
+- `make go && make ui`
+- `yarn pw-smoke`

--- a/package.json
+++ b/package.json
@@ -85,7 +85,9 @@
     "test": "cross-env NODE_ENV=testing jest --all --updateSnapshot --no-cache --coverage --env=jsdom",
     "sass-lint": "sass-lint 'front-end/assets/sass/**/*.scss' --verbose",
     "smoke": "testcafe chrome front-end/test/* --skip-js-errors",
-    "ci-smoke": "testcafe chrome:headless front-end/test/* --skip-js-errors"
+    "ci-smoke": "testcafe chrome:headless front-end/test/* --skip-js-errors",
+    "pw-smoke": "playwright test",
+    "pw-smoke:headed": "playwright test --headed"
   },
   "repository": {
     "type": "git",
@@ -144,5 +146,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.59.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,41 @@
+const { defineConfig } = require('@playwright/test')
+
+module.exports = defineConfig({
+  testDir: './front-end/e2e',
+  fullyParallel: false,
+  workers: 1,
+  timeout: 60000,
+  expect: {
+    timeout: 10000
+  },
+  reporter: process.env.CI
+    ? [['list'], ['html', { open: 'never' }]]
+    : [['list']],
+  outputDir: 'test-results/playwright',
+  use: {
+    baseURL: 'http://127.0.0.1:8080',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure'
+  },
+  webServer: {
+    command: 'rtk make start-dev',
+    url: 'http://127.0.0.1:8080/',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000
+  },
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /.*\.setup\.js/
+    },
+    {
+      name: 'chromium',
+      dependencies: ['setup'],
+      use: {
+        browserName: 'chromium',
+        storageState: 'front-end/e2e/.auth/user.json'
+      }
+    }
+  ]
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2853,6 +2853,13 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.37.0.tgz#aa2b4fa0b910b66a050c5ddfcac1d262e91a321a"
   integrity sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA==
 
+"@playwright/test@^1.59.1":
+  version "1.59.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.59.1.tgz#5c4d38eac84a61527af466602ae20277685a02d6"
+  integrity sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==
+  dependencies:
+    playwright "1.59.1"
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -7739,7 +7746,7 @@ fscreen@^1.0.1:
   resolved "https://registry.yarnpkg.com/fscreen/-/fscreen-1.2.0.tgz#1a8c88e06bc16a07b473ad96196fb06d6657f59e"
   integrity sha512-hlq4+BU0hlPmwsFjwGGzZ+OZ9N/wq9Ljg/sq3pX+2CD7hrJsX9tJgWWK/wiNTFM212CLHWhicOoqwXyZGGetJg==
 
-fsevents@^2.3.2, fsevents@~2.3.2:
+fsevents@2.3.2, fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -11595,6 +11602,20 @@ pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
+
+playwright-core@1.59.1:
+  version "1.59.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.59.1.tgz#d8a2b28bcb8f2bd08ef3df93b02ae83c813244b2"
+  integrity sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==
+
+playwright@1.59.1:
+  version "1.59.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.59.1.tgz#f7b0ca61637ae25264cec370df671bbe1f368a4a"
+  integrity sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==
+  dependencies:
+    playwright-core "1.59.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 pluralize@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## Summary
- add a Playwright smoke test harness alongside the existing TestCafe suite
- seed smoke configuration and dashboard state through authenticated API helpers
- add a dedicated GitHub Actions workflow for Playwright smoke coverage and artifacts

## Validation
- `rtk make go`
- `rtk make ui`
- `rtk yarn pw-smoke`

## Review Notes
- This branch is intended to stack on #2582 (`codex/smoke-api-reset`). GitHub is still rejecting stacked PR creation for these codex branches, so this draft targets `main` and should be reviewed after or together with #2582.
- This is the Playwright bootstrap slice from the smoke roadmap tracked in #2580.