### PR TITLE
[codex] Continue React 19 tail cleanup on fresh main

### DIFF
--- a/front-end/src/drivers/edit_driver.test.js
+++ b/front-end/src/drivers/edit_driver.test.js
@@ -1,34 +1,26 @@
 import React from 'react'
-import * as Alert from '../utils/alert'
-import { shallow } from 'enzyme'
 import EditDriver from './edit_driver'
 import 'isomorphic-fetch'
 
-
 describe('<EditDriver />', () => {
-  let values = {}
-  let options = {
-    ezo: {},
-    pca9685: {}
+  const values = {}
+  const options = {
+    ezo: [],
+    pca9685: []
   }
-  let fn = jest.fn()
-
-  beforeEach(() => {
-    jest.spyOn(Alert, 'showError')
-  })
-
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
+  const fn = jest.fn()
 
   it('<EditDriver />', () => {
-    shallow(
-      <EditDriver
-        values={values}
-        handleBlur={fn}
-        submitForm={fn}
-        driverOptions={options}
-      />
-    )
+    const element = EditDriver({
+      values,
+      errors: {},
+      touched: {},
+      handleBlur: fn,
+      submitForm: fn,
+      handleChange: fn,
+      driverOptions: options
+    })
+    expect(element.type).toBe('form')
+    expect(typeof element.props.onSubmit).toBe('function')
   })
 })

--- a/front-end/src/telemetry/main.jsx
+++ b/front-end/src/telemetry/main.jsx
@@ -290,4 +290,5 @@ const Telemetry = connect(
   mapStateToProps,
   mapDispatchToProps
 )(telemetry)
+export { telemetry as RawTelemetry }
 export default Telemetry

--- a/front-end/src/telemetry/telmetry.test.js
+++ b/front-end/src/telemetry/telmetry.test.js
@@ -1,135 +1,114 @@
 import React from 'react'
-import { shallow, mount } from 'enzyme'
-import { Provider } from 'react-redux'
-import configureMockStore from 'redux-mock-store'
-import Main from './main'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { RawTelemetry as Main } from './main'
 import AdafruitIO from './adafruit_io'
 import Mqtt from './mqtt'
 import Notification from './notification'
-import thunk from 'redux-thunk'
 import 'isomorphic-fetch'
-import fetchMock from 'fetch-mock'
-
-jest.mock('utils/alert', () => ({
-  showError: jest.fn(),
-  showSuccess: jest.fn(),
-  showUpdateSuccessful: jest.fn()
-}))
-
-const mockStore = configureMockStore([thunk])
-
-const fullTelemetry = {
-  mailer: { port: 546, server: 'test.example.com', from: 'a@b.com', to: ['c@d.com'] },
-  throttle: 10,
-  notify: true,
-  adafruitio: { enable: true, user: 'u', token: 'foo' },
-  mqtt: { enable: true, server: 'mqtt.local', username: '', client_id: '', password: '', qos: 0, prefix: '', retained: false },
-  current_limit: 100,
-  historical_limit: 720
-}
 
 describe('Telemetry UI', () => {
-  afterEach(() => {
-    fetchMock.reset()
-    fetchMock.restore()
-  })
+  const makeMain = (props = {}) => {
+    const mailer = {
+      port: 546,
+      server: 'test.example.com',
+      from: 'reef@example.com',
+      to: ['reefer@example.com']
+    }
+    const aio = {
+      enable: true,
+      user: 'u',
+      token: 'foo',
+      prefix: 'reef'
+    }
+    const mqtt = {
+      enable: true,
+      server: 'mqtt.example.com',
+      username: '',
+      client_id: '',
+      password: '',
+      qos: 0,
+      prefix: '',
+      retained: false
+    }
+    const telemetry = {
+      mailer: mailer,
+      throttle: 10,
+      notify: true,
+      adafruitio: aio,
+      mqtt: mqtt,
+      current_limit: 100,
+      historical_limit: 720
+    }
+    const instance = new Main({
+      config: telemetry,
+      fetch: jest.fn(),
+      update: jest.fn(),
+      sendTestMessage: jest.fn(),
+      ...props
+    })
+    instance.setState = update => {
+      const next = typeof update === 'function' ? update(instance.state, instance.props) : update
+      instance.state = { ...instance.state, ...next }
+    }
+    return instance
+  }
 
-  it('<Main /> smoke test via Provider', () => {
-    fetchMock.get('/api/telemetry', fullTelemetry)
-    const store = mockStore({ telemetry: fullTelemetry })
-    expect(() =>
-      shallow(<Provider store={store}><Main /></Provider>)
-    ).not.toThrow()
-  })
+  it('<Main />', () => {
+    const m = makeMain()
+    expect(m).toBeInstanceOf(Main)
 
-  it('<Main /> mounts with full config including notify', () => {
-    fetchMock.get('/api/telemetry', fullTelemetry)
-    fetchMock.post('/api/telemetry', fullTelemetry)
-    const store = mockStore({ telemetry: fullTelemetry })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
-  })
+    const derived = Main.getDerivedStateFromProps({ config: m.props.config }, m.state)
+    expect(derived.config).toEqual(m.props.config)
 
-  it('<Main /> mounts with no notify (notification hidden)', () => {
-    fetchMock.get('/api/telemetry', {})
-    const config = { ...fullTelemetry, notify: false }
-    const store = mockStore({ telemetry: config })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
-  })
+    m.componentDidMount()
+    expect(m.props.fetch).toHaveBeenCalled()
 
-  it('<Main /> mounts with no adafruitio (showAdafruitIO hidden)', () => {
-    fetchMock.get('/api/telemetry', {})
-    const config = { ...fullTelemetry, adafruitio: undefined }
-    const store = mockStore({ telemetry: config })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
-  })
+    m.handleEnableMailer({ target: { checked: false } })
+    expect(m.state.config.notify).toBe(false)
 
-  it('<Main /> mounts with no mqtt (showMqtt hidden)', () => {
-    fetchMock.get('/api/telemetry', {})
-    const config = { ...fullTelemetry, mqtt: undefined }
-    const store = mockStore({ telemetry: config })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
-  })
+    m.updateLimit('current_limit')({ target: { value: '42' } })
+    expect(m.state.config.current_limit).toBe('42')
 
-  it('<Main /> handleSave — valid config with adafruitio and notify', () => {
-    fetchMock.get('/api/telemetry', fullTelemetry)
-    fetchMock.post('/api/telemetry', fullTelemetry)
-    const store = mockStore({ telemetry: fullTelemetry })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    wrapper.find('#updateTelemetry').simulate('click')
-    wrapper.unmount()
-  })
+    m.handleUpdateThrottle({ target: { value: '15' } })
+    expect(m.state.config.throttle).toBe('15')
 
-  it('<Main /> handleSave — adafruitio enabled with empty user rejects', () => {
-    fetchMock.get('/api/telemetry', {})
-    const badAio = { ...fullTelemetry, adafruitio: { enable: true, user: '', token: '' } }
-    const store = mockStore({ telemetry: badAio })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    wrapper.find('#updateTelemetry').simulate('click')
-    wrapper.unmount()
-  })
+    m.handleTestMessage()
+    expect(m.props.sendTestMessage).toHaveBeenCalled()
 
-  it('<Main /> handleEnableMailer toggles notify', () => {
-    fetchMock.get('/api/telemetry', {})
-    const store = mockStore({ telemetry: fullTelemetry })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    wrapper.find('#enable-mailer').simulate('click', { target: { checked: false } })
-    wrapper.unmount()
-  })
+    m.updateAio({ enable: true, user: 'u2', token: 'bar', prefix: 'reef' })
+    expect(m.state.config.adafruitio.user).toBe('u2')
 
-  it('<Main /> updateLimit changes current_limit', () => {
-    fetchMock.get('/api/telemetry', {})
-    const store = mockStore({ telemetry: fullTelemetry })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    wrapper.find('#updateCurrentLimit').simulate('change', { target: { value: '50' } })
-    wrapper.unmount()
-  })
+    m.updateMqtt({ enable: true, server: 'broker.local', qos: 1, retained: true })
+    expect(m.state.config.mqtt.server).toBe('broker.local')
 
-  it('<Main /> getDerivedStateFromProps — skips update when state.updated is true', () => {
-    fetchMock.get('/api/telemetry', fullTelemetry)
-    const store = mockStore({ telemetry: fullTelemetry })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
-  })
+    m.updateMailer({ server: 'smtp.local', port: '2525', from: 'reef@example.com', to: ['reef@example.com'] })
+    expect(m.state.config.mailer.server).toBe('smtp.local')
 
-  it('<Main /> old dive still works for smoke', () => {
-    fetchMock.get('/api/telemetry', fullTelemetry)
-    const m = shallow(<Main store={mockStore({ telemetry: fullTelemetry })} />).dive()
-    expect(m).toBeDefined()
+    m.handleSave()
+    expect(m.props.update).toHaveBeenCalledWith(expect.objectContaining({
+      current_limit: 42,
+      historical_limit: 720,
+      throttle: '15'
+    }))
+
+    const markup = renderToStaticMarkup(m.render())
+    expect(markup).toContain('updateTelemetry')
   })
 
   it('<AdafruitIO />', () => {
-    const m = shallow(<AdafruitIO adafruitio={{}} update={() => true} />).instance()
+    let updated = {}
+    const m = new AdafruitIO({
+      adafruitio: {},
+      update: c => { updated = c }
+    })
+    m.setState = update => {
+      const next = typeof update === 'function' ? update(m.state, m.props) : update
+      m.state = { ...m.state, ...next }
+    }
     m.handleUpdateEnable({ target: { checked: true } })
+    expect(updated.enable).toBe(true)
     m.onChange('foo')({ target: { value: 1 } })
+    expect(updated.foo).toBe(1)
   })
 
   it('<Mqtt /> onChange sends boolean for checkbox, string for text', () => {
@@ -144,7 +123,11 @@ describe('Telemetry UI', () => {
       retained: false
     }
     let updated = {}
-    const m = shallow(<Mqtt config={mqttConfig} update={(c) => { updated = c }} />).instance()
+    const m = new Mqtt({ config: mqttConfig, update: (c) => { updated = c } })
+    m.setState = update => {
+      const next = typeof update === 'function' ? update(m.state, m.props) : update
+      m.state = { ...m.state, ...next }
+    }
 
     // Text input should send string value
     m.onChange('server')({ target: { type: 'text', value: 'broker.local' } })
@@ -160,7 +143,18 @@ describe('Telemetry UI', () => {
   })
 
   it('<Notification />', () => {
-    const m = shallow(<Notification update={() => true} mailer={{ to: [] }} />).instance()
+    let updated = {}
+    const m = new Notification({
+      update: c => { updated = c },
+      mailer: { to: [], server: '', port: '', from: '', username: '', password: '' }
+    })
+    m.setState = update => {
+      const next = typeof update === 'function' ? update(m.state, m.props) : update
+      m.state = { ...m.state, ...next }
+    }
     m.update(1)({ target: { value: 'foo' } })
+    expect(updated[1]).toBe('foo')
+    m.updateTo()({ target: { value: 'a@example.com, b@example.com' } })
+    expect(updated.to).toEqual(['a@example.com', 'b@example.com'])
   })
 })

--- a/front-end/src/ui_components/boolean_select.test.js
+++ b/front-end/src/ui_components/boolean_select.test.js
@@ -1,7 +1,5 @@
 import React from 'react'
-import { shallow } from 'enzyme'
 import BooleanSelect from './boolean_select'
-
 
 describe('<BooleanSelect />', () => {
   it('<BooleanSelect /> should bind true', () => {
@@ -12,13 +10,15 @@ describe('<BooleanSelect />', () => {
         val = e.target.value
       }
     }
-    const wrapper = shallow(
-      <BooleanSelect field={field}>
-        <option value='true'>Yes</option>
-        <option value='false'>No</option>
-      </BooleanSelect>
-    )
-    wrapper.find('select').simulate('change', { target: { value: 'true' } })
+    const element = BooleanSelect({
+      field,
+      children: [
+        <option key='true' value='true'>Yes</option>,
+        <option key='false' value='false'>No</option>
+      ]
+    })
+
+    element.props.onChange({ target: { name: 'name', value: 'true' } })
     expect(val).toBe(true)
   })
 
@@ -30,13 +30,15 @@ describe('<BooleanSelect />', () => {
         val = e.target.value
       }
     }
-    const wrapper = shallow(
-      <BooleanSelect field={field}>
-        <option value='true'>Yes</option>
-        <option value='false'>No</option>
-      </BooleanSelect>
-    )
-    wrapper.find('select').simulate('change', { target: { value: 'false' } })
+    const element = BooleanSelect({
+      field,
+      children: [
+        <option key='true' value='true'>Yes</option>,
+        <option key='false' value='false'>No</option>
+      ]
+    })
+
+    element.props.onChange({ target: { name: 'name', value: 'false' } })
     expect(val).toBe(false)
   })
 })

--- a/front-end/src/ui_components/collapsible.test.js
+++ b/front-end/src/ui_components/collapsible.test.js
@@ -1,128 +1,158 @@
-import React, { act } from 'react'
-import { shallow, mount } from 'enzyme'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 import CollapsibleList from './collapsible_list'
 import Collapsible from './collapsible'
 
-
 describe('Collapsible', () => {
   const noop = () => {}
-  const click = (node, event = {}) => {
-    act(() => {
-      node.prop('onClick')(event)
-    })
-  }
   const Content = (props) => {
     return (
       <div>
         This is inner content
-        <button type='button' id='submit' onClick={props.onSubmit}>click</button>
+        <button type='button' id='submit' onClick={() => props.onSubmit('ok')}>click</button>
       </div>
     )
   }
 
-  it('should not show content when collapsed', () => {
-    const wrapper = mount(
-      <Collapsible name='test' title='title' expanded={false} readOnly onToggle={noop} onDelete={noop} onEdit={noop} onSubmit={noop}>
-        <Content onSubmit={noop} />
-      </Collapsible>
-    )
-    expect(wrapper.find('button#submit').length).toBe(0)
+  const makeCollapsible = (props = {}) => {
+    const instance = new Collapsible({
+      name: 'test',
+      title: 'title',
+      expanded: false,
+      readOnly: true,
+      item: { id: 1, name: 'item' },
+      onToggle: jest.fn(),
+      onDelete: jest.fn(),
+      onEdit: jest.fn(),
+      onSubmit: jest.fn(),
+      children: <Content onSubmit={jest.fn()} />,
+      ...props
+    })
+    instance.setState = update => {
+      const next = typeof update === 'function' ? update(instance.state, instance.props) : update
+      instance.state = { ...instance.state, ...next }
+    }
+    return instance
+  }
+
+  const makeCollapsibleList = (children) => {
+    const instance = new CollapsibleList({ children })
+    instance.setState = update => {
+      const next = typeof update === 'function' ? update(instance.state, instance.props) : update
+      instance.state = { ...instance.state, ...next }
+    }
+    return instance
+  }
+
+  const visitElements = (node, predicate, matches = []) => {
+    if (node == null || typeof node === 'boolean') {
+      return matches
+    }
+    if (Array.isArray(node)) {
+      node.forEach(child => visitElements(child, predicate, matches))
+      return matches
+    }
+    if (React.isValidElement(node)) {
+      if (predicate(node)) {
+        matches.push(node)
+      }
+      visitElements(node.props && node.props.children, predicate, matches)
+    }
+    return matches
+  }
+
+  it('does not show content when collapsed', () => {
+    const instance = makeCollapsible({ expanded: false })
+    const markup = renderToStaticMarkup(instance.render())
+    expect(markup).not.toContain('This is inner content')
+    expect(markup).not.toContain('id="submit"')
   })
 
-  it('should show content when expanded', () => {
-    const wrapper = mount(
-      <Collapsible name='test' title='title' expanded readOnly={false} onToggle={noop} onDelete={noop} onEdit={noop} onSubmit={noop}>
-        <Content onSubmit={noop} />
-      </Collapsible>
-    )
-
-    expect(wrapper.find('button#submit').length).toBe(1)
+  it('shows content when expanded', () => {
+    const instance = makeCollapsible({ expanded: true, readOnly: false })
+    const markup = renderToStaticMarkup(instance.render())
+    expect(markup).toContain('This is inner content')
+    expect(markup).toContain('id="submit"')
   })
 
-  it('should show Edit button when readOnly', () => {
-    const wrapper = shallow(
-      <Collapsible name='test' title='title' expanded readOnly onToggle={noop} onDelete={noop} onEdit={noop} onSubmit={noop}>
-        <Content onSubmit={noop} />
-      </Collapsible>
-    )
-    expect(wrapper.find('#edit-test').length).toBe(1)
+  it('shows Edit button when readOnly', () => {
+    const instance = makeCollapsible({ expanded: true, readOnly: true })
+    const markup = renderToStaticMarkup(instance.render())
+    expect(markup).toContain('id="edit-test"')
   })
 
-  it('should not show Edit button when readOnly is false', () => {
-    const wrapper = shallow(
-      <Collapsible name='test' title='title' expanded readOnly={false} onToggle={noop} onDelete={noop} onEdit={noop} onSubmit={noop}>
-        <Content onSubmit={noop} />
-      </Collapsible>
-    )
-    expect(wrapper.find('#edit-test').length).toBe(0)
+  it('does not show Edit button when readOnly is false', () => {
+    const instance = makeCollapsible({ expanded: true, readOnly: false })
+    const markup = renderToStaticMarkup(instance.render())
+    expect(markup).not.toContain('id="edit-test"')
   })
 
-  it('should fire edit function', () => {
-    const jestFn = jest.fn()
-    const wrapper = shallow(
-      <Collapsible name='test' title='title' expanded readOnly onToggle={noop} onDelete={noop} onEdit={jestFn} onSubmit={noop}>
-        <Content onSubmit={noop} />
-      </Collapsible>
-    )
-    click(wrapper.find('#edit-test'), { stopPropagation: noop })
-    expect(jestFn).toHaveBeenCalled()
+  it('fires edit function', () => {
+    const onEdit = jest.fn()
+    const instance = makeCollapsible({ onEdit })
+    const event = { stopPropagation: jest.fn() }
+    instance.handleEdit(event)
+    expect(event.stopPropagation).toHaveBeenCalled()
+    expect(onEdit).toHaveBeenCalledWith('test')
   })
 
-  it('should fire delete function', () => {
-    const jestFn = jest.fn()
-    const wrapper = shallow(
-      <Collapsible name='test' title='title' expanded readOnly onToggle={noop} onDelete={jestFn} onEdit={noop} onSubmit={noop}>
-        <Content onSubmit={noop} />
-      </Collapsible>
-    )
-    click(wrapper.find('#delete-test'), { stopPropagation: noop })
-    expect(jestFn).toHaveBeenCalled()
+  it('fires delete function', () => {
+    const item = { id: 7 }
+    const onDelete = jest.fn()
+    const instance = makeCollapsible({ item, onDelete })
+    const event = { stopPropagation: jest.fn() }
+    instance.handleDelete(event)
+    expect(event.stopPropagation).toHaveBeenCalled()
+    expect(onDelete).toHaveBeenCalledWith(item)
   })
 
-  it('should fire onToggle function', () => {
-    const jestFn = jest.fn()
-    const wrapper = shallow(
-      <Collapsible name='test' title='title' expanded readOnly onToggle={jestFn} onDelete={noop} onEdit={noop} onSubmit={noop}>
-        <Content onSubmit={noop} />
-      </Collapsible>
-    )
-    click(wrapper.find('div.collapsible-title'))
-    expect(jestFn).toHaveBeenCalled()
+  it('fires onToggle function', () => {
+    const onToggle = jest.fn()
+    const instance = makeCollapsible({ expanded: true, onToggle })
+    const titleNode = visitElements(
+      instance.render(),
+      element => typeof element.props.className === 'string' && element.props.className.includes('collapsible-title')
+    )[0]
+
+    titleNode.props.onClick()
+    expect(onToggle).toHaveBeenCalledWith('test')
   })
 
-  it('should fire submit function', () => {
-    const jestFn = jest.fn()
-    const wrapper = mount(
-      <Collapsible name='test' title='title' expanded readOnly onToggle={noop} onDelete={noop} onEdit={noop} onSubmit={jestFn}>
-        <Content onSubmit={noop} />
-      </Collapsible>
-    )
-    click(wrapper.find('#submit'), { stopPropagation: noop })
-    expect(jestFn).toHaveBeenCalled()
+  it('fires submit function and forwards values to the child submit handler', () => {
+    const onSubmit = jest.fn()
+    const childSubmit = jest.fn()
+    const instance = makeCollapsible({
+      expanded: true,
+      onSubmit,
+      children: <Content onSubmit={childSubmit} />
+    })
+
+    const child = visitElements(instance.render(), element => element.type === Content)[0]
+    child.props.onSubmit('done')
+
+    expect(onSubmit).toHaveBeenCalledWith('test')
+    expect(childSubmit).toHaveBeenCalledWith('done')
   })
 
-  it('should expand and set readonly false when edit is clicked', () => {
-    const wrapper = mount(
-      <CollapsibleList>
-        <Collapsible name='test' title='title'>
-          <Content onSubmit={noop} />
-        </Collapsible>
-      </CollapsibleList>
-    )
-    click(wrapper.find('#edit-test'), { stopPropagation: noop })
+  it('expands and clears readOnly when edit is clicked in CollapsibleList', () => {
+    const child = <Collapsible name='test' title='title'><Content onSubmit={noop} /></Collapsible>
+    const list = makeCollapsibleList(child)
+
+    expect(list.state.expanded.test).toBe(false)
+    expect(list.state.readOnly.test).toBe(true)
+
+    list.onEdit('test')
+    expect(list.state.expanded.test).toBe(true)
+    expect(list.state.readOnly.test).toBe(false)
   })
 
-  it('should add new panel as collapsed', () => {
-    const wrapper = mount(
-      <CollapsibleList>
-        <Collapsible name='test' title='title'>
-          <Content onSubmit={noop} />
-        </Collapsible>
-      </CollapsibleList>
-    )
-    wrapper.setProps({ children: [<Collapsible name='another'><div /></Collapsible>] })
+  it('adds a new panel as collapsed', () => {
+    const initialChild = <Collapsible name='test' title='title'><Content onSubmit={noop} /></Collapsible>
+    const state = makeCollapsibleList(initialChild).state
+    const nextChildren = [<Collapsible key='another' name='another' title='another'><div /></Collapsible>]
 
-    const expanded = wrapper.state('expanded')
-    expect(expanded.another).toBe(false)
+    const derived = CollapsibleList.getDerivedStateFromProps({ children: nextChildren }, state)
+    expect(derived.expanded.another).toBe(false)
+    expect(derived.readOnly.another).toBe(true)
   })
 })

--- a/front-end/src/ui_components/collapsible_list.test.js
+++ b/front-end/src/ui_components/collapsible_list.test.js
@@ -1,139 +1,91 @@
 import React from 'react'
-import { mount } from 'enzyme'
 import CollapsibleList from './collapsible_list'
-
 
 const Item = (props) => <div name={props.name}>{props.name}</div>
 
 describe('CollapsibleList', () => {
+  const makeList = (children) => {
+    const instance = new CollapsibleList({ children })
+    instance.setState = update => {
+      const next = typeof update === 'function' ? update(instance.state, instance.props) : update
+      instance.state = { ...instance.state, ...next }
+    }
+    return instance
+  }
+
+  const renderedChildren = (instance) => React.Children.toArray(instance.render().props.children)
+
   it('renders children', () => {
-    const wrapper = mount(
-      <CollapsibleList>
-        <Item name='a' />
-        <Item name='b' />
-      </CollapsibleList>
-    )
-    expect(wrapper.find(Item)).toHaveLength(2)
+    const list = makeList([
+      <Item key='a' name='a' />,
+      <Item key='b' name='b' />
+    ])
+    expect(renderedChildren(list)).toHaveLength(2)
   })
 
   it('starts collapsed (expanded false) for items without defaultOpen', () => {
-    const wrapper = mount(
-      <CollapsibleList>
-        <Item name='x' />
-      </CollapsibleList>
-    )
-    expect(wrapper.state('expanded').x).toBe(false)
+    const list = makeList(<Item name='x' />)
+    expect(list.state.expanded.x).toBe(false)
   })
 
   it('starts expanded for items with defaultOpen', () => {
-    const wrapper = mount(
-      <CollapsibleList>
-        <Item name='y' defaultOpen />
-      </CollapsibleList>
-    )
-    expect(wrapper.state('expanded').y).toBe(true)
+    const list = makeList(<Item name='y' defaultOpen />)
+    expect(list.state.expanded.y).toBe(true)
   })
 
   it('starts readOnly for all items', () => {
-    const wrapper = mount(
-      <CollapsibleList>
-        <Item name='z' />
-      </CollapsibleList>
-    )
-    expect(wrapper.state('readOnly').z).toBe(true)
+    const list = makeList(<Item name='z' />)
+    expect(list.state.readOnly.z).toBe(true)
   })
 
   it('onToggle toggles expanded state when readOnly', () => {
-    const wrapper = mount(
-      <CollapsibleList>
-        <Item name='t' />
-      </CollapsibleList>
-    )
-    React.act(() => {
-      wrapper.instance().onToggle('t')
-    })
-    wrapper.update()
-    expect(wrapper.state('expanded').t).toBe(true)
-    React.act(() => {
-      wrapper.instance().onToggle('t')
-    })
-    wrapper.update()
-    expect(wrapper.state('expanded').t).toBe(false)
+    const list = makeList(<Item name='t' />)
+    list.onToggle('t')
+    expect(list.state.expanded.t).toBe(true)
+    list.onToggle('t')
+    expect(list.state.expanded.t).toBe(false)
   })
 
   it('onToggle does not toggle when not readOnly (editing)', () => {
-    const wrapper = mount(
-      <CollapsibleList>
-        <Item name='e' />
-      </CollapsibleList>
-    )
-    React.act(() => {
-      wrapper.instance().onEdit('e')
-    })
-    wrapper.update()
-    expect(wrapper.state('readOnly').e).toBe(false)
-    React.act(() => {
-      wrapper.instance().onToggle('e')
-    })
-    wrapper.update()
-    // Still expanded because editing prevents toggle
-    expect(wrapper.state('expanded').e).toBe(true)
+    const list = makeList(<Item name='e' />)
+    list.onEdit('e')
+    expect(list.state.readOnly.e).toBe(false)
+    list.onToggle('e')
+    expect(list.state.expanded.e).toBe(true)
   })
 
   it('onEdit expands and sets readOnly to false', () => {
-    const wrapper = mount(
-      <CollapsibleList>
-        <Item name='ed' />
-      </CollapsibleList>
-    )
-    React.act(() => {
-      wrapper.instance().onEdit('ed')
-    })
-    wrapper.update()
-    expect(wrapper.state('expanded').ed).toBe(true)
-    expect(wrapper.state('readOnly').ed).toBe(false)
+    const list = makeList(<Item name='ed' />)
+    list.onEdit('ed')
+    expect(list.state.expanded.ed).toBe(true)
+    expect(list.state.readOnly.ed).toBe(false)
   })
 
   it('onSubmit collapses and sets readOnly to true', () => {
-    const wrapper = mount(
-      <CollapsibleList>
-        <Item name='s' />
-      </CollapsibleList>
-    )
-    React.act(() => {
-      wrapper.instance().onEdit('s')
-    })
-    wrapper.update()
-    React.act(() => {
-      wrapper.instance().onSubmit('s')
-    })
-    wrapper.update()
-    expect(wrapper.state('expanded').s).toBe(false)
-    expect(wrapper.state('readOnly').s).toBe(true)
+    const list = makeList(<Item name='s' />)
+    list.onEdit('s')
+    list.onSubmit('s')
+    expect(list.state.expanded.s).toBe(false)
+    expect(list.state.readOnly.s).toBe(true)
   })
 
   it('getDerivedStateFromProps adds new child as collapsed', () => {
-    const wrapper = mount(
-      <CollapsibleList>
-        <Item name='first' />
-      </CollapsibleList>
+    const initial = makeList(<Item name='first' />)
+    const derived = CollapsibleList.getDerivedStateFromProps(
+      { children: [<Item key='new' name='new' />] },
+      initial.state
     )
-    wrapper.setProps({ children: [<Item key='new' name='new' />] })
-    expect(wrapper.state('expanded').new).toBe(false)
-    expect(wrapper.state('readOnly').new).toBe(true)
+    expect(derived.expanded.new).toBe(false)
+    expect(derived.readOnly.new).toBe(true)
   })
 
   it('passes expanded, readOnly, onToggle, onEdit, onSubmit to children', () => {
-    const wrapper = mount(
-      <CollapsibleList>
-        <Item name='p' />
-      </CollapsibleList>
-    )
-    const child = wrapper.find(Item).first()
-    expect(child.prop('expanded')).toBeDefined()
-    expect(child.prop('readOnly')).toBeDefined()
-    expect(typeof child.prop('onToggle')).toBe('function')
-    expect(typeof child.prop('onEdit')).toBe('function')
-    expect(typeof child.prop('onSubmit')).toBe('function')
+    const list = makeList(<Item name='p' />)
+    const child = renderedChildren(list)[0]
+    expect(child.props.expanded).toBeDefined()
+    expect(child.props.readOnly).toBeDefined()
+    expect(typeof child.props.onToggle).toBe('function')
+    expect(typeof child.props.onEdit).toBe('function')
+    expect(typeof child.props.onSubmit).toBe('function')
   })
 })


### PR DESCRIPTION
## Summary
- fix the React 19 telemetry and collapsible test cluster on top of fresh main
- fix three small wrapper-based test files that still failed after the merged runtime and Jest updates
- keep this slice focused on currently failing tests that are still unshipped after the fresh-main reassessment

## Included commits
- a750af7a 
- 20799c74 

## Validation
- yarn run v1.22.22
$ cross-env NODE_ENV=testing jest --env=jsdom front-end/src/ui_components/collapsible.test.js front-end/src/telemetry/telmetry.test.js --runInBand
Done in 4.70s.
- yarn run v1.22.22
$ cross-env NODE_ENV=testing jest --env=jsdom front-end/src/ui_components/collapsible_list.test.js --runInBand
Done in 2.77s.
- yarn run v1.22.22
$ cross-env NODE_ENV=testing jest --env=jsdom front-end/src/ui_components/boolean_select.test.js --runInBand
Done in 2.33s.
- yarn run v1.22.22
$ cross-env NODE_ENV=testing jest --env=jsdom front-end/src/drivers/edit_driver.test.js --runInBand
Done in 2.45s.

## Notes
- The branch also preserves the saved older Slice 22 stash locally, but that stash is not part of this PR.
- Local untracked aider helper files were intentionally excluded from the PR.
