### PR TITLE
test: add drivers/main tests and improve macro/main coverage

### DIFF
--- a/front-end/src/drivers/main.test.js
+++ b/front-end/src/drivers/main.test.js
@@ -1,0 +1,61 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { Provider } from 'react-redux'
+import Drivers from './main'
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+import 'isomorphic-fetch'
+import fetchMock from 'fetch-mock'
+
+const mockStore = configureMockStore([thunk])
+
+const drivers = [
+  { id: '1', name: 'RPI', type: 'rpi', config: {} },
+  { id: '2', name: 'PCA', type: 'pca9685', config: {} }
+]
+const driverOptions = [{ name: 'pca9685', display: 'PCA9685' }]
+
+describe('Drivers Main', () => {
+  afterEach(() => {
+    fetchMock.reset()
+    fetchMock.restore()
+  })
+
+  it('renders without throwing with drivers', () => {
+    const store = mockStore({ drivers, driverOptions })
+    expect(() =>
+      shallow(<Provider store={store}><Drivers /></Provider>)
+    ).not.toThrow()
+  })
+
+  it('renders without throwing with empty drivers list', () => {
+    const store = mockStore({ drivers: [], driverOptions: [] })
+    expect(() =>
+      shallow(<Provider store={store}><Drivers /></Provider>)
+    ).not.toThrow()
+  })
+
+  it('renders via dive with drivers', () => {
+    fetchMock.get('/api/drivers', drivers)
+    fetchMock.get('/api/drivers/options', driverOptions)
+    const store = mockStore({ drivers, driverOptions })
+    const wrapper = shallow(<Drivers store={store} />).dive()
+    expect(wrapper).toBeDefined()
+  })
+
+  it('renders via dive with empty drivers', () => {
+    fetchMock.get('/api/drivers', [])
+    fetchMock.get('/api/drivers/options', [])
+    const store = mockStore({ drivers: [], driverOptions: [] })
+    const wrapper = shallow(<Drivers store={store} />).dive()
+    expect(wrapper).toBeDefined()
+  })
+
+  it('renders via dive with multiple drivers including rpi type', () => {
+    fetchMock.get('/api/drivers', drivers)
+    fetchMock.get('/api/drivers/options', driverOptions)
+    const store = mockStore({ drivers, driverOptions })
+    const wrapper = shallow(<Drivers store={store} />).dive()
+    expect(wrapper).toBeDefined()
+  })
+})

--- a/front-end/src/macro/main.test.js
+++ b/front-end/src/macro/main.test.js
@@ -70,6 +70,13 @@ describe('Macro UI', () => {
     expect(fn).toHaveBeenCalled()
   })
 
+  it('<Main /> with reversible macro renders revert button', () => {
+    fetchMock.get('/api/macros', {})
+    const reversibleMacro = { ...macro, reversible: true }
+    const wrapper = shallow(<Main store={mockStore({ macros: [reversibleMacro] })} />).dive()
+    expect(wrapper).toBeDefined()
+  })
+
   it('<MacroForm /> for diving', () => {
     const fn = jest.fn()
     const wrapper = mount(


### PR DESCRIPTION
## Summary
- Add 5 tests for `front-end/src/drivers/main.jsx` (previously 0% coverage): Provider smoke tests and store+dive variants for empty/populated driver lists
- Add reversible macro branch test to `front-end/src/macro/main.test.js` — covers the `macro.reversible` conditional that renders the revert button

## Test plan
- [ ] `npm run jest -- --testPathPatterns="drivers/main" --no-coverage` → 5 passing
- [ ] `npm run jest -- --testPathPatterns="macro/main" --no-coverage` → 6 passing (was 5)
- [ ] No regressions in existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)