### PR TITLE
fix: include DS1820 (10- prefix) in temperature sensor discovery (fixes #1980)

### DIFF
--- a/controller/modules/temperature/api.go
+++ b/controller/modules/temperature/api.go
@@ -14,6 +14,7 @@ import (
 var (
 	mockSensors = []string{
 		"/sys/bus/w1/devices/28-devmodeenable",
+		"/sys/bus/w1/devices/10-devmodeenable",
 	}
 )
 
@@ -236,11 +237,15 @@ func (t *Controller) sensors(w http.ResponseWriter, r *http.Request) {
 	fn := func(id string) (interface{}, error) {
 		fs := mockSensors
 		if !t.devMode {
-			files, err := filepath.Glob("/sys/bus/w1/devices/28-*")
+			files28, err := filepath.Glob("/sys/bus/w1/devices/28-*")
 			if err != nil {
 				return nil, err
 			}
-			fs = files
+			files10, err := filepath.Glob("/sys/bus/w1/devices/10-*")
+			if err != nil {
+				return nil, err
+			}
+			fs = append(files28, files10...)
 		}
 		sensors := []string{}
 		for _, f := range fs {


### PR DESCRIPTION
## Summary

- The `/api/tcs/sensors` endpoint used `filepath.Glob("/sys/bus/w1/devices/28-*")` which only discovers DS18B20 sensors
- DS1820 (non-B) sensors enumerate under the `10-` prefix in `/sys/bus/w1/devices/` and were silently omitted from the list
- Now scans both `28-*` and `10-*` prefixes and merges the results
- Added a `10-devmodeenable` entry to `mockSensors` for dev-mode test coverage

## Test plan

- [x] `go test ./controller/modules/temperature/...` passes

Closes #1980
🤖 Generated with [Claude Code](https://claude.com/claude-code)