### PR TITLE
test: add solar profile coverage (new SolarProfile component)

### DIFF
--- a/front-end/src/lighting/light_schema.test.js
+++ b/front-end/src/lighting/light_schema.test.js
@@ -62,6 +62,16 @@ describe('LightSchema', () => {
     return expect(LightSchema.isValid(validLight(ch))).resolves.toBe(false)
   })
 
+  it('validates a solar profile', () => {
+    const ch = validChannel('solar', { latitude: 37.7, longitude: -122.4 })
+    return expect(LightSchema.isValid(validLight(ch))).resolves.toBe(true)
+  })
+
+  it('rejects solar profile with latitude out of range', () => {
+    const ch = validChannel('solar', { latitude: 91, longitude: 0 })
+    return expect(LightSchema.isValid(validLight(ch))).resolves.toBe(false)
+  })
+
   it('validates a lightning profile', () => {
     const ch = validChannel('lightning', {
       start: '08:00:00',

--- a/front-end/src/lighting/profile.test.js
+++ b/front-end/src/lighting/profile.test.js
@@ -74,6 +74,13 @@ describe('Profile', () => {
     expect(wrapper).toBeDefined()
   })
 
+  it('renders solar profile', () => {
+    const wrapper = shallow(
+      <Profile {...baseProps} type='solar' value={{ latitude: 37.7, longitude: -122.4 }} />
+    )
+    expect(wrapper).toBeDefined()
+  })
+
   it('renders unknown profile type with fallback span', () => {
     const wrapper = shallow(
       <Profile {...baseProps} type='unknown_type' value={{}} />

--- a/front-end/src/lighting/solar_profile.test.js
+++ b/front-end/src/lighting/solar_profile.test.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import SolarProfile from './solar_profile'
+
+const baseProps = {
+  name: 'profile',
+  config: { latitude: 37.7, longitude: -122.4 },
+  readOnly: false,
+  onChangeHandler: jest.fn(),
+  touched: {},
+  errors: {}
+}
+
+describe('SolarProfile', () => {
+  it('renders without throwing', () => {
+    const wrapper = shallow(<SolarProfile {...baseProps} />)
+    expect(wrapper).toBeDefined()
+  })
+
+  it('renders in readOnly mode', () => {
+    const wrapper = shallow(<SolarProfile {...baseProps} readOnly />)
+    expect(wrapper).toBeDefined()
+  })
+
+  it('renders with validation errors', () => {
+    const wrapper = shallow(
+      <SolarProfile
+        {...baseProps}
+        errors={{ 'profile.latitude': 'required' }}
+        touched={{ 'profile.latitude': true }}
+      />
+    )
+    expect(wrapper).toBeDefined()
+  })
+
+  it('renders with no config', () => {
+    const wrapper = shallow(<SolarProfile {...baseProps} config={undefined} />)
+    expect(wrapper).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary
The `solar_profile.jsx` component was added in the same merge that introduced the solar PWM profile feature. This PR adds test coverage before it drifts.

- **`solar_profile.test.js`** (new): 4 tests — renders, readOnly, validation errors, no config
- **`profile.test.js`**: add `solar` case to cover the new switch branch in `Profile`
- **`light_schema.test.js`**: 2 new tests for `solarSchema` — valid lat/long accepts, lat > 90 rejects

## Test plan
- [ ] `npm run jest -- --testPathPatterns="lighting" --no-coverage` → 88 passing, 9 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)