### PR TITLE
[codex] Reduce React 19 test noise in dashboard and settings flows

### DIFF
--- a/front-end/src/configuration/configuration.test.js
+++ b/front-end/src/configuration/configuration.test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { act } from 'react'
 import { shallow, mount } from 'enzyme'
 import { Provider } from 'react-redux'
 import configureMockStore from 'redux-mock-store'
@@ -38,6 +38,18 @@ const fullSettings = {
 }
 
 describe('Configuration ui', () => {
+  const click = (node, event = {}) => {
+    act(() => {
+      node.prop('onClick')(event)
+    })
+  }
+
+  const change = (node, event) => {
+    act(() => {
+      node.prop('onChange')(event)
+    })
+  }
+
   afterEach(() => {
     fetchMock.reset()
     fetchMock.restore()
@@ -73,8 +85,8 @@ describe('Configuration ui', () => {
     fetchMock.post('/api/display', {})
     const store = mockStore({ display: { brightness: 50, on: true } })
     const wrapper = mount(<Provider store={store}><Display /></Provider>)
-    wrapper.find('button').simulate('click')
-    wrapper.find('input[type="range"]').simulate('change', { target: { value: '100' } })
+    click(wrapper.find('button').first())
+    change(wrapper.find('input[type="range"]'), { target: { value: '100' } })
     wrapper.unmount()
   })
 
@@ -136,7 +148,7 @@ describe('Configuration ui', () => {
     fetchMock.post('/api/settings', fullSettings)
     const store = mockStore({ settings: fullSettings, capabilities: fullCapabilities })
     const wrapper = mount(<Provider store={store}><Settings /></Provider>)
-    wrapper.find('#systemUpdateSettings').simulate('click')
+    click(wrapper.find('#systemUpdateSettings'))
     wrapper.unmount()
   })
 
@@ -144,7 +156,7 @@ describe('Configuration ui', () => {
     fetchMock.get('/api/settings', {})
     const store = mockStore({ settings: fullSettings, capabilities: fullCapabilities })
     const wrapper = mount(<Provider store={store}><Settings /></Provider>)
-    wrapper.find('#to-row-address').simulate('change', { target: { value: 'localhost:9090' } })
+    change(wrapper.find('#to-row-address'), { target: { value: 'localhost:9090' } })
     wrapper.unmount()
   })
 
@@ -152,7 +164,7 @@ describe('Configuration ui', () => {
     fetchMock.get('/api/settings', {})
     const store = mockStore({ settings: fullSettings, capabilities: fullCapabilities })
     const wrapper = mount(<Provider store={store}><Settings /></Provider>)
-    wrapper.find('#to-row-name').simulate('change', { target: { value: 'new-name' } })
+    change(wrapper.find('#to-row-name'), { target: { value: 'new-name' } })
     wrapper.unmount()
   })
 
@@ -161,7 +173,7 @@ describe('Configuration ui', () => {
     const s = { ...fullSettings, address: 'localhost:80', https: false }
     const store = mockStore({ settings: s, capabilities: fullCapabilities })
     const wrapper = mount(<Provider store={store}><Settings /></Provider>)
-    wrapper.find('a.dropdown-item').last().simulate('click')
+    click(wrapper.find('a.dropdown-item').last(), { preventDefault: () => {} })
     wrapper.unmount()
   })
 
@@ -170,7 +182,7 @@ describe('Configuration ui', () => {
     const s = { ...fullSettings, address: 'localhost:443', https: true }
     const store = mockStore({ settings: s, capabilities: fullCapabilities })
     const wrapper = mount(<Provider store={store}><Settings /></Provider>)
-    wrapper.find('a.dropdown-item').first().simulate('click')
+    click(wrapper.find('a.dropdown-item').first(), { preventDefault: () => {} })
     wrapper.unmount()
   })
 
@@ -179,7 +191,7 @@ describe('Configuration ui', () => {
     const s = { ...fullSettings, address: 'localhost:8080', https: false }
     const store = mockStore({ settings: s, capabilities: fullCapabilities })
     const wrapper = mount(<Provider store={store}><Settings /></Provider>)
-    wrapper.find('a.dropdown-item').last().simulate('click')
+    click(wrapper.find('a.dropdown-item').last(), { preventDefault: () => {} })
     wrapper.unmount()
   })
 
@@ -187,7 +199,7 @@ describe('Configuration ui', () => {
     fetchMock.get('/api/settings', {})
     const store = mockStore({ settings: fullSettings, capabilities: fullCapabilities })
     const wrapper = mount(<Provider store={store}><Settings /></Provider>)
-    wrapper.find('#notification').simulate('change', { target: { checked: true } })
+    change(wrapper.find('#notification'), { target: { checked: true } })
     wrapper.unmount()
   })
 
@@ -228,7 +240,7 @@ describe('Configuration ui', () => {
     ]
     const store = mockStore({ errors: errs })
     const wrapper = mount(<Provider store={store}><Errors /></Provider>)
-    wrapper.find('button').simulate('click')
+    click(wrapper.find('button').first())
     wrapper.unmount()
   })
 
@@ -246,7 +258,7 @@ describe('Configuration ui', () => {
     const errs = [{ id: '1', time: '2026-04-18', message: 'err', count: 1 }]
     const store = mockStore({ errors: errs })
     const wrapper = mount(<Provider store={store}><Errors /></Provider>)
-    wrapper.find('input.btn-outline-secondary').simulate('click')
+    click(wrapper.find('input.btn-outline-secondary'))
     wrapper.unmount()
   })
 })

--- a/front-end/src/dashboard/dashboard.test.js
+++ b/front-end/src/dashboard/dashboard.test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { act } from 'react'
 import ComponentSelector from './component_selector'
 import Config from './config'
 import { shallow, mount } from 'enzyme'
@@ -15,18 +15,30 @@ const mockStore = configureMockStore([thunk])
 // Minimal store state so connected child components don't crash
 const childState = {
   equipment: [],
-  ato: [],
+  atos: [],
   dosers: [],
-  journal: [],
+  journals: [],
   lights: [],
-  ph: [],
-  temperature: [],
+  light_usage: {},
+  ato_usage: {},
+  doser_usage: {},
+  journal_usage: {},
+  phprobes: [],
+  ph_readings: {},
+  tcs: [],
+  tc_usage: {},
   sensors: [],
-  health: {},
+  health_stats: {},
   readings: []
 }
 
 describe('Dashboard', () => {
+  const click = (node, event = {}) => {
+    act(() => {
+      node.prop('onClick')(event)
+    })
+  }
+
   afterEach(() => {
     fetchMock.reset()
     fetchMock.restore()
@@ -52,11 +64,14 @@ describe('Dashboard', () => {
   it('<Main /> renders all chart types (switch coverage)', () => {
     fetchMock.get('/api/dashboard', {})
     fetchMock.get('/api/equipment', [])
-    fetchMock.get('/api/ato', [])
-    fetchMock.get('/api/dosers', [])
+    fetchMock.get('/api/atos/1/usage', { historical: [] })
+    fetchMock.get('/api/doser/pumps/1/usage', { historical: [] })
+    fetchMock.get('/api/journal/1/usage', { historical: [] })
+    fetchMock.get('/api/lights/1/usage', { current: [] })
+    fetchMock.get('/api/phprobes/1/readings', { current: [], historical: [] })
+    fetchMock.get('/api/tcs/1/usage', { current: [], historical: [] })
+    fetchMock.get('/api/health_stats', {})
     fetchMock.get('/api/lights', [])
-    fetchMock.get('/api/ph/probes', [])
-    fetchMock.get('/api/temperature/sensors', [])
     fetchMock.get('/api/health', {})
     const config = {
       row: 3,
@@ -84,7 +99,22 @@ describe('Dashboard', () => {
         ]
       ]
     }
-    const store = mockStore({ ...childState, dashboard: config })
+    const store = mockStore({
+      ...childState,
+      atos: [{ id: '1', name: 'ATO 1' }],
+      dosers: [{ id: '1', name: 'Doser 1' }],
+      journals: [{ id: '1', name: 'Journal 1', unit: 'ml' }],
+      lights: [{ id: '1', name: 'Light 1', channels: { blue: { name: 'Blue', color: '#00f' } } }],
+      light_usage: { 1: { current: [] } },
+      ato_usage: { 1: { historical: [] } },
+      phprobes: [{ id: '1', name: 'PH 1', chart: { color: '#00f', ymin: 0, ymax: 14, unit: 'pH' }, notify: { enable: false, min: 0, max: 0 } }],
+      journal_usage: { 1: { historical: [] } },
+      ph_readings: { 1: { current: [], historical: [] } },
+      doser_usage: { 1: { historical: [] } },
+      tcs: [{ id: '1', name: 'Temp 1', chart: { color: '#f00', ymin: 70, ymax: 90 }, fahrenheit: true }],
+      tc_usage: { 1: { current: [], historical: [] } },
+      dashboard: config
+    })
     const wrapper = mount(<Provider store={store}><Main /></Provider>)
     expect(wrapper).toBeDefined()
     wrapper.unmount()
@@ -92,6 +122,7 @@ describe('Dashboard', () => {
 
   it('<Main /> renders temp_historical and default unknown types', () => {
     fetchMock.get('/api/dashboard', {})
+    fetchMock.get('/api/tcs/1/usage', { current: [], historical: [] })
     const config = {
       row: 1,
       column: 2,
@@ -101,7 +132,12 @@ describe('Dashboard', () => {
         [{ type: 'temp_historical', id: '1' }, { type: 'unknown_widget', id: '1' }]
       ]
     }
-    const store = mockStore({ ...childState, dashboard: config })
+    const store = mockStore({
+      ...childState,
+      tcs: [{ id: '1', name: 'Temp 1', chart: { color: '#f00', ymin: 70, ymax: 90 }, fahrenheit: true }],
+      tc_usage: { 1: { current: [], historical: [] } },
+      dashboard: config
+    })
     const wrapper = mount(<Provider store={store}><Main /></Provider>)
     expect(wrapper).toBeDefined()
     wrapper.unmount()
@@ -112,7 +148,7 @@ describe('Dashboard', () => {
     const config = { row: 1, column: 1, width: 400, height: 200, grid_details: [[]] }
     const store = mockStore({ ...childState, dashboard: config })
     const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    wrapper.find('#configure-dashboard').simulate('click')
+    click(wrapper.find('#configure-dashboard'))
     expect(wrapper).toBeDefined()
     wrapper.unmount()
   })

--- a/front-end/src/instances/instances.test.js
+++ b/front-end/src/instances/instances.test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { act } from 'react'
 import { shallow, mount } from 'enzyme'
 import { Provider } from 'react-redux'
 import fetchMock from 'fetch-mock'
@@ -20,6 +20,12 @@ const instanceData = { id: '1', name: 'Remote Tank', address: 'http://192.168.1.
 const fn = jest.fn()
 
 describe('Instances Main', () => {
+  const click = (node, event = {}) => {
+    act(() => {
+      node.prop('onClick')(event)
+    })
+  }
+
   afterEach(() => {
     fetchMock.reset()
     fetchMock.restore()
@@ -45,8 +51,8 @@ describe('Instances Main', () => {
     fetchMock.get('/api/instances', [])
     const store = mockStore({ instances: [] })
     const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    wrapper.find('#add_instance').simulate('click')
-    wrapper.find('#add_instance').simulate('click')
+    click(wrapper.find('#add_instance'))
+    click(wrapper.find('#add_instance'))
     wrapper.unmount()
   })
 })

--- a/front-end/src/telemetry/telmetry.test.js
+++ b/front-end/src/telemetry/telmetry.test.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { act } from 'react'
 import { shallow, mount } from 'enzyme'
 import { Provider } from 'react-redux'
 import configureMockStore from 'redux-mock-store'
@@ -29,6 +29,18 @@ const fullTelemetry = {
 }
 
 describe('Telemetry UI', () => {
+  const click = (node, event = {}) => {
+    act(() => {
+      node.prop('onClick')(event)
+    })
+  }
+
+  const change = (node, event) => {
+    act(() => {
+      node.prop('onChange')(event)
+    })
+  }
+
   afterEach(() => {
     fetchMock.reset()
     fetchMock.restore()
@@ -83,7 +95,7 @@ describe('Telemetry UI', () => {
     fetchMock.post('/api/telemetry', fullTelemetry)
     const store = mockStore({ telemetry: fullTelemetry })
     const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    wrapper.find('#updateTelemetry').simulate('click')
+    click(wrapper.find('#updateTelemetry'))
     wrapper.unmount()
   })
 
@@ -92,7 +104,7 @@ describe('Telemetry UI', () => {
     const badAio = { ...fullTelemetry, adafruitio: { enable: true, user: '', token: '' } }
     const store = mockStore({ telemetry: badAio })
     const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    wrapper.find('#updateTelemetry').simulate('click')
+    click(wrapper.find('#updateTelemetry'))
     wrapper.unmount()
   })
 
@@ -100,7 +112,7 @@ describe('Telemetry UI', () => {
     fetchMock.get('/api/telemetry', {})
     const store = mockStore({ telemetry: fullTelemetry })
     const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    wrapper.find('#enable-mailer').simulate('click', { target: { checked: false } })
+    click(wrapper.find('#enable-mailer'), { target: { checked: false } })
     wrapper.unmount()
   })
 
@@ -108,7 +120,7 @@ describe('Telemetry UI', () => {
     fetchMock.get('/api/telemetry', {})
     const store = mockStore({ telemetry: fullTelemetry })
     const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    wrapper.find('#updateCurrentLimit').simulate('change', { target: { value: '50' } })
+    change(wrapper.find('#updateCurrentLimit'), { target: { value: '50' } })
     wrapper.unmount()
   })
 


### PR DESCRIPTION
## Summary
- replace unsupported Enzyme `simulate(...)` calls in configuration, dashboard, instances, and telemetry tests with direct handler invocation wrapped in `act()`
- align the dashboard test fixture with the real Redux reducer shape so connected chart components mount cleanly under React 19
- stub the remaining background usage and health fetches that fire during dashboard mounts

## Validation
- `rtk yarn jest front-end/src/dashboard/dashboard.test.js front-end/src/configuration/configuration.test.js front-end/src/instances/instances.test.js front-end/src/telemetry/telmetry.test.js --runInBand`
- `rtk yarn jest --runInBand`

## Notes
- This is an incremental React 19 test-cleanup slice. Remaining Enzyme/Formik warning surfaces can continue in follow-up PRs without widening this one.