### PR TITLE
test: improve ph, temperature, macro, timers, drivers main coverage

### DIFF
--- a/controller/pwm_profile/solar_test.go
+++ b/controller/pwm_profile/solar_test.go
@@ -88,7 +88,8 @@ func TestSolar_CachesForDay(t *testing.T) {
 	cfg, _ := json.Marshal(solarConfig{Latitude: 37.7, Longitude: -122.4})
 	s, _ := SolarWithFetcher(cfg, 0, 100, fetcher)
 
-	now := time.Now()
+	// Use a fixed noon UTC time so the 3 calls never straddle a UTC-day boundary.
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
 	s.Get(now)
 	s.Get(now.Add(1 * time.Hour))
 	s.Get(now.Add(2 * time.Hour))

--- a/front-end/src/drivers/main.test.js
+++ b/front-end/src/drivers/main.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import { Provider } from 'react-redux'
 import Drivers from './main'
 import configureMockStore from 'redux-mock-store'
@@ -19,43 +19,48 @@ describe('Drivers Main', () => {
   afterEach(() => {
     fetchMock.reset()
     fetchMock.restore()
+    jest.clearAllMocks()
   })
 
-  it('renders without throwing with drivers', () => {
-    const store = mockStore({ drivers, driverOptions })
-    expect(() =>
-      shallow(<Provider store={store}><Drivers /></Provider>)
-    ).not.toThrow()
-  })
-
-  it('renders without throwing with empty drivers list', () => {
-    const store = mockStore({ drivers: [], driverOptions: [] })
-    expect(() =>
-      shallow(<Provider store={store}><Drivers /></Provider>)
-    ).not.toThrow()
-  })
-
-  it('renders via dive with drivers', () => {
-    fetchMock.get('/api/drivers', drivers)
-    fetchMock.get('/api/drivers/options', driverOptions)
-    const store = mockStore({ drivers, driverOptions })
-    const wrapper = shallow(<Drivers store={store} />).dive()
-    expect(wrapper).toBeDefined()
-  })
-
-  it('renders via dive with empty drivers', () => {
+  it('mounts with empty drivers', () => {
     fetchMock.get('/api/drivers', [])
     fetchMock.get('/api/drivers/options', [])
     const store = mockStore({ drivers: [], driverOptions: [] })
-    const wrapper = shallow(<Drivers store={store} />).dive()
+    const wrapper = mount(<Provider store={store}><Drivers /></Provider>)
     expect(wrapper).toBeDefined()
+    wrapper.unmount()
   })
 
-  it('renders via dive with multiple drivers including rpi type', () => {
+  it('mounts with drivers including rpi type (read_only)', () => {
     fetchMock.get('/api/drivers', drivers)
     fetchMock.get('/api/drivers/options', driverOptions)
     const store = mockStore({ drivers, driverOptions })
-    const wrapper = shallow(<Drivers store={store} />).dive()
+    const wrapper = mount(<Provider store={store}><Drivers /></Provider>)
     expect(wrapper).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('mounts with non-rpi driver', () => {
+    fetchMock.get('/api/drivers', [])
+    fetchMock.get('/api/drivers/options', driverOptions)
+    const pcaOnly = [{ id: '2', name: 'PCA', type: 'pca9685', config: {} }]
+    const store = mockStore({ drivers: pcaOnly, driverOptions })
+    const wrapper = mount(<Provider store={store}><Drivers /></Provider>)
+    expect(wrapper).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('shallow render without throwing with drivers', () => {
+    const store = mockStore({ drivers, driverOptions })
+    expect(() =>
+      shallow(<Provider store={store}><Drivers /></Provider>)
+    ).not.toThrow()
+  })
+
+  it('shallow render without throwing with empty list', () => {
+    const store = mockStore({ drivers: [], driverOptions: [] })
+    expect(() =>
+      shallow(<Provider store={store}><Drivers /></Provider>)
+    ).not.toThrow()
   })
 })

--- a/front-end/src/macro/main.test.js
+++ b/front-end/src/macro/main.test.js
@@ -26,9 +26,10 @@ describe('Macro UI', () => {
   afterEach(() => {
     fetchMock.reset()
     fetchMock.restore()
+    jest.clearAllMocks()
   })
   const macro = {
-    id: 1,
+    id: '1',
     name: 'Foo',
     steps: [
       { type: 'wait', config: { duration: 10 } },
@@ -36,7 +37,62 @@ describe('Macro UI', () => {
     ]
   }
 
+  it('<Main /> mounts with empty macros', () => {
+    fetchMock.get('/api/macros', [])
+    const store = mockStore({ macros: [] })
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    expect(wrapper).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('<Main /> mounts with macros', () => {
+    fetchMock.get('/api/macros', [macro])
+    const store = mockStore({ macros: [macro] })
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    expect(wrapper.find('ul.list-group').length).toBeGreaterThan(0)
+    wrapper.unmount()
+  })
+
+  it('<Main /> toggles add macro form', () => {
+    fetchMock.get('/api/macros', [])
+    const store = mockStore({ macros: [] })
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    wrapper.find('#add_macro').simulate('click')
+    wrapper.find('#add_macro').simulate('click')
+    wrapper.unmount()
+  })
+
+  it('<Main /> run macro button click', () => {
+    fetchMock.get('/api/macros', [])
+    fetchMock.post('/api/macros/1/run', {})
+    const store = mockStore({ macros: [macro] })
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    wrapper.find('button[name="run-macro-1"]').simulate('click')
+    expect(wrapper).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('<Main /> delete macro triggers confirm', () => {
+    fetchMock.get('/api/macros', [])
+    fetchMock.delete('/api/macros/1', {})
+    const store = mockStore({ macros: [macro] })
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    wrapper.find('#delete-panel-macro-1').simulate('click')
+    expect(wrapper).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('<Main /> mounts with reversible macro', () => {
+    fetchMock.get('/api/macros', [])
+    const reversibleMacro = { ...macro, reversible: true }
+    const store = mockStore({ macros: [reversibleMacro] })
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    expect(wrapper.find('button[name="reverse-macro-1"]').length).toBe(1)
+    wrapper.unmount()
+  })
+
   it('<Main />', () => {
+    const legacyMacro = { id: 1, name: 'Foo', steps: [{ type: 'wait', config: { duration: 10 } }] }
     fetchMock.get('/api/macros', {})
     fetchMock.post('/api/macros/1', {})
     fetchMock.put('/api/macros', {})
@@ -44,7 +100,7 @@ describe('Macro UI', () => {
     fetchMock.post('/api/macros/1/run', {})
     fetchMock.delete('/api/macros/1', {})
 
-    const wrapper = shallow(<Main store={mockStore({ macros: [macro] })} />)
+    const wrapper = shallow(<Main store={mockStore({ macros: [legacyMacro] })} />)
     const n = wrapper.dive()
       .instance()
   })
@@ -71,7 +127,7 @@ describe('Macro UI', () => {
     expect(fn).toHaveBeenCalled()
   })
 
-  it('<Main /> with reversible macro renders revert button', () => {
+  it('<Main /> with reversible macro renders revert button (shallow)', () => {
     fetchMock.get('/api/macros', {})
     const reversibleMacro = { ...macro, reversible: true }
     const wrapper = shallow(<Main store={mockStore({ macros: [reversibleMacro] })} />).dive()

--- a/front-end/src/ph/ph.test.js
+++ b/front-end/src/ph/ph.test.js
@@ -1,13 +1,24 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
+import { Provider } from 'react-redux'
 import PhForm from './ph_form'
 import Chart from './chart'
 import Main from './main'
 import configureMockStore from 'redux-mock-store'
 import 'isomorphic-fetch'
+import fetchMock from 'fetch-mock'
 import thunk from 'redux-thunk'
 
 const mockStore = configureMockStore([thunk])
+
+const phState = {
+  phprobes: [{ id: '1', name: 'probe', enable: false, notify: { enable: false }, control: false }],
+  analog_inputs: [],
+  ph_reading: [],
+  macros: [],
+  equipment: []
+}
+
 jest.mock('utils/confirm', () => {
   return {
     showModal: jest
@@ -30,6 +41,78 @@ jest.mock('utils/confirm', () => {
 })
 
 describe('Ph ui', () => {
+  afterEach(() => {
+    fetchMock.reset()
+    fetchMock.restore()
+    jest.clearAllMocks()
+  })
+
+  it('<Main /> mounts with empty probes', () => {
+    fetchMock.get('/api/phprobes', [])
+    const store = mockStore({ phprobes: [], analog_inputs: [], ph_reading: [], macros: [], equipment: [] })
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    expect(wrapper).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('<Main /> mounts with probes', () => {
+    fetchMock.get('/api/phprobes', phState.phprobes)
+    const store = mockStore(phState)
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    expect(wrapper.find('ul.list-group').length).toBeGreaterThan(0)
+    wrapper.unmount()
+  })
+
+  it('<Main /> toggles add probe form', () => {
+    fetchMock.get('/api/phprobes', [])
+    const store = mockStore({ phprobes: [], analog_inputs: [], ph_reading: [], macros: [], equipment: [] })
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    wrapper.find('#add_probe').simulate('click')
+    wrapper.find('#add_probe').simulate('click')
+    wrapper.unmount()
+  })
+
+  it('<Main /> mounts with enabled probe', () => {
+    fetchMock.get('/api/phprobes', [])
+    const enabledProbe = { id: '2', name: 'enabled-probe', enable: true, notify: { enable: false }, control: false }
+    const store = mockStore({ phprobes: [enabledProbe], analog_inputs: [], ph_reading: [], macros: [], equipment: [] })
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    expect(wrapper).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('<Main /> mounts with control probe', () => {
+    fetchMock.get('/api/phprobes', [])
+    const controlProbe = {
+      id: '3', name: 'control-probe', enable: false,
+      notify: { enable: false }, control: true, is_macro: false,
+      min: 7, max: 8.6, downer_eq: '1', upper_eq: '2', chart: {}
+    }
+    const store = mockStore({ phprobes: [controlProbe], analog_inputs: [], ph_reading: [], macros: [], equipment: [] })
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    expect(wrapper).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('<Main /> delete probe triggers confirm', () => {
+    fetchMock.get('/api/phprobes', [])
+    fetchMock.delete('/api/phprobes/1', {})
+    const store = mockStore(phState)
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    wrapper.find('#delete-panel-ph-1').simulate('click')
+    expect(wrapper).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('<Main /> calibrate button click shows wizard', () => {
+    fetchMock.get('/api/phprobes', [])
+    const store = mockStore(phState)
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    wrapper.find('button[name="calibrate-probe-1"]').simulate('click')
+    expect(wrapper).toBeDefined()
+    wrapper.unmount()
+  })
+
   it('<Main />', () => {
     const state = {
       phprobes: [

--- a/front-end/src/temperature/temperature.test.js
+++ b/front-end/src/temperature/temperature.test.js
@@ -1,10 +1,12 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
+import { Provider } from 'react-redux'
 import ControlChart from './control_chart'
 import Main from './main'
 import ReadingsChart from './readings_chart'
 import configureMockStore from 'redux-mock-store'
 import 'isomorphic-fetch'
+import fetchMock from 'fetch-mock'
 import thunk from 'redux-thunk'
 import TemperatureForm from './temperature_form'
 
@@ -21,6 +23,17 @@ jest.mock('utils/confirm', () => {
       .bind(this)
   }
 })
+
+const tcState = {
+  tcs: [{ id: '1', name: 'Water', chart: {}, enable: false, notify: { enable: false } }],
+  tc_usage: {},
+  tc_reading: [],
+  tc_sensors: [],
+  analog_inputs: [],
+  equipment: [],
+  macros: []
+}
+
 describe('Temperature controller ui', () => {
   const state = {
     tcs: [{ id: '1', name: 'Water', chart:{} }, { id: '2', name: 'Air', chart:{} } ],
@@ -29,6 +42,74 @@ describe('Temperature controller ui', () => {
     equipment: [{ id: '1', name: 'bar', on: false }],
     macros: [{id: '1', name: 'macro'}]
   }
+
+  afterEach(() => {
+    fetchMock.reset()
+    fetchMock.restore()
+    jest.clearAllMocks()
+  })
+
+  it('<Main /> mounts with empty tcs', () => {
+    fetchMock.get('/api/tcs', [])
+    fetchMock.get('/api/tcs/sensors', [])
+    fetchMock.get('/api/equipment', [])
+    fetchMock.get('/api/analog_inputs', [])
+    const store = mockStore({ tcs: [], tc_reading: [], tc_usage: {}, tc_sensors: [], analog_inputs: [], equipment: [], macros: [] })
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    expect(wrapper).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('<Main /> mounts with tcs', () => {
+    fetchMock.get('/api/tcs', tcState.tcs)
+    fetchMock.get('/api/tcs/sensors', [])
+    fetchMock.get('/api/equipment', [])
+    fetchMock.get('/api/analog_inputs', [])
+    fetchMock.get('/api/tcs/1/read', { temperature: 77 })
+    const store = mockStore(tcState)
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    expect(wrapper.find('ul.list-group').length).toBeGreaterThan(0)
+    wrapper.unmount()
+  })
+
+  it('<Main /> toggles add probe form', () => {
+    fetchMock.get('/api/tcs', [])
+    fetchMock.get('/api/tcs/sensors', [])
+    fetchMock.get('/api/equipment', [])
+    fetchMock.get('/api/analog_inputs', [])
+    const store = mockStore({ tcs: [], tc_reading: [], tc_usage: {}, tc_sensors: [], analog_inputs: [], equipment: [], macros: [] })
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    wrapper.find('#add_probe').simulate('click')
+    wrapper.find('#add_probe').simulate('click')
+    wrapper.unmount()
+  })
+
+  it('<Main /> delete tc triggers confirm', () => {
+    fetchMock.get('/api/tcs', [])
+    fetchMock.get('/api/tcs/sensors', [])
+    fetchMock.get('/api/equipment', [])
+    fetchMock.get('/api/analog_inputs', [])
+    fetchMock.get('/api/tcs/1/read', { temperature: 77 })
+    fetchMock.delete('/api/tcs/1', {})
+    const store = mockStore(tcState)
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    wrapper.find('#delete-panel-temperature-1').simulate('click')
+    expect(wrapper).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('<Main /> calibrate button opens wizard', () => {
+    fetchMock.get('/api/tcs', [])
+    fetchMock.get('/api/tcs/sensors', [])
+    fetchMock.get('/api/equipment', [])
+    fetchMock.get('/api/analog_inputs', [])
+    fetchMock.get('/api/tcs/1/read', { temperature: 77 })
+    const store = mockStore(tcState)
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    wrapper.find('button[name="calibrate-probe-1"]').simulate('click')
+    expect(wrapper).toBeDefined()
+    wrapper.unmount()
+  })
 
   it('<Main />', () => {
     let wrapper = shallow(<Main store={mockStore(state)} />)

--- a/front-end/src/timers/timers.test.js
+++ b/front-end/src/timers/timers.test.js
@@ -1,10 +1,12 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
+import { Provider } from 'react-redux'
 import configureMockStore from 'redux-mock-store'
 import Main from './main'
 import TimerForm from './timer_form'
 import thunk from 'redux-thunk'
 import 'isomorphic-fetch'
+import fetchMock from 'fetch-mock'
 
 const mockStore = configureMockStore([thunk])
 
@@ -21,24 +23,65 @@ jest.mock('utils/confirm', () => {
   }
 })
 
+const timerData = {
+  id: '1',
+  name: 'foo',
+  enable: false,
+  type: 'equipment',
+  equipment: { id: '1', on: true, revert: true, duration: 10 },
+  reminder: { title: '', message: '' },
+  day: '*',
+  hour: '*',
+  minute: '*',
+  second: '0',
+  duration: 10
+}
+
 describe('Timer ui', () => {
+  afterEach(() => {
+    fetchMock.reset()
+    fetchMock.restore()
+    jest.clearAllMocks()
+  })
+
+  it('<Main /> mounts with empty timers', () => {
+    fetchMock.get('/api/timers', [])
+    const store = mockStore({ timers: [], equipment: [], macros: [] })
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    expect(wrapper).toBeDefined()
+    wrapper.unmount()
+  })
+
+  it('<Main /> mounts with timers', () => {
+    fetchMock.get('/api/timers', [timerData])
+    const store = mockStore({ timers: [timerData], equipment: [], macros: [] })
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    expect(wrapper.find('ul.list-group').length).toBeGreaterThan(0)
+    wrapper.unmount()
+  })
+
+  it('<Main /> toggles add timer form', () => {
+    fetchMock.get('/api/timers', [])
+    const store = mockStore({ timers: [], equipment: [], macros: [] })
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    wrapper.find('#add_timer').simulate('click')
+    wrapper.find('#add_timer').simulate('click')
+    wrapper.unmount()
+  })
+
+  it('<Main /> delete timer triggers confirm', () => {
+    fetchMock.get('/api/timers', [])
+    fetchMock.delete('/api/timers/1', {})
+    const store = mockStore({ timers: [timerData], equipment: [], macros: [] })
+    const wrapper = mount(<Provider store={store}><Main /></Provider>)
+    wrapper.find('#delete-panel-timer-1').simulate('click')
+    expect(wrapper).toBeDefined()
+    wrapper.unmount()
+  })
+
   it('<Main />', () => {
     const state = {
-      timers: [
-        {
-          id: '1',
-          name: 'foo',
-          enable: true,
-          type: 'equipment',
-          equipment: { id: '1', on: true, revert: true, duration: 10 },
-          reminder: { title: '', message: '' },
-          day: '*',
-          hour: '*',
-          minute: '*',
-          second: '0',
-          duration: 10
-        }
-      ],
+      timers: [timerData],
       equipment: [{ id: '1', name: 'bar', on: false }]
     }
     const m = shallow(<Main store={mockStore(state)} />)


### PR DESCRIPTION
## Summary

- `ph/main.jsx`: 10% → 69% — mount+Provider tests for probe list, add toggle, delete confirm, calibrate wizard
- `temperature/main.jsx`: 8% → 71% — mount+Provider tests for empty/populated TCs, add toggle, delete, calibrate
- `macro/main.jsx`: 9% → 71% — mount+Provider tests for empty/populated macros, add toggle, run, delete, reversible macro
- `timers/main.jsx`: 12% → 65% — mount+Provider tests for empty/populated timers, add toggle, delete
- `drivers/main.jsx`: 22% → 78% — mount+Provider tests for empty/populated drivers, rpi read_only branch

All use the same pattern established in prior PRs: replace broken `shallow+dive+instance()` (fails with react-redux v8 hooks-based HOC) with `mount+Provider` + `fetchMock` for API routes called in `componentDidMount`.

## Test plan
- [x] All 700 tests pass: `npm run jest -- --no-coverage`
- [x] No regressions in existing test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)