### PR TITLE
feat: per-equipment boot delay to stagger startup (fixes #2288)

### DIFF
--- a/controller/modules/equipment/controller.go
+++ b/controller/modules/equipment/controller.go
@@ -3,6 +3,7 @@ package equipment
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/reef-pi/reef-pi/controller"
 	"github.com/reef-pi/reef-pi/controller/device_manager/connectors"
@@ -43,6 +44,10 @@ func (c *Controller) Start() {
 		}
 		if err := c.updateOutlet(eq); err != nil {
 			log.Println("ERROR: equipment subsystem: Failed to sync equipment", eq.Name, ". Error:", err)
+		}
+		if !eq.StayOffOnBoot && eq.On && eq.BootDelay > 0 {
+			log.Printf("INFO: equipment subsystem: waiting %d second(s) after powering on %s\n", eq.BootDelay, eq.Name)
+			time.Sleep(time.Duration(eq.BootDelay) * time.Second)
 		}
 	}
 	log.Println("INFO: equipment subsystem: Finished syncing all equipment")

--- a/controller/modules/equipment/equipment.go
+++ b/controller/modules/equipment/equipment.go
@@ -17,6 +17,7 @@ type Equipment struct {
 	Outlet        string `json:"outlet"`
 	On            bool   `json:"on"`
 	StayOffOnBoot bool   `json:"stay_off_on_boot"`
+	BootDelay     int    `json:"boot_delay"` // seconds to wait after powering on during boot
 }
 
 func (c *Controller) Get(id string) (Equipment, error) {

--- a/front-end/assets/translations/de.csv
+++ b/front-end/assets/translations/de.csv
@@ -212,6 +212,7 @@ doser:volume_ml,
 doser:vpr,
 doser:warn_delete,Wollen Sie die Dosierpumpe {{name}} wirklich löschen?
 doser:warn_reset,Wollen Sie den Verlauf von {{name}} wirklich löschen?
+equipment:boot_delay,
 equipment:chart:barchart,Geräte (Balken)
 equipment:chart:ctrlpanel,Geräte (Schalter)
 equipment:sort,Sort

--- a/front-end/assets/translations/en.csv
+++ b/front-end/assets/translations/en.csv
@@ -212,6 +212,7 @@ doser:volume_ml,Volume (mL per dose)
 doser:vpr,Volume Per Rotation
 doser:warn_delete,This action will delete doser {{name}}
 doser:warn_reset,This action will reset usage data for doser {{name}}
+equipment:boot_delay,Boot Delay (seconds)
 equipment:chart:barchart,Equipment(Bar Chart)
 equipment:chart:ctrlpanel,Equipment(Switch Panel)
 equipment:sort,Sort

--- a/front-end/assets/translations/es.csv
+++ b/front-end/assets/translations/es.csv
@@ -212,6 +212,7 @@ doser:volume_ml,
 doser:vpr,
 doser:warn_delete,
 doser:warn_reset,
+equipment:boot_delay,
 equipment:chart:barchart,Equipo(Gráfica de Barras)
 equipment:chart:ctrlpanel,Equipo(Panel de Interruptores)
 equipment:sort,Sort

--- a/front-end/assets/translations/fa.csv
+++ b/front-end/assets/translations/fa.csv
@@ -212,6 +212,7 @@ doser:volume_ml,
 doser:vpr,
 doser:warn_delete,
 doser:warn_reset,
+equipment:boot_delay,
 equipment:chart:barchart,
 equipment:chart:ctrlpanel,
 equipment:sort,Sort

--- a/front-end/assets/translations/fr.csv
+++ b/front-end/assets/translations/fr.csv
@@ -212,6 +212,7 @@ doser:volume_ml,
 doser:vpr,
 doser:warn_delete,
 doser:warn_reset,
+equipment:boot_delay,
 equipment:chart:barchart,
 equipment:chart:ctrlpanel,
 equipment:sort,Sort

--- a/front-end/assets/translations/hi.csv
+++ b/front-end/assets/translations/hi.csv
@@ -212,6 +212,7 @@ doser:volume_ml,
 doser:vpr,
 doser:warn_delete,
 doser:warn_reset,
+equipment:boot_delay,
 equipment:chart:barchart,
 equipment:chart:ctrlpanel,
 equipment:sort,Sort

--- a/front-end/assets/translations/it.csv
+++ b/front-end/assets/translations/it.csv
@@ -212,6 +212,7 @@ doser:volume_ml,
 doser:vpr,
 doser:warn_delete,
 doser:warn_reset,
+equipment:boot_delay,
 equipment:chart:barchart,
 equipment:chart:ctrlpanel,
 equipment:sort,Sort

--- a/front-end/assets/translations/nl.csv
+++ b/front-end/assets/translations/nl.csv
@@ -212,6 +212,7 @@ doser:volume_ml,
 doser:vpr,
 doser:warn_delete,
 doser:warn_reset,
+equipment:boot_delay,
 equipment:chart:barchart,
 equipment:chart:ctrlpanel,
 equipment:sort,Sort

--- a/front-end/assets/translations/pt-BR.csv
+++ b/front-end/assets/translations/pt-BR.csv
@@ -212,6 +212,7 @@ doser:volume_ml,
 doser:vpr,vpr
 doser:warn_delete,Aviso de exclusão
 doser:warn_reset,Aviso de reinicialização
+equipment:boot_delay,
 equipment:chart:barchart,Gráfico
 equipment:chart:ctrlpanel,Painel de Controle
 equipment:sort,Ordenar

--- a/front-end/assets/translations/pt.csv
+++ b/front-end/assets/translations/pt.csv
@@ -212,6 +212,7 @@ doser:volume_ml,
 doser:vpr,vpr
 doser:warn_delete,Aviso Apagar
 doser:warn_reset,Aviso Reninciar
+equipment:boot_delay,
 equipment:chart:barchart,Grafico
 equipment:chart:ctrlpanel,Painel de Control
 equipment:sort,Sort

--- a/front-end/assets/translations/zh.csv
+++ b/front-end/assets/translations/zh.csv
@@ -212,6 +212,7 @@ doser:volume_ml,
 doser:vpr,
 doser:warn_delete,
 doser:warn_reset,
+equipment:boot_delay,
 equipment:chart:barchart,
 equipment:chart:ctrlpanel,
 equipment:sort,Sort

--- a/front-end/src/equipment/edit_equipment.jsx
+++ b/front-end/src/equipment/edit_equipment.jsx
@@ -97,6 +97,19 @@ const EditEquipment = ({
           <ErrorFor errors={errors} touched={touched} name='stay_off_on_boot' />
         </div>
         <div className='p-2 mr-auto'>
+          <label className='mr-2'>{i18next.t('equipment:boot_delay')}</label>
+          <input
+            type='number'
+            min='0'
+            name='boot_delay'
+            value={values.boot_delay}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            className={classNames('form-control', { 'is-invalid': ShowError('boot_delay', touched, errors) })}
+          />
+          <ErrorFor errors={errors} touched={touched} name='boot_delay' />
+        </div>
+        <div className='p-2 mr-auto'>
           <button type='submit' id='add_equipment' data-testid='smoke-equipment-submit'>
             {FaSave()}
           </button>

--- a/front-end/src/equipment/equipment.jsx
+++ b/front-end/src/equipment/equipment.jsx
@@ -37,7 +37,8 @@ export default class Equipment extends React.Component {
       name: values.name,
       outlet: values.outlet,
       on: values.on,
-      stay_off_on_boot: values.stay_off_on_boot
+      stay_off_on_boot: values.stay_off_on_boot,
+      boot_delay: parseInt(values.boot_delay, 10) || 0
     }
 
     this.props.update(id, payload).then(() => {

--- a/front-end/src/equipment/equipment.test.js
+++ b/front-end/src/equipment/equipment.test.js
@@ -60,7 +60,8 @@ describe('Equipment ui', () => {
       name: 'Foo',
       on: false,
       outlet: '1',
-      stay_off_on_boot: undefined
+      stay_off_on_boot: undefined,
+      boot_delay: 0
     })
   })
 

--- a/front-end/src/equipment/equipment_form.jsx
+++ b/front-end/src/equipment/equipment_form.jsx
@@ -10,6 +10,7 @@ const EditEquipmentForm = withFormik({
     id: (props.equipment && props.equipment.id) || '',
     on: (props.equipment && props.equipment.on) || false,
     stay_off_on_boot: (props.equipment && props.equipment.stay_off_on_boot) || false,
+    boot_delay: (props.equipment && props.equipment.boot_delay) || 0,
     outlets: props.outlets,
     remove: props.remove
   }),

--- a/front-end/src/equipment/equipment_schema.jsx
+++ b/front-end/src/equipment/equipment_schema.jsx
@@ -6,7 +6,10 @@ const EquipmentSchema = Yup.object().shape({
     .required(i18n.t('validation:name_required')),
   outlet: Yup.string()
     .required(i18n.t('validation:selection_required')),
-  stay_off_on_boot: Yup.bool().default(false)
+  stay_off_on_boot: Yup.bool().default(false),
+  boot_delay: Yup.number()
+    .min(0, i18n.t('validation:integer_min_required'))
+    .default(0)
 })
 
 export default EquipmentSchema

--- a/front-end/src/equipment/utils.js
+++ b/front-end/src/equipment/utils.js
@@ -27,6 +27,7 @@ export function buildEquipmentPayload (equipment, updates = {}) {
     on: equipment.on,
     outlet: equipment.outlet,
     stay_off_on_boot: equipment.stay_off_on_boot,
+    boot_delay: equipment.boot_delay || 0,
     ...updates
   }
 }


### PR DESCRIPTION
## Summary

- Adds a `boot_delay` field (integer seconds) to `Equipment`
- During `Start()`, after powering on each equipment item the controller sleeps `boot_delay` seconds before moving to the next — preventing simultaneous inrush current spikes when all devices power on at once after a reboot
- Default `0` → no delay, fully backward compatible
- Delay only applies when the equipment is actually being powered on (`On: true` and not `StayOffOnBoot`)
- Frontend: new "Boot Delay (seconds)" number input in the equipment edit form, validated ≥ 0
- `equipment:boot_delay` i18n key synced across all 11 language files

## Test plan

- [x] `go test ./controller/modules/equipment/...` — all tests pass
- [x] `yarn test --testPathPatterns="equipment"` — 36 tests pass
- [x] `npm run translations:chk` — synchronized

Closes #2288
🤖 Generated with [Claude Code](https://claude.com/claude-code)