### PR TITLE
[codex] Apply React 19 UI cleanup sweep

### DIFF
--- a/front-end/src/ato/chart.jsx
+++ b/front-end/src/ato/chart.jsx
@@ -18,7 +18,7 @@ class chart extends React.Component {
   componentDidMount () {
     this.updateUsage()
     const timer = window.setInterval(this.updateUsage, 10 * 1000)
-    this.setState({ timer: timer })
+    this.setState({ timer })
   }
 
   componentWillUnmount () {
@@ -43,13 +43,13 @@ class chart extends React.Component {
         <ResponsiveContainer height={this.props.height} width='100%'>
           <BarChart data={metrics} barSize={8}>
             <Bar dataKey='pump' fill='#33b5e5' isAnimationActive={false} />
-            <YAxis type="number">
-                <Label
-                    value={i18next.t('sec')}
-                    position="insideLeft"
-                    angle={-90}
-                    style={{ textAnchor: 'middle' }}
-                    />
+            <YAxis type='number'>
+              <Label
+                value={i18next.t('sec')}
+                position='insideLeft'
+                angle={-90}
+                style={{ textAnchor: 'middle' }}
+              />
             </YAxis>
             <XAxis dataKey='ts' type='number' scale='time' domain={['auto', 'auto']} tickFormatter={formatChartTime} />
             <Tooltip />

--- a/front-end/src/camera/config.jsx
+++ b/front-end/src/camera/config.jsx
@@ -31,7 +31,7 @@ export default class Config extends React.Component {
       const config = this.state.config
       config[k] = ev.target.checked
       this.setState({
-        config: config,
+        config,
         updated: true
       })
     }.bind(this))
@@ -42,7 +42,7 @@ export default class Config extends React.Component {
       const config = this.state.config
       config[k] = ev.target.value
       this.setState({
-        config: config,
+        config,
         updated: true
       })
     }.bind(this)

--- a/front-end/src/configuration/capabilities.jsx
+++ b/front-end/src/configuration/capabilities.jsx
@@ -15,7 +15,7 @@ export default class Capabilities extends React.Component {
     return function (ev) {
       const capabilities = this.state.capabilities
       capabilities[cap] = ev.target.checked
-      this.setState({ capabilities: capabilities })
+      this.setState({ capabilities })
       this.props.update(this.state.capabilities)
     }.bind(this)
   }

--- a/front-end/src/configuration/main.jsx
+++ b/front-end/src/configuration/main.jsx
@@ -28,11 +28,11 @@ const configRouteElements = configRoutes.map(route => (
 class Configuration extends React.Component {
   render () {
     const panels = configRoutes.map(route => (
-        <li key={'conf-tabs' + route.key}>
-          <NavLink id={'config-' + route.key} className='nav-link' to={route.path || ''}>
-            {route.label}
-          </NavLink>
-        </li>
+      <li key={'conf-tabs' + route.key}>
+        <NavLink id={'config-' + route.key} className='nav-link' to={route.path || ''}>
+          {route.label}
+        </NavLink>
+      </li>
     ))
 
     return (

--- a/front-end/src/configuration/settings.jsx
+++ b/front-end/src/configuration/settings.jsx
@@ -84,7 +84,7 @@ class settings extends React.Component {
     if (notify !== undefined) {
       const settings = this.state.settings
       settings.health_check = notify
-      this.setState({ settings: settings, updated: true })
+      this.setState({ settings, updated: true })
     }
     return this.state
   }
@@ -94,7 +94,7 @@ class settings extends React.Component {
       const settings = this.state.settings
       settings[key] = ev.target.checked
       this.setState({
-        settings: settings,
+        settings,
         updated: true
       })
     }.bind(this)
@@ -104,7 +104,7 @@ class settings extends React.Component {
     const settings = this.state.settings
     settings.address = ev.target.value
     this.setState({
-      settings: settings,
+      settings,
       updated: true
     })
   }
@@ -134,7 +134,7 @@ class settings extends React.Component {
 
     settings.https = value
     this.setState({
-      settings: settings,
+      settings,
       updated: true
     })
   }
@@ -158,7 +158,7 @@ class settings extends React.Component {
     const settings = this.state.settings
     settings.capabilities = capabilities
     this.setState({
-      settings: settings,
+      settings,
       updated: true
     })
   }
@@ -167,7 +167,7 @@ class settings extends React.Component {
     let settings = this.state.settings
     if (SettingsSchema.isValidSync(settings)) {
       settings = SettingsSchema.cast(settings)
-      this.setState({ updated: false, settings: settings })
+      this.setState({ updated: false, settings })
       this.props.updateSettings(settings)
       showUpdateSuccessful()
       return
@@ -186,7 +186,7 @@ class settings extends React.Component {
       const settings = this.state.settings
       settings[label] = ev.target.value
       this.setState({
-        settings: settings,
+        settings,
         updated: true
       })
     }.bind(this)

--- a/front-end/src/connectors/inlet.jsx
+++ b/front-end/src/connectors/inlet.jsx
@@ -29,7 +29,7 @@ export default class Inlet extends React.Component {
   handleDriverChange (e) {
     const driver = this.props.drivers.filter(d => d.id === e.target.value)[0] || {}
     this.setState({
-      driver: driver
+      driver
     })
   }
 

--- a/front-end/src/connectors/inlet_selector.jsx
+++ b/front-end/src/connectors/inlet_selector.jsx
@@ -13,7 +13,7 @@ class inletSelector extends React.Component {
       }
     })
     this.state = {
-      inlet: inlet
+      inlet
     }
     this.inlets = this.inlets.bind(this)
     this.set = this.set.bind(this)

--- a/front-end/src/connectors/inlets.jsx
+++ b/front-end/src/connectors/inlets.jsx
@@ -47,7 +47,7 @@ class inlets extends React.Component {
   handleDriverChange (e) {
     const driver = this.props.drivers.filter(d => d.id === e.target.value)[0] || {}
     this.setState({
-      driver: driver
+      driver
     })
   }
 

--- a/front-end/src/connectors/jack.jsx
+++ b/front-end/src/connectors/jack.jsx
@@ -64,7 +64,7 @@ export default class Jack extends React.Component {
     }
     const payload = {
       name: this.state.name,
-      pins: pins,
+      pins,
       driver: this.state.driver,
       reverse: this.state.reverse
     }

--- a/front-end/src/connectors/jacks.jsx
+++ b/front-end/src/connectors/jacks.jsx
@@ -90,7 +90,7 @@ class jacks extends React.Component {
     }
     const payload = {
       name: this.state.JackName,
-      pins: pins,
+      pins,
       driver: this.state.JackDriver,
       reverse: this.state.JackReverse
     }

--- a/front-end/src/connectors/pin.jsx
+++ b/front-end/src/connectors/pin.jsx
@@ -14,7 +14,7 @@ export default class Pin extends React.Component {
   }
 
   options () {
-    if (this.props.driver === undefined ) {
+    if (this.props.driver === undefined) {
       return
     }
     if (this.props.driver.pinmap === undefined || this.props.driver.pinmap === null) {

--- a/front-end/src/dashboard/config.jsx
+++ b/front-end/src/dashboard/config.jsx
@@ -103,7 +103,7 @@ class config extends React.Component {
   }
 
   render () {
-    let updateButtonClass = 'btn btn-outline-success col-12'
+    const updateButtonClass = 'btn btn-outline-success col-12'
     if (this.state.config.grid_details === undefined) {
       return <div />
     }

--- a/front-end/src/dashboard/grid.jsx
+++ b/front-end/src/dashboard/grid.jsx
@@ -7,13 +7,12 @@ export const numColsToColSize = (numCols) => {
   /*
   Given a number of columns, returns the maximum bootstrap column size in order
   to fit all columns on one row
-  
+
   i.e. 1->12, 2->6, 3->4, 4->3, 5->2, 6->2, 7->1, 8->1, 9->1, 10->1, 11->1, 12->1
   */
-  let colSize = 1;
-  if (numCols <= 12)
-    colSize = Math.floor(12 / numCols);
-  return colSize;
+  let colSize = 1
+  if (numCols <= 12) { colSize = Math.floor(12 / numCols) }
+  return colSize
 }
 
 // props: rows, columns, hook, cells, tcs, atos
@@ -45,7 +44,7 @@ export default class Grid extends React.Component {
       id = cell.id
     }
 
-    let colSize = numColsToColSize(this.props.columns);
+    const colSize = numColsToColSize(this.props.columns)
 
     return (
       <div className={'col-xs-12 col-md-' + colSize + ' grid-cell-container'} key={'chart-type-' + i + '-' + j}>
@@ -79,7 +78,7 @@ export default class Grid extends React.Component {
       cell.id = id
       row[j] = cell
       cells[i] = row
-      this.setState({ cells: cells })
+      this.setState({ cells })
       this.props.hook(cells)
     }.bind(this))
   }
@@ -92,7 +91,7 @@ export default class Grid extends React.Component {
       cell.type = type
       row[j] = cell
       cells[i] = row
-      this.setState({ cells: cells })
+      this.setState({ cells })
       this.props.hook(cells)
     }.bind(this))
   }
@@ -144,7 +143,7 @@ export default class Grid extends React.Component {
       }
       rows.push(
         <div className='row grid-row' key={'chart-row-' + i}>
-          <label className='d-block d-md-none'>Row {i+1}</label>
+          <label className='d-block d-md-none'>Row {i + 1}</label>
           {columns}
         </div>
       )

--- a/front-end/src/dashboard/main.jsx
+++ b/front-end/src/dashboard/main.jsx
@@ -44,8 +44,8 @@ class dashboard extends React.Component {
     if (config.grid_details === undefined) {
       return
     }
-    
-    let colSize = numColsToColSize(config.column);
+
+    const colSize = numColsToColSize(config.column)
 
     let i, j
     const rows = []
@@ -212,7 +212,7 @@ class dashboard extends React.Component {
                 {lbl}
               </button>
             </div>
-        </div>
+          </div>
         </div>
       </>
     )

--- a/front-end/src/doser/chart.jsx
+++ b/front-end/src/doser/chart.jsx
@@ -18,7 +18,7 @@ class chart extends React.Component {
   componentDidMount () {
     this.updateUsage()
     const timer = window.setInterval(this.updateUsage, 10 * 1000)
-    this.setState({ timer: timer })
+    this.setState({ timer })
   }
 
   componentWillUnmount () {

--- a/front-end/src/doser/edit_dcpump.jsx
+++ b/front-end/src/doser/edit_dcpump.jsx
@@ -142,16 +142,16 @@ const EditDcPump = ({
               </small>
             </div>
           </div>
-        )
+          )
         : (
           <div className='col-12 col-sm-6 col-md-3'>
             <div className='form-group'>
               <label htmlFor='duration'>{i18n.t('doser:duration')}</label>
               <div className='input-group'>
-              <Field
-                name='duration'
-                data-testid='smoke-doser-duration'
-                readOnly={readOnly}
+                <Field
+                  name='duration'
+                  data-testid='smoke-doser-duration'
+                  readOnly={readOnly}
                   type='number'
                   className={classNames('form-control', {
                     'is-invalid': ShowError('duration', touched, errors)
@@ -167,7 +167,7 @@ const EditDcPump = ({
               </div>
             </div>
           </div>
-        )
+          )
       )}
 
       <div className='col col-sm-6 col-md-3'>

--- a/front-end/src/fatal_error.jsx
+++ b/front-end/src/fatal_error.jsx
@@ -9,8 +9,8 @@ export default class FatalError extends React.Component {
       up: true
     }
   }
-  componentDidMount () {
 
+  componentDidMount () {
     this.timer = setInterval(() => {
       this.checkHealth()
     }, RefreshTime)

--- a/front-end/src/health_chart.jsx
+++ b/front-end/src/health_chart.jsx
@@ -29,7 +29,7 @@ class healthChart extends React.Component {
       return (<div />)
     }
     const healthStats = this.props.health_stats[this.state.trend]
-    if(healthStats){
+    if (healthStats) {
       healthStats.sort((a, b) => {
         return ParseTimestamp(a.time) > ParseTimestamp(b.time) ? 1 : -1
       })

--- a/front-end/src/jack_selector.jsx
+++ b/front-end/src/jack_selector.jsx
@@ -13,7 +13,7 @@ class jackSelector extends React.Component {
       }
     })
     this.state = {
-      jack: jack,
+      jack,
       pin: jack === undefined ? undefined : jack.pins[0]
     }
 

--- a/front-end/src/jack_selector.test.jsx
+++ b/front-end/src/jack_selector.test.jsx
@@ -9,7 +9,6 @@ import 'isomorphic-fetch'
 const mockStore = configureMockStore([thunk])
 
 const jacks = [{ id: '1', name: 'Foo', pins: [1, 2] }]
-
 describe('JackSelector', () => {
   it('renders without throwing with matching jack', () => {
     const store = mockStore({ jacks })

--- a/front-end/src/journal/chart.jsx
+++ b/front-end/src/journal/chart.jsx
@@ -10,7 +10,7 @@ class chart extends React.Component {
     const timer = window.setInterval(() => {
       this.props.fetch(this.props.journal_id)
     }, 10 * 1000)
-    this.setState({ timer: timer })
+    this.setState({ timer })
   }
 
   componentWillUnmount () {

--- a/front-end/src/lighting/auto_profile.jsx
+++ b/front-end/src/lighting/auto_profile.jsx
@@ -13,7 +13,7 @@ export default class AutoProfile extends React.Component {
     if (props.config && props.config.values && Array.isArray(props.config.values)) {
       values = props.config.values
     }
-    this.state = { values: values }
+    this.state = { values }
 
     this.curry = this.curry.bind(this)
     this.handleAddPoint = this.handleAddPoint.bind(this)
@@ -35,9 +35,9 @@ export default class AutoProfile extends React.Component {
     this.props.onChangeHandler({
       start: this.props.config.start,
       end: this.props.config.end,
-      values: values
+      values
     })
-    this.setState({ values: values })
+    this.setState({ values })
   }
 
   handleRemovePoint (x) {
@@ -46,9 +46,9 @@ export default class AutoProfile extends React.Component {
     this.props.onChangeHandler({
       start: this.props.config.start,
       end: this.props.config.end,
-      values: values
+      values
     })
-    this.setState({ values: values })
+    this.setState({ values })
   }
 
   curry (i) {
@@ -62,9 +62,9 @@ export default class AutoProfile extends React.Component {
         this.props.onChangeHandler({
           start: this.props.config.start,
           end: this.props.config.end,
-          values: values
+          values
         })
-        this.setState({ values: values })
+        this.setState({ values })
       }
     }
   }

--- a/front-end/src/lighting/charts/generic.jsx
+++ b/front-end/src/lighting/charts/generic.jsx
@@ -10,7 +10,7 @@ class chart extends React.Component {
   componentDidMount () {
     this.props.fetch(this.props.light_id)
     const timer = window.setInterval(() => { this.props.fetch(this.props.light.id) }, 10 * 1000)
-    this.setState({ timer: timer })
+    this.setState({ timer })
   }
 
   componentWillUnmount () {

--- a/front-end/src/lighting/fixed_profile.jsx
+++ b/front-end/src/lighting/fixed_profile.jsx
@@ -22,11 +22,11 @@ export default class FixedProfile extends React.Component {
       if (isNaN(value)) {
         value = ''
       }
-      this.setState({ value: value })
+      this.setState({ value })
       this.props.onChangeHandler({
         start: this.props.config.start,
         end: this.props.config.end,
-        value: value
+        value
       })
     }
   }

--- a/front-end/src/lighting/main.jsx
+++ b/front-end/src/lighting/main.jsx
@@ -112,7 +112,7 @@ class main extends React.Component {
         max: 100,
         name: 'Channel-' + (idx + 1),
         on: true,
-        pin: pin,
+        pin,
         value: 0,
         profile: {
           type: 'fixed',
@@ -128,7 +128,7 @@ class main extends React.Component {
       name: $('#lightName').val(),
       jack: String(jack.id),
       enable: true,
-      channels: channels
+      channels
     }
 
     this.props.createLight(payload)

--- a/front-end/src/lighting/manual_light.jsx
+++ b/front-end/src/lighting/manual_light.jsx
@@ -13,7 +13,7 @@ export default class ManualLight extends React.Component {
       }
     }
     this.state = {
-      channels: channels
+      channels
     }
 
     this.handleValueChange = this.handleValueChange.bind(this)
@@ -31,7 +31,7 @@ export default class ManualLight extends React.Component {
     if (/^([0-9]{0,2}$)|(100)$|^([0-9]{1,2}.[0-9]+$)/.test(e.target.value)) {
       const channels = Object.assign({}, this.state.channels)
       channels[e.target.name].value = e.target.value
-      this.setState({ channels: channels })
+      this.setState({ channels })
 
       if (isNaN(parseFloat(e.target.value)) === false) {
         this.debouncedChange(e.target.name, parseFloat(e.target.value))

--- a/front-end/src/macro/main.jsx
+++ b/front-end/src/macro/main.jsx
@@ -35,7 +35,7 @@ class main extends React.Component {
     // TODO: [ML] Consider Server Events, Long Polling, or Web Sockets after 2.0
     // Polling for macro status.
     const timer = window.setInterval(this.props.fetch, 10 * 1000)
-    this.setState({ timer: timer })
+    this.setState({ timer })
   }
 
   componentWillUnmount () {

--- a/front-end/src/main_panel.jsx
+++ b/front-end/src/main_panel.jsx
@@ -22,7 +22,6 @@ import i18n from 'utils/i18n'
 import Instances from 'instances/main'
 import Journal from 'journal/main'
 
-
 const routes = [
   { key: 'dashboard', index: true, path: '', element: <Dashboard />, label: i18n.t('capabilities:dashboard') },
   { key: 'equipment', path: '/equipment', element: <Equipment />, label: i18n.t('capabilities:equipment') },
@@ -51,13 +50,12 @@ const routeMatchesLocation = (route, pathname) => {
   return pathname === basePath || pathname.startsWith(basePath + '/')
 }
 
-function CurrentPageHeader() {
+function CurrentPageHeader () {
   const location = useLocation()
   const route = routes.find(r => routeMatchesLocation(r, location.pathname))
   const label = route ? route.label : location.pathname.slice(1)
   return <span>{label}</span>
 }
-
 
 class mainPanel extends React.Component {
   constructor (props) {
@@ -74,7 +72,7 @@ class mainPanel extends React.Component {
       .filter(route => currentCaps[route.key] !== undefined && currentCaps[route.key])
       .map(route => (
         <li className='nav-item' key={'li-tab-' + route.key}>
-          <NavLink to={route.path || ''} id={'tab-' + route.key} data-testid={'smoke-tab-' + route.key} className="nav-link">
+          <NavLink to={route.path || ''} id={'tab-' + route.key} data-testid={'smoke-tab-' + route.key} className='nav-link'>
             {route.label}
           </NavLink>
         </li>
@@ -89,7 +87,7 @@ class mainPanel extends React.Component {
 
     return (
       <BrowserRouter>
-          <div id='content' data-testid='smoke-shell-root'>
+        <div id='content' data-testid='smoke-shell-root'>
           <nav className='navbar navbar-dark navbar-reefpi navbar-expand-lg'>
             <span className='navbar-brand mb-0 h1' data-testid='smoke-brand'>{this.props.info.name}</span>
             <span className='navbar-brand mb-0 h1 navbar-toggler current-tab' data-testid='smoke-current-tab'><CurrentPageHeader /></span>

--- a/front-end/src/notifications/statics.js
+++ b/front-end/src/notifications/statics.js
@@ -1,3 +1,3 @@
 export function setAlert (type, content) {
-  return { type: type, content: content, ts: new Date().getTime() }
+  return { type, content, ts: new Date().getTime() }
 }

--- a/front-end/src/ph/calibration_wizard.jsx
+++ b/front-end/src/ph/calibration_wizard.jsx
@@ -40,7 +40,7 @@ export default class CalibrationWizard extends React.Component {
   handleCalibrate (point, expected) {
     const payload = {
       type: point,
-      expected: expected,
+      expected,
       observed: this.props.currentReading[this.props.probe.id]
     }
 

--- a/front-end/src/ph/chart.jsx
+++ b/front-end/src/ph/chart.jsx
@@ -11,7 +11,7 @@ class chart extends React.Component {
     const timer = window.setInterval(() => {
       this.props.fetchProbeReadings(this.props.probe_id)
     }, 10 * 1000)
-    this.setState({ timer: timer })
+    this.setState({ timer })
   }
 
   componentWillUnmount () {

--- a/front-end/src/ph/control_chart.jsx
+++ b/front-end/src/ph/control_chart.jsx
@@ -12,7 +12,7 @@ class chart extends React.Component {
     const timer = window.setInterval(() => {
       this.props.fetchProbeReadings(this.props.probe_id)
     }, 10 * 1000)
-    this.setState({ timer: timer })
+    this.setState({ timer })
   }
 
   componentWillUnmount () {

--- a/front-end/src/redux/actions/admin.js
+++ b/front-end/src/redux/actions/admin.js
@@ -70,6 +70,6 @@ export const upgrade = (version) => {
     reduxPost({
       url: '/api/admin/upgrade',
       success: upgraded,
-      data: { version: version }
+      data: { version }
     }))
 }

--- a/front-end/src/redux/actions/ato.js
+++ b/front-end/src/redux/actions/ato.js
@@ -32,7 +32,7 @@ export const atoUsageLoaded = (id) => {
   return (s) => {
     return ({
       type: 'ATO_USAGE_LOADED',
-      payload: { data: s, id: id }
+      payload: { data: s, id }
     })
   }
 }

--- a/front-end/src/redux/actions/doser.js
+++ b/front-end/src/redux/actions/doser.js
@@ -84,7 +84,7 @@ export const doserUsageLoaded = (id) => {
   return (s) => {
     return ({
       type: 'DOSER_USAGE_LOADED',
-      payload: { data: s, id: id }
+      payload: { data: s, id }
     })
   }
 }

--- a/front-end/src/redux/actions/journal.js
+++ b/front-end/src/redux/actions/journal.js
@@ -38,7 +38,7 @@ export const journalUsageLoaded = (id) => {
   return (s) => {
     return ({
       type: 'JOURNAL_USAGE_LOADED',
-      payload: { data: s, id: id }
+      payload: { data: s, id }
     })
   }
 }
@@ -85,7 +85,7 @@ export const journalRecorded = (id) => {
   return (s) => {
     return ({
       type: 'JOURNAL_RECORDED',
-      payload: { data: s, id: id }
+      payload: { data: s, id }
     })
   }
 }

--- a/front-end/src/redux/actions/lights.js
+++ b/front-end/src/redux/actions/lights.js
@@ -19,7 +19,7 @@ export const lightLoaded = (id) => {
   return (l) => {
     return ({
       type: 'LIGHT_LOADED',
-      payload: { light: l, id: id }
+      payload: { light: l, id }
     })
   }
 }
@@ -28,7 +28,7 @@ export const lightUsageLoaded = (id) => {
   return (u) => {
     return ({
       type: 'LIGHT_USAGE_LOADED',
-      payload: { usage: u, id: id }
+      payload: { usage: u, id }
     })
   }
 }

--- a/front-end/src/redux/actions/macro.js
+++ b/front-end/src/redux/actions/macro.js
@@ -35,7 +35,7 @@ export const macroUsageLoaded = (id) => {
   return (s) => {
     return ({
       type: 'MACRO_USAGE_LOADED',
-      payload: { data: s, id: id }
+      payload: { data: s, id }
     })
   }
 }

--- a/front-end/src/redux/actions/phprobes.js
+++ b/front-end/src/redux/actions/phprobes.js
@@ -10,7 +10,7 @@ export const probeReadingsLoaded = (id) => {
   return (s) => {
     return ({
       type: 'PH_PROBE_READINGS_LOADED',
-      payload: { readings: s, id: id }
+      payload: { readings: s, id }
     })
   }
 }
@@ -45,7 +45,7 @@ export const probeReadComplete = (id) => {
   return (s) => {
     return ({
       type: 'PH_PROBE_READING_COMPLETE',
-      payload: { reading: s, id: id }
+      payload: { reading: s, id }
     })
   }
 }

--- a/front-end/src/redux/actions/tcs.js
+++ b/front-end/src/redux/actions/tcs.js
@@ -18,7 +18,7 @@ export const tcUsageLoaded = (id) => {
   return (s) => {
     return ({
       type: 'TC_USAGE_LOADED',
-      payload: { id: id, usage: s }
+      payload: { id, usage: s }
     })
   }
 }
@@ -78,7 +78,7 @@ export const tcReadComplete = (id) => {
   return (s) => {
     return ({
       type: 'TC_READING_COMPLETE',
-      payload: { reading: s, id: id }
+      payload: { reading: s, id }
     })
   }
 }

--- a/front-end/src/select_equipment.jsx
+++ b/front-end/src/select_equipment.jsx
@@ -12,7 +12,7 @@ class selectEquipment extends React.Component {
       }
     })
     this.state = {
-      equipment: equipment
+      equipment
     }
     this.equipmentList = this.equipmentList.bind(this)
     this.setEquipment = this.setEquipment.bind(this)
@@ -25,7 +25,7 @@ class selectEquipment extends React.Component {
   equipmentList () {
     const menuItems = [
       <a className='dropdown-item' href='#' key='none' onClick={this.setEquipment('none')}>
-        {'--'}
+        --
       </a>
     ]
     this.props.equipment.forEach((v, k) => {

--- a/front-end/src/sign_in.jsx
+++ b/front-end/src/sign_in.jsx
@@ -82,13 +82,15 @@ export default class SignIn extends React.Component {
             <form id='sign-in-form' data-testid='smoke-sign-in-form'>
               <div className='form'>
                 <h1 className='h3 mb-3 font-weight-normal reef-pi-title'>reef-pi</h1>
-                {this.state.invalidCredentials ? (
-                  <div className='alert alert-danger' role='alert'>
-                    <strong>Oops!</strong> {i18n.t('signin:invalidcredentials')}
-                  </div>
-                ) : (
-                  <div />
-                )}
+                {this.state.invalidCredentials
+                  ? (
+                    <div className='alert alert-danger' role='alert'>
+                      <strong>Oops!</strong> {i18n.t('signin:invalidcredentials')}
+                    </div>
+                    )
+                  : (
+                    <div />
+                    )}
                 <label htmlFor='reef-pi-user' className='sr-only'>
                   {i18n.t('signin:username')}
                 </label>

--- a/front-end/src/telemetry/adafruit_io.jsx
+++ b/front-end/src/telemetry/adafruit_io.jsx
@@ -15,7 +15,7 @@ export default class AdafruitIO extends React.Component {
     return function (ev) {
       const adafruitio = this.state.adafruitio
       adafruitio[label] = ev.target.value
-      this.setState({ adafruitio: adafruitio })
+      this.setState({ adafruitio })
       this.props.update(this.state.adafruitio)
     }.bind(this)
   }
@@ -23,7 +23,7 @@ export default class AdafruitIO extends React.Component {
   handleUpdateEnable (ev) {
     const adafruitio = this.state.adafruitio
     adafruitio.enable = ev.target.checked
-    this.setState({ adafruitio: adafruitio })
+    this.setState({ adafruitio })
     this.props.update(this.state.adafruitio)
   }
 

--- a/front-end/src/telemetry/mqtt.jsx
+++ b/front-end/src/telemetry/mqtt.jsx
@@ -16,7 +16,7 @@ export default class Mqtt extends React.Component {
       const config = this.state.config
       config[label] = ev.target.type === 'checkbox' ? ev.target.checked : ev.target.value
       config.qos = parseInt(config.qos)
-      this.setState({ config: config })
+      this.setState({ config })
       this.props.update(this.state.config)
     }.bind(this)
   }
@@ -24,7 +24,7 @@ export default class Mqtt extends React.Component {
   handleUpdateEnable (ev) {
     const config = this.state.config
     config.enable = ev.target.checked
-    this.setState({ config: config })
+    this.setState({ config })
     this.props.update(this.state.config)
   }
 

--- a/front-end/src/telemetry/notification.jsx
+++ b/front-end/src/telemetry/notification.jsx
@@ -19,7 +19,7 @@ export default class NotificationSettings extends React.Component {
       const config = this.state.config
       config[key] = ev.target.value
       this.setState({
-        config: config
+        config
       })
       this.props.update(config)
     }.bind(this)
@@ -31,7 +31,7 @@ export default class NotificationSettings extends React.Component {
       const recipients = ev.target.value.split(',')
       config.to = recipients.map(s => s.trim())
       this.setState({
-        config: config
+        config
       })
       this.props.update(config)
     }.bind(this)

--- a/front-end/src/temperature/control_chart.jsx
+++ b/front-end/src/temperature/control_chart.jsx
@@ -13,7 +13,7 @@ class chart extends React.Component {
     const timer = window.setInterval(() => {
       this.props.fetchTCUsage(this.props.sensor_id)
     }, 10 * 1000)
-    this.setState({ timer: timer })
+    this.setState({ timer })
   }
 
   componentWillUnmount () {

--- a/front-end/src/temperature/readings_chart.jsx
+++ b/front-end/src/temperature/readings_chart.jsx
@@ -9,7 +9,7 @@ class chart extends React.Component {
   componentDidMount () {
     this.props.fetch(this.props.sensor_id)
     const timer = window.setInterval(() => { this.props.fetch(this.props.sensor_id) }, 10 * 1000)
-    this.setState({ timer: timer })
+    this.setState({ timer })
   }
 
   componentWillUnmount () {

--- a/front-end/src/timers/main.jsx
+++ b/front-end/src/timers/main.jsx
@@ -86,7 +86,7 @@ class Main extends React.Component {
       minute: values.minute,
       second: values.second,
       enable: values.enable,
-      target: target
+      target
     }
     return timer
   }

--- a/front-end/src/timers/subsystem.jsx
+++ b/front-end/src/timers/subsystem.jsx
@@ -12,7 +12,7 @@ export default class Subsystem extends React.Component {
       }
     })
     this.state = {
-      name: name,
+      name,
       duration: props.duration,
       revert: props.revert,
       on: props.on,

--- a/front-end/src/ui_components/collapsible.jsx
+++ b/front-end/src/ui_components/collapsible.jsx
@@ -82,9 +82,9 @@ class Collapsible extends React.Component {
         </div>
         {expanded
           ? cloneElement(children, {
-              readOnly: readOnly,
-              onSubmit: handleSubmit
-            })
+            readOnly,
+            onSubmit: handleSubmit
+          })
           : null}
       </li>
     )

--- a/front-end/src/ui_components/error_boundary.jsx
+++ b/front-end/src/ui_components/error_boundary.jsx
@@ -18,8 +18,8 @@ class ErrorBoundary extends React.Component {
 
   componentDidCatch (error, errorInfo) {
     this.setState({
-      error: error,
-      errorInfo: errorInfo
+      error,
+      errorInfo
     })
   }
 

--- a/front-end/src/utils/ajax.js
+++ b/front-end/src/utils/ajax.js
@@ -68,7 +68,7 @@ function request (params, dispatch) {
     .then(response => parseResponse(response, params))
     .then(data => dispatch(params.success(data)))
     .catch(() => {
-      dispatch({ type: 'API_FAILURE', params: params })
+      dispatch({ type: 'API_FAILURE', params })
     })
 }
 

--- a/front-end/src/utils/alert.js
+++ b/front-end/src/utils/alert.js
@@ -1,6 +1,6 @@
 import { getStore } from 'redux/store'
 import { setAlert } from 'notifications/statics'
-import { addAlert, delAlert} from 'redux/actions/alert'
+import { addAlert, delAlert } from 'redux/actions/alert'
 import { MsgLevel } from 'utils/enums'
 import i18n from 'utils/i18n'
 
@@ -17,14 +17,14 @@ export function showWarning (msg) {
   _showAlert(MsgLevel.warning, msg)
 }
 export function showUpdateSuccessful () {
-  let alert = _showAlert(MsgLevel.success, i18n.t("save_successful"))
+  const alert = _showAlert(MsgLevel.success, i18n.t('save_successful'))
   setTimeout(() => {
     // only show alert for a second to not block page content
     getStore().dispatch(delAlert(alert))
   }, 1000)
 }
 function _showAlert (type, msg) {
-  let alert = setAlert(type, msg)
+  const alert = setAlert(type, msg)
   getStore().dispatch(addAlert(alert))
   return alert
 }

--- a/front-end/src/utils/confirm.js
+++ b/front-end/src/utils/confirm.js
@@ -4,7 +4,7 @@ import { flushSync } from 'react-dom'
 import { createRoot } from 'react-dom/client'
 
 export function confirm (message, options = {}) {
-  const props = Object.assign({ message: message }, options)
+  const props = Object.assign({ message }, options)
   return showModal(<Confirm {...props} />)
 }
 


### PR DESCRIPTION
Summary:
- apply the remaining behavior-neutral React 19 cleanup edits across the frontend runtime
- normalize object shorthand, timer state updates, and JSX formatting in the touched components
- keep this PR scoped to cleanup only, with no intended product behavior change

Validation:
- rtk yarn standard
- rtk yarn build
- rtk make go
- rtk yarn pw-smoke

Notes:
- This PR was extracted from the in-progress local React 19 migration workspace because the changes were already shippable on their own.
- The deeper migration work continues separately.