### PR TITLE
Fix additional React 19 frontend test tails

### DIFF
--- a/front-end/src/ato/edit_ato.test.js
+++ b/front-end/src/ato/edit_ato.test.js
@@ -1,72 +1,116 @@
 import React from 'react'
-import { shallow } from 'enzyme'
 import EditAto from './edit_ato'
 import 'isomorphic-fetch'
 import * as Alert from '../utils/alert'
 
+const findFieldByName = (node, name) => {
+  if (!node || typeof node !== 'object') {
+    return null
+  }
+
+  if (node.props && node.props.name === name) {
+    return node
+  }
+
+  const children = React.Children.toArray(node.props?.children)
+  for (const child of children) {
+    const found = findFieldByName(child, name)
+    if (found) {
+      return found
+    }
+  }
+
+  return null
+}
 
 describe('<EditAto />', () => {
-  let values = {}
-  let inlets = [{ id: '1', name: 'inlet 1' }]
-  let equipment = [{ id: '1', name: 'EQ' }]
-  let fn = jest.fn()
+  const inlets = [{ id: '1', name: 'inlet 1' }]
+  const equipment = [{ id: '1', name: 'EQ' }]
+  const submitForm = jest.fn()
+
+  const baseValues = {
+    id: '',
+    name: 'ATO 1',
+    inlet: '1',
+    period: 10,
+    debounce: 1,
+    enable: true,
+    control: '',
+    pump: '',
+    one_shot: false,
+    notify: true,
+    maxAlert: 120,
+    disable_on_alert: false
+  }
+
+  const renderComponent = (props = {}) =>
+    EditAto({
+      values: baseValues,
+      errors: {},
+      touched: {},
+      inlets,
+      equipment,
+      macros: [],
+      handleBlur: jest.fn(),
+      handleChange: jest.fn(),
+      submitForm,
+      isValid: true,
+      dirty: true,
+      readOnly: false,
+      ...props
+    })
 
   beforeEach(() => {
     jest.spyOn(Alert, 'showError')
+    jest.spyOn(Alert, 'showUpdateSuccessful')
   })
 
   afterEach(() => {
     jest.clearAllMocks()
   })
 
-  it('<EditAto />', () => {
-    shallow(
-      <EditAto
-        values={values}
-        inlets={inlets}
-        equipment={equipment}
-        handleBlur={fn}
-        handleChange={fn}
-        submitForm={fn}
-      />
-    )
+  it('renders a form', () => {
+    const element = renderComponent()
+
+    expect(element.type).toBe('form')
+    expect(findFieldByName(element, 'name')).not.toBeNull()
+    expect(findFieldByName(element, 'inlet')).not.toBeNull()
   })
 
-  it('<EditATO /> should submit', () => {
-    const wrapper = shallow(
-      <EditAto
-        values={values}
-        inlets={inlets}
-        equipment={equipment}
-        handleBlur={fn}
-        handleChange={fn}
-        submitForm={fn}
-        dirty
-        isValid
-        showChart={false}
-      />
-    )
-    wrapper.find('form').simulate('submit', { preventDefault: () => {} })
+  it('submits when valid', () => {
+    const element = renderComponent({ dirty: true, isValid: true })
+
+    element.props.onSubmit({ preventDefault: jest.fn() })
+
+    expect(submitForm).toHaveBeenCalled()
+    expect(Alert.showUpdateSuccessful).toHaveBeenCalled()
     expect(Alert.showError).not.toHaveBeenCalled()
   })
 
-  it('<EditAto /> should show alert when invalid', () => {
-    values.name = ''
-    values.fahrenheit = false
-    const wrapper = shallow(
-      <EditAto
-        values={values}
-        inlets={inlets}
-        equipment={equipment}
-        handleBlur={fn}
-        handleChange={fn}
-        submitForm={fn}
-        showChart
-        dirty
-        isValid={false}
-      />
-    )
-    wrapper.find('form').simulate('submit', { preventDefault: () => {} })
+  it('shows an alert when invalid', () => {
+    const element = renderComponent({
+      values: { ...baseValues, name: '' },
+      dirty: true,
+      isValid: false
+    })
+
+    element.props.onSubmit({ preventDefault: jest.fn() })
+
+    expect(submitForm).toHaveBeenCalled()
     expect(Alert.showError).toHaveBeenCalled()
+    expect(Alert.showUpdateSuccessful).not.toHaveBeenCalled()
+  })
+
+  it('disables the pump selector until a control target is chosen', () => {
+    const element = renderComponent()
+    const pumpField = findFieldByName(element, 'pump')
+
+    expect(pumpField.props.disabled).toBe(true)
+
+    const withControl = renderComponent({
+      values: { ...baseValues, control: 'equipment' }
+    })
+
+    expect(findFieldByName(withControl, 'pump').props.disabled).toBe(false)
   })
 })

--- a/front-end/src/camera/camera.test.js
+++ b/front-end/src/camera/camera.test.js
@@ -1,88 +1,119 @@
 import React from 'react'
-import { shallow, mount } from 'enzyme'
-import { Provider } from 'react-redux'
-import Main from './main'
-import Capture from './capture'
+import { RawCamera } from './main'
+import { RawCapture } from './capture'
 import Config from './config'
 import Gallery from './gallery'
 import Motion from './motion'
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
 import fetchMock from 'fetch-mock'
 import 'isomorphic-fetch'
-
-const mockStore = configureMockStore([thunk])
+import * as Alert from '../utils/alert'
 
 const cameraState = {
   camera: { config: { tick_interval: 60, enable: false }, images: [{ name: 'foo.jpg' }, { name: 'bar.jpg' }] }
+}
+
+const countByType = (node, predicate) => {
+  if (!node || typeof node !== 'object') {
+    return 0
+  }
+  let count = predicate(node) ? 1 : 0
+  React.Children.toArray(node.props?.children).forEach(child => {
+    count += countByType(child, predicate)
+  })
+  return count
 }
 
 describe('Camera module', () => {
   afterEach(() => {
     fetchMock.reset()
     fetchMock.restore()
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
   })
 
   it('<Main /> mounts with images', () => {
-    fetchMock.get('/api/camera/config', cameraState.camera.config)
-    fetchMock.get('/api/camera/images', cameraState.camera.images)
-    fetchMock.get('/api/camera/latest', '')
-    const store = mockStore(cameraState)
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+    const fetchConfig = jest.fn()
+    const listImages = jest.fn()
+    const updateConfig = jest.fn()
+    const camera = new RawCamera({
+      config: cameraState.camera.config,
+      images: cameraState.camera.images,
+      fetchConfig,
+      listImages,
+      updateConfig
+    })
+
+    camera.componentDidMount()
+    expect(fetchConfig).toHaveBeenCalled()
+    expect(listImages).toHaveBeenCalled()
+
+    const rendered = camera.render()
+    expect(rendered.type).toBe('div')
   })
 
   it('<Main /> mounts with empty state', () => {
-    fetchMock.get('/api/camera/config', {})
-    fetchMock.get('/api/camera/images', [])
-    fetchMock.get('/api/camera/latest', '')
-    const store = mockStore({ camera: { config: {}, images: [] } })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+    const camera = new RawCamera({
+      config: {},
+      images: [],
+      fetchConfig: jest.fn(),
+      listImages: jest.fn(),
+      updateConfig: jest.fn()
+    })
+
+    expect(() => camera.render()).not.toThrow()
   })
 
   it('<Capture />', () => {
-    const d = shallow(<Capture store={mockStore({ camera: { latest: '' } })} />)
-      .dive()
-      .instance()
+    const getLatestImage = jest.fn()
+    const capture = new RawCapture({ latest: '', getLatestImage, takeImage: jest.fn() })
+
+    capture.componentDidMount()
+    expect(getLatestImage).toHaveBeenCalled()
+    expect(capture.render().type).toBe('div')
   })
 
   it('<Config />', () => {
-    let m = shallow(<Config config={{ tick_interval: 1 }} update={() => {}} />)
-    m.instance().updateBool('enable')({ target: { checked: true } })
-    m.instance().updateText('bar')({ target: {} })
-    m.update()
-    m.instance().handleSave()
-    m = m.instance()
-    m.state.config.tick_interval = 'foo'
-    m.handleSave()
+    jest.spyOn(Alert, 'showError')
+    const update = jest.fn()
+    const config = new Config({ config: { tick_interval: 1 }, update })
+    config.setState = jest.fn(next => {
+      config.state = { ...config.state, ...next }
+    })
+
+    config.updateBool('enable')({ target: { checked: true } })
+    config.updateText('bar')({ target: { value: 'baz' } })
+    config.handleSave()
+    expect(update).toHaveBeenCalled()
+
+    config.state.config.tick_interval = 'foo'
+    config.handleSave()
+    expect(Alert.showError).toHaveBeenCalled()
   })
 
   it('<Gallery />', () => {
     const images = [{ thumbnail: '', src: '' }]
-    const ev = {
-      preventDefault: () => true
-    }
-    const wrapper = shallow(<Gallery images={images} />)
-    wrapper
-      .find('a')
-      .first()
-      .simulate('click', ev)
-    const m = wrapper.instance()
+    const gallery = new Gallery({ images })
+    gallery.setState = jest.fn(next => {
+      gallery.state = { ...gallery.state, ...next }
+    })
+    const ev = { preventDefault: jest.fn() }
 
-    m.handleClose()
-    m.handleGotoPrevious()
-    m.handleGotoNext()
-    m.handleGotoImage(0)
-    m.handleOnClick()
-    m.state.current = -1
-    m.handleOnClick()
-    shallow(<Gallery />).instance()
+    gallery.open(0, ev)
+    expect(ev.preventDefault).toHaveBeenCalled()
+    gallery.handleClose()
+    gallery.handleGotoPrevious()
+    gallery.handleGotoNext()
+    gallery.handleGotoImage(0)
+    gallery.handleOnClick()
+    gallery.state.current = -1
+    gallery.handleOnClick()
+    expect(() => new Gallery({}).render()).not.toThrow()
   })
 
   it('<Motion />', () => {
-    shallow(<Motion url='/foo' width={300} height={600} />)
+    const motion = new Motion({ url: '/foo', width: 300, height: 600 })
+    const rendered = motion.render()
+    expect(rendered.type).toBe('div')
+    expect(countByType(rendered, node => node.type === 'img')).toBe(1)
   })
 })

--- a/front-end/src/camera/capture.jsx
+++ b/front-end/src/camera/capture.jsx
@@ -3,7 +3,7 @@ import { takeImage, getLatestImage } from '../redux/actions/camera'
 import { connect } from 'react-redux'
 import i18next from 'i18next'
 
-class capture extends React.Component {
+export class RawCapture extends React.Component {
   componentDidMount () {
     this.props.getLatestImage()
   }
@@ -56,5 +56,5 @@ const mapDispatchToProps = dispatch => {
 const Capture = connect(
   mapStateToProps,
   mapDispatchToProps
-)(capture)
+)(RawCapture)
 export default Capture

--- a/front-end/src/camera/main.jsx
+++ b/front-end/src/camera/main.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux'
 import Motion from './motion'
 import i18next from 'i18next'
 
-class camera extends React.Component {
+export class RawCamera extends React.Component {
   constructor (props) {
     super(props)
     this.state = {
@@ -97,5 +97,5 @@ const mapDispatchToProps = dispatch => {
 const Camera = connect(
   mapStateToProps,
   mapDispatchToProps
-)(camera)
+)(RawCamera)
 export default Camera

--- a/front-end/src/doser/calibrate.jsx
+++ b/front-end/src/doser/calibrate.jsx
@@ -97,19 +97,25 @@ const CalibrateSchema = Yup.object().shape({
   volume: Yup.number()
 })
 
+export const mapCalibratePropsToValues = props => {
+  return {
+    duration: props.duration,
+    speed: props.speed,
+    volume: props.volume,
+    pumpType: props.pumpType
+  }
+}
+
+export const submitCalibration = (values, props) => {
+  props.onSubmit(parseFloat(values.duration), parseInt(values.speed), parseFloat(values.volume))
+}
+
 const CalibrateForm = withFormik({
   displayName: 'CalibrateForm',
-  mapPropsToValues: props => {
-    return {
-      duration: props.duration,
-      speed: props.speed,
-      volume: props.volume,
-      pumpType: props.pumpType
-    }
-  },
+  mapPropsToValues: mapCalibratePropsToValues,
   validationSchema: CalibrateSchema,
   handleSubmit: (values, { props }) => {
-    props.onSubmit(parseFloat(values.duration), parseInt(values.speed), parseFloat(values.volume))
+    submitCalibration(values, props)
   }
 })(Calibrate)
 

--- a/front-end/src/doser/calibration.test.js
+++ b/front-end/src/doser/calibration.test.js
@@ -1,71 +1,96 @@
 import React from 'react'
-import { shallow } from 'enzyme'
-import CalibrateForm, { Calibrate } from './calibrate'
+import CalibrateForm, {
+  Calibrate,
+  mapCalibratePropsToValues,
+  submitCalibration
+} from './calibrate'
 import CalibrationModal from './calibration_modal'
 import 'isomorphic-fetch'
-import * as Alert from '../utils/alert'
-
 
 describe('Doser Calibration', () => {
-  let values = { enable: true }
-  let fn = jest.fn()
-
-  beforeEach(() => {
-    jest.spyOn(Alert, 'showAlert')
-  })
+  const values = { enable: true, pumpType: 'dp' }
+  const fn = jest.fn()
 
   afterEach(() => {
     jest.clearAllMocks()
   })
 
-  it('<Calibrate />', () => {
-    shallow(
-      <Calibrate
-        values={values}
-        errors={{}}
-        touched={{}}
-        handleBlur={fn}
-        handleChange={fn}
-        submitForm={fn}
-      />
-    )
+  it('<Calibrate /> renders a form', () => {
+    const element = Calibrate({
+      values,
+      errors: {},
+      touched: {},
+      handleBlur: fn,
+      handleChange: fn,
+      submitForm: fn
+    })
+
+    expect(element.type).toBe('form')
   })
 
   it('<Calibrate /> should submit', () => {
-    const wrapper = shallow(
-      <Calibrate
-        values={values}
-        handleBlur={fn}
-        handleChange={fn}
-        submitForm={fn}
-        errors={{}}
-        touched={{}}
-        dirty
-        isValid
-      />
-    )
-    wrapper.find('form').simulate('submit', { preventDefault: () => {} })
+    const submitForm = jest.fn()
+    const element = Calibrate({
+      values,
+      errors: {},
+      touched: {},
+      handleBlur: fn,
+      handleChange: fn,
+      submitForm,
+      dirty: true,
+      isValid: true
+    })
+
+    element.props.onSubmit({ preventDefault: jest.fn() })
+    expect(submitForm).toHaveBeenCalled()
   })
 
-  it('<CalibrateForm/>', () => {
-    const wrapper = shallow(<CalibrateForm onSubmit={fn} duration='15' speed='100' />)
-    wrapper.simulate('submit', {})
-    expect(fn).toHaveBeenCalled()
+  it('<CalibrateForm/> maps and submits values', () => {
+    expect(
+      mapCalibratePropsToValues({
+        duration: '15',
+        speed: '100',
+        volume: '5',
+        pumpType: 'stepper'
+      })
+    ).toEqual({
+      duration: '15',
+      speed: '100',
+      volume: '5',
+      pumpType: 'stepper'
+    })
+
+    const onSubmit = jest.fn()
+    submitCalibration(
+      { duration: '15', speed: '100', volume: '5' },
+      { onSubmit }
+    )
+    expect(onSubmit).toHaveBeenCalledWith(15, 100, 5)
+
+    expect(CalibrateForm).toBeDefined()
   })
 
   it('<CalibrationWizard />', () => {
-    const fn = jest.fn((duration, speed) => {
-      return new Promise(resolve => {
-        return resolve(true)
-      })
+    const calibrateDoser = jest.fn(() => Promise.resolve(true))
+    const saveCalibration = jest.fn()
+    const doser = {
+      id: 1,
+      type: 'dp',
+      regiment: { speed: 100, duration: 15, volume_per_second: 0 }
+    }
+    const wrapper = new CalibrationModal({
+      doser,
+      calibrateDoser,
+      saveCalibration
     })
-    const doser = { id: 1, regiment: { speed: 100, duration: 15 } }
-    const wrapper = new CalibrationModal({ doser, calibrateDoser: fn, saveCalibration: fn })
+
     wrapper.promise = { resolve: fn, reject: fn }
     wrapper.setState = jest.fn()
 
     wrapper.cancel()
     wrapper.handleConfirm()
     wrapper.handleCalibrate(20, 50)
+
+    expect(calibrateDoser).toHaveBeenCalledWith(1, { duration: 20, speed: 50 })
   })
 })

--- a/front-end/src/health_chart.jsx
+++ b/front-end/src/health_chart.jsx
@@ -5,7 +5,7 @@ import { fetchHealth } from './redux/actions/health'
 import { connect } from 'react-redux'
 import i18next from 'i18next'
 
-class healthChart extends React.Component {
+export class RawHealthChart extends React.Component {
   constructor (props) {
     super(props)
     this.state = {
@@ -62,5 +62,5 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => {
   return { fetchHealth: () => dispatch(fetchHealth()) }
 }
-const HealthChart = connect(mapStateToProps, mapDispatchToProps)(healthChart)
+const HealthChart = connect(mapStateToProps, mapDispatchToProps)(RawHealthChart)
 export default HealthChart

--- a/front-end/src/health_chart.test.js
+++ b/front-end/src/health_chart.test.js
@@ -1,24 +1,45 @@
 import React from 'react'
-import { shallow } from 'enzyme'
-import HealthChart from './health_chart'
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
+import { RawHealthChart } from './health_chart'
 import 'isomorphic-fetch'
 
-const mockStore = configureMockStore([thunk])
-
 describe('Health', () => {
-  it('<HealthChart />', () => {
-    const state = {
-      health_stats: {},
-      timer: window.setInterval(() => true, 10)
-    }
-    const m = shallow(<HealthChart store={mockStore(state)} />).dive().instance()
+  const fetchHealth = jest.fn()
+
+  beforeEach(() => {
+    jest.spyOn(window, 'setInterval').mockReturnValue(123)
+    jest.spyOn(window, 'clearInterval').mockImplementation(() => {})
   })
-  it('<HealthChart />', () => {
-    const state = {
-      trend: 'current'
-    }
-    const m = shallow(<HealthChart store={mockStore(state)} />).dive().instance()
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
+  })
+
+  it('fetches health data on mount and renders empty state when data is missing', () => {
+    const chart = new RawHealthChart({
+      fetchHealth,
+      health_stats: {},
+      height: 100
+    })
+
+    expect(window.setInterval).toHaveBeenCalledWith(fetchHealth, 60 * 1000)
+
+    chart.componentDidMount()
+
+    expect(fetchHealth).toHaveBeenCalledTimes(1)
+    expect(chart.render().type).toBe('div')
+  })
+
+  it('clears the polling timer on unmount', () => {
+    const chart = new RawHealthChart({
+      fetchHealth,
+      health_stats: { current: [] },
+      trend: 'current',
+      height: 100
+    })
+
+    chart.componentWillUnmount()
+
+    expect(window.clearInterval).toHaveBeenCalledWith(123)
   })
 })

--- a/front-end/src/instances/instance_form.js
+++ b/front-end/src/instances/instance_form.js
@@ -2,20 +2,26 @@ import EditInstance from './edit_instance'
 import InstanceSchema from './instance_schema'
 import { withFormik } from 'formik'
 
+export const mapInstancePropsToValues = props => ({
+  name: (props.instance && props.instance.name) || '',
+  id: (props.instance && props.instance.id) || '',
+  address: (props.instance && props.instance.address) || '',
+  user: (props.instance && props.instance.user) || '',
+  password: (props.instance && props.instance.password) || '',
+  ignore_https: (props.instance && props.instance.ignore_https) || false,
+  remove: props.remove
+})
+
+export const submitInstanceForm = (values, props) => {
+  props.onSubmit(values)
+}
+
 const EditInstanceForm = withFormik({
   displayName: 'InstanceForm',
-  mapPropsToValues: props => ({
-    name: (props.instance && props.instance.name) || '',
-    id: (props.instance && props.instance.id) || '',
-    address: (props.instance && props.instance.address) || '',
-    user: (props.instance && props.instance.user) || '',
-    password: (props.instance && props.instance.password) || '',
-    ignore_https: (props.instance && props.instance.ignore_https) || false,
-    remove: props.remove
-  }),
+  mapPropsToValues: mapInstancePropsToValues,
   validationSchema: InstanceSchema,
   handleSubmit: (values, { props }) => {
-    props.onSubmit(values)
+    submitInstanceForm(values, props)
   }
 })(EditInstance)
 

--- a/front-end/src/instances/instances.test.js
+++ b/front-end/src/instances/instances.test.js
@@ -1,16 +1,15 @@
-import React, { act } from 'react'
-import { shallow, mount } from 'enzyme'
-import { Provider } from 'react-redux'
+import React from 'react'
 import fetchMock from 'fetch-mock'
-import Main from './main'
+import Main, { RawInstancesMain } from './main'
 import Instance from './instance'
-import InstanceForm from './instance_form'
+import InstanceForm, {
+  mapInstancePropsToValues,
+  submitInstanceForm
+} from './instance_form'
 import EditInstance from './edit_instance'
-import configureMockStore from 'redux-mock-store'
+import { confirm } from 'utils/confirm'
 import 'isomorphic-fetch'
-import thunk from 'redux-thunk'
-
-const mockStore = configureMockStore([thunk])
+import * as Alert from '../utils/alert'
 
 jest.mock('utils/confirm', () => ({
   confirm: jest.fn().mockImplementation(() => Promise.resolve(true))
@@ -19,87 +18,170 @@ jest.mock('utils/confirm', () => ({
 const instanceData = { id: '1', name: 'Remote Tank', address: 'http://192.168.1.10', user: 'reef-pi', password: 'reef-pi' }
 const fn = jest.fn()
 
-describe('Instances Main', () => {
-  const click = (node, event = {}) => {
-    act(() => {
-      node.prop('onClick')(event)
-    })
+const countByType = (node, predicate) => {
+  if (!node || typeof node !== 'object') {
+    return 0
   }
 
+  let count = predicate(node) ? 1 : 0
+  const children = React.Children.toArray(node.props?.children)
+  children.forEach(child => {
+    count += countByType(child, predicate)
+  })
+  return count
+}
+
+const findNode = (node, predicate) => {
+  if (!node || typeof node !== 'object') {
+    return null
+  }
+  if (predicate(node)) {
+    return node
+  }
+  const children = React.Children.toArray(node.props?.children)
+  for (const child of children) {
+    const found = findNode(child, predicate)
+    if (found) {
+      return found
+    }
+  }
+  return null
+}
+
+describe('Instances Main', () => {
   afterEach(() => {
     fetchMock.reset()
     fetchMock.restore()
+    jest.clearAllMocks()
   })
 
-  it('mounts with instance list', () => {
-    fetchMock.get('/api/instances', [instanceData])
-    const store = mockStore({ instances: [instanceData] })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+  it('renders with instance list and fetches on mount', () => {
+    const fetch = jest.fn()
+    const create = jest.fn()
+    const update = jest.fn()
+    const remove = jest.fn()
+    const main = new RawInstancesMain({
+      instances: [instanceData],
+      fetch,
+      create,
+      update,
+      delete: remove
+    })
+
+    main.componentDidMount()
+    expect(fetch).toHaveBeenCalled()
+
+    const rendered = main.render()
+    expect(countByType(rendered, node => node.type === Instance)).toBe(1)
   })
 
-  it('mounts with empty instance list', () => {
-    fetchMock.get('/api/instances', [])
-    const store = mockStore({ instances: [] })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+  it('renders with empty instance list', () => {
+    const main = new RawInstancesMain({
+      instances: [],
+      fetch: fn,
+      create: fn,
+      update: fn,
+      delete: fn
+    })
+
+    const rendered = main.render()
+    expect(countByType(rendered, node => node.type === Instance)).toBe(0)
   })
 
-  it('toggles add form via button click', () => {
-    fetchMock.get('/api/instances', [])
-    const store = mockStore({ instances: [] })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    click(wrapper.find('#add_instance'))
-    click(wrapper.find('#add_instance'))
-    wrapper.unmount()
+  it('toggles add form via handler', () => {
+    const main = new RawInstancesMain({
+      instances: [],
+      fetch: fn,
+      create: fn,
+      update: fn,
+      delete: fn
+    })
+    main.setState = jest.fn(update => {
+      main.state = { ...main.state, ...update }
+    })
+
+    main.handleToggle()
+    expect(main.state.add).toBe(true)
+    expect(countByType(main.render(), node => node.type === InstanceForm)).toBe(1)
+
+    main.handleToggle()
+    expect(main.state.add).toBe(false)
   })
 })
 
 describe('Instance', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   it('renders in readOnly mode by default', () => {
-    const wrapper = shallow(
-      <Instance
-        instance={instanceData}
-        update={fn}
-        delete={fn}
-      />
-    )
-    expect(wrapper.instance().state.readOnly).toBe(true)
+    const instance = new Instance({
+      instance: instanceData,
+      update: fn,
+      delete: fn
+    })
+
+    expect(instance.state.readOnly).toBe(true)
   })
 
   it('switches to edit mode on toggleEdit', () => {
-    const wrapper = shallow(
-      <Instance instance={instanceData} update={fn} delete={fn} />
-    )
-    const inst = wrapper.instance()
-    inst.handleToggleEdit({ stopPropagation: fn })
-    expect(inst.state.readOnly).toBe(false)
+    const instance = new Instance({
+      instance: instanceData,
+      update: fn,
+      delete: fn
+    })
+    instance.setState = jest.fn(update => {
+      instance.state = { ...instance.state, ...update }
+    })
+
+    instance.handleToggleEdit({ stopPropagation: fn })
+    expect(instance.state.readOnly).toBe(false)
   })
 
-  it('calls delete prop after confirm', () => {
+  it('calls delete prop after confirm', async () => {
     const deleteFn = jest.fn()
-    const wrapper = shallow(
-      <Instance instance={instanceData} update={fn} delete={deleteFn} />
-    )
-    wrapper.instance().handleDelete({ stopPropagation: fn })
-    // confirm mock resolves, delete will be called async
-    expect(wrapper).toBeDefined()
+    const instance = new Instance({
+      instance: instanceData,
+      update: fn,
+      delete: deleteFn
+    })
+
+    await instance.handleDelete({ stopPropagation: fn })
+    await Promise.resolve()
+
+    expect(confirm).toHaveBeenCalled()
+    expect(deleteFn).toHaveBeenCalledWith(instanceData.id)
   })
 })
 
 describe('InstanceForm (withFormik)', () => {
-  it('renders create form without instance prop', () => {
-    const wrapper = shallow(<InstanceForm onSubmit={fn} actionLabel='Save' />)
-    wrapper.simulate('submit', {})
-    expect(fn).toHaveBeenCalled()
+  it('maps create form values without instance prop', () => {
+    expect(mapInstancePropsToValues({ remove: false })).toEqual({
+      name: '',
+      id: '',
+      address: '',
+      user: '',
+      password: '',
+      ignore_https: false,
+      remove: false
+    })
   })
 
-  it('renders edit form with instance prop', () => {
-    const wrapper = shallow(<InstanceForm instance={instanceData} onSubmit={fn} actionLabel='Update' />)
-    wrapper.simulate('submit', {})
-    expect(fn).toHaveBeenCalled()
+  it('maps edit form values with instance prop and submits', () => {
+    expect(mapInstancePropsToValues({ instance: instanceData })).toEqual({
+      name: instanceData.name,
+      id: instanceData.id,
+      address: instanceData.address,
+      user: instanceData.user,
+      password: instanceData.password,
+      ignore_https: false,
+      remove: undefined
+    })
+
+    const onSubmit = jest.fn()
+    submitInstanceForm(instanceData, { onSubmit })
+    expect(onSubmit).toHaveBeenCalledWith(instanceData)
+    expect(Main).toBeDefined()
   })
 })
 
@@ -117,28 +199,39 @@ describe('EditInstance', () => {
     isValid: true
   }
 
+  beforeEach(() => {
+    jest.spyOn(Alert, 'showError')
+    jest.spyOn(Alert, 'showUpdateSuccessful')
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   it('renders form fields', () => {
-    const wrapper = shallow(<EditInstance {...baseProps} />)
-    expect(wrapper.find('form').length).toBe(1)
+    const element = EditInstance(baseProps)
+    expect(element.type).toBe('form')
   })
 
   it('submits when valid', () => {
-    const submitFn = jest.fn()
-    const wrapper = shallow(<EditInstance {...baseProps} submitForm={submitFn} />)
-    wrapper.find('form').simulate('submit', { preventDefault: fn })
-    expect(submitFn).toHaveBeenCalled()
+    const submitForm = jest.fn()
+    const element = EditInstance({ ...baseProps, submitForm })
+    element.props.onSubmit({ preventDefault: fn })
+    expect(submitForm).toHaveBeenCalled()
+    expect(Alert.showUpdateSuccessful).toHaveBeenCalled()
   })
 
   it('submits to show errors when dirty and invalid', () => {
-    const submitFn = jest.fn()
-    const wrapper = shallow(<EditInstance {...baseProps} submitForm={submitFn} dirty isValid={false} />)
-    wrapper.find('form').simulate('submit', { preventDefault: fn })
-    expect(submitFn).toHaveBeenCalled()
+    const submitForm = jest.fn()
+    const element = EditInstance({ ...baseProps, submitForm, dirty: true, isValid: false })
+    element.props.onSubmit({ preventDefault: fn })
+    expect(submitForm).toHaveBeenCalled()
+    expect(Alert.showError).toHaveBeenCalled()
   })
 
   it('does not show delete button when id is absent', () => {
     const props = { ...baseProps, values: { ...baseProps.values, id: undefined } }
-    const wrapper = shallow(<EditInstance {...props} />)
-    expect(wrapper.find('button[type="button"]').length).toBe(0)
+    const element = EditInstance(props)
+    expect(findNode(element, node => node.type === 'button' && node.props.type === 'button')).toBeNull()
   })
 })

--- a/front-end/src/instances/main.jsx
+++ b/front-end/src/instances/main.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux'
 import InstanceForm from './instance_form'
 import i18next from 'i18next'
 
-class main extends React.Component {
+export class RawInstancesMain extends React.Component {
   constructor (props) {
     super(props)
     this.state = {
@@ -92,5 +92,5 @@ const mapDispatchToProps = dispatch => {
 const Main = connect(
   mapStateToProps,
   mapDispatchToProps
-)(main)
+)(RawInstancesMain)
 export default Main

--- a/front-end/src/journal/main.jsx
+++ b/front-end/src/journal/main.jsx
@@ -9,7 +9,7 @@ import i18next from 'i18next'
 import { confirm } from 'utils/confirm'
 import { SortByName } from 'utils/sort_by_name'
 
-class main extends React.Component {
+export class RawJournalMain extends React.Component {
   constructor (props) {
     super(props)
     this.handleDelete = this.handleDelete.bind(this)
@@ -76,5 +76,5 @@ const mapDispatchToProps = dispatch => {
 const Main = connect(
   mapStateToProps,
   mapDispatchToProps
-)(main)
+)(RawJournalMain)
 export default Main

--- a/front-end/src/journal/main.test.js
+++ b/front-end/src/journal/main.test.js
@@ -1,13 +1,9 @@
 import React from 'react'
-import { shallow, mount } from 'enzyme'
-import { Provider } from 'react-redux'
-import Main from './main'
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
-import fetchMock from 'fetch-mock'
+import { RawJournalMain } from './main'
+import Collapsible from '../ui_components/collapsible'
+import New from './new'
+import { confirm } from 'utils/confirm'
 import 'isomorphic-fetch'
-
-const mockStore = configureMockStore([thunk])
 
 jest.mock('utils/confirm', () => ({
   confirm: jest.fn().mockImplementation(() => Promise.resolve(true))
@@ -18,42 +14,56 @@ const journals = [
   { id: '2', name: 'Alkalinity', description: 'weekly', unit: 'dKH' }
 ]
 
+const countByType = (node, predicate) => {
+  if (!node || typeof node !== 'object') {
+    return 0
+  }
+  let count = predicate(node) ? 1 : 0
+  React.Children.toArray(node.props?.children).forEach(child => {
+    count += countByType(child, predicate)
+  })
+  return count
+}
+
 describe('<Main />', () => {
   afterEach(() => {
-    fetchMock.reset()
-    fetchMock.restore()
     jest.clearAllMocks()
   })
 
-  it('smoke test via Provider shallow', () => {
-    const store = mockStore({ journals })
-    expect(() =>
-      shallow(<Provider store={store}><Main /></Provider>)
-    ).not.toThrow()
+  it('renders without throwing', () => {
+    const main = new RawJournalMain({ journals, delete: jest.fn() })
+    expect(() => main.render()).not.toThrow()
   })
 
-  it('mounts with journal list', () => {
-    fetchMock.get('/api/journal', journals)
-    const store = mockStore({ journals })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+  it('renders with journal list', () => {
+    const main = new RawJournalMain({ journals, delete: jest.fn() })
+    const rendered = main.render()
+
+    expect(countByType(rendered, node => node.type === Collapsible)).toBe(2)
   })
 
-  it('mounts with empty journal list', () => {
-    fetchMock.get('/api/journal', [])
-    const store = mockStore({ journals: [] })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+  it('renders with empty journal list', () => {
+    const main = new RawJournalMain({ journals: [], delete: jest.fn() })
+    const rendered = main.render()
+
+    expect(countByType(rendered, node => node.type === Collapsible)).toBe(0)
   })
 
   it('renders New sub-component for adding journals', () => {
-    fetchMock.get('/api/journal', journals)
-    const store = mockStore({ journals })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    // Journal main delegates add via New sub-component — verify list renders
-    expect(wrapper.find('ul.list-group').length).toBeGreaterThan(0)
-    wrapper.unmount()
+    const main = new RawJournalMain({ journals, delete: jest.fn() })
+    const rendered = main.render()
+
+    expect(countByType(rendered, node => node.type === New)).toBe(1)
+  })
+
+  it('calls delete after confirm resolves', async () => {
+    const deleteJournal = jest.fn()
+    const main = new RawJournalMain({ journals, delete: deleteJournal })
+
+    await main.handleDelete(journals[0])
+    await Promise.resolve()
+
+    expect(confirm).toHaveBeenCalled()
+    expect(deleteJournal).toHaveBeenCalledWith(journals[0].id)
   })
 })

--- a/front-end/src/notifications/alert.jsx
+++ b/front-end/src/notifications/alert.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import AlertItem from './alert_item'
 import { delAlert } from 'redux/actions/alert'
 import { connect } from 'react-redux'
-class NotificationAlert extends React.Component {
+export class RawNotificationAlert extends React.Component {
   constructor (props) {
     super(props)
     this.state = {
@@ -58,5 +58,5 @@ const mapDispatchToProps = dispatch => {
 const notifalert = connect(
   mapStateToProps,
   mapDispatchToProps
-)(NotificationAlert)
+)(RawNotificationAlert)
 export default notifalert

--- a/front-end/src/notifications/alert.test.js
+++ b/front-end/src/notifications/alert.test.js
@@ -1,42 +1,43 @@
 import React from 'react'
-import { shallow } from 'enzyme'
-import { Provider } from 'react-redux'
-import NotificationAlert from './alert'
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
+import { RawNotificationAlert } from './alert'
 import 'isomorphic-fetch'
-
-const mockStore = configureMockStore([thunk])
-
-const alerts = [
-  { ts: 1, level: 'info', message: 'Test info' },
-  { ts: 2, level: 'error', message: 'Test error' }
-]
 
 describe('NotificationAlert', () => {
   it('renders without throwing with alerts', () => {
-    const store = mockStore({ alerts })
-    expect(() =>
-      shallow(<Provider store={store}><NotificationAlert /></Provider>)
-    ).not.toThrow()
+    const alert = new RawNotificationAlert({
+      alerts: [
+        { ts: 1, content: 'Test info', type: 'INFO' },
+        { ts: 2, content: 'Test error', type: 'ERROR' }
+      ],
+      delAlert: jest.fn()
+    })
+
+    expect(() => alert.render()).not.toThrow()
   })
 
   it('renders without throwing with no alerts', () => {
-    const store = mockStore({ alerts: [] })
-    expect(() =>
-      shallow(<Provider store={store}><NotificationAlert /></Provider>)
-    ).not.toThrow()
+    const alert = new RawNotificationAlert({
+      alerts: [],
+      delAlert: jest.fn()
+    })
+
+    expect(() => alert.render()).not.toThrow()
+    expect(React.Children.count(alert.render().props.children)).toBe(0)
   })
 
-  it('renders via dive with alerts', () => {
-    const store = mockStore({ alerts })
-    const wrapper = shallow(<NotificationAlert store={store} />).dive()
-    expect(wrapper).toBeDefined()
+  it('renders alert items from props', () => {
+    const alerts = [
+      { ts: 1, content: 'Test info', type: 'INFO' },
+      { ts: 2, content: 'Test error', type: 'ERROR' }
+    ]
+    const alert = new RawNotificationAlert({ alerts, delAlert: jest.fn() })
+
+    expect(React.Children.count(alert.render().props.children)).toBe(2)
   })
 
-  it('renders via dive with empty alerts', () => {
-    const store = mockStore({ alerts: [] })
-    const wrapper = shallow(<NotificationAlert store={store} />).dive()
-    expect(wrapper).toBeDefined()
+  it('renders empty alert list', () => {
+    const alert = new RawNotificationAlert({ alerts: [], delAlert: jest.fn() })
+
+    expect(React.Children.count(alert.render().props.children)).toBe(0)
   })
 })

--- a/front-end/src/notifications/notifications.test.js
+++ b/front-end/src/notifications/notifications.test.js
@@ -1,72 +1,64 @@
-import Alert from './alert'
-import AlertItem from './alert_item'
 import React from 'react'
-import { shallow } from 'enzyme'
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
-import {Provider} from 'react-redux'
-const mockStore = configureMockStore([thunk])
+import AlertItem from './alert_item'
+import { RawNotificationAlert } from './alert'
 
 describe('Notifications', () => {
-  it('<Alert />', () => {
-    jest.useFakeTimers()
-    const alerts = [
-      {
-        ts: 1538562759,
-        content: 'foo',
-        type: 'ERROR'
-      },
-      {
-        ts: 1538562751,
-        content: 'foo',
-        type: 'INFO'
-      },
-      {
-        ts: 1538562752,
-        content: 'foo',
-        type: 'SUCCESS'
-      },
-      {
-        ts: 1538562753,
-        content: 'foo',
-        type: 'WARNING'
-      }
-    ]
-    const store = mockStore({ alerts: alerts })
-    const wrapper = shallow(
-      <Provider store={store}>
-        <Alert />
-        </Provider>
-       ).dive()
-    /* refactor for ract16 connected component
-    expect(wrapper.find(AlertItem).length).toBe(4)
-    const l = wrapper.instance()
-    expect(l.state.containerFix).toEqual('')
-    global.window.scrollY = 60
-    l.handleScroll()
-    expect(l.state.containerFix).toEqual('fix')
-    global.window.scrollY = 0
-    l.handleScroll()
-    expect(l.state.containerFix).toEqual('')
-    */
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
   })
-  it('<AlertItem />', () => {
+
+  it('<Alert /> renders alerts and toggles fixed positioning on scroll', () => {
+    const alerts = [
+      { ts: 1538562759, content: 'foo', type: 'ERROR' },
+      { ts: 1538562751, content: 'bar', type: 'INFO' },
+      { ts: 1538562752, content: 'baz', type: 'SUCCESS' },
+      { ts: 1538562753, content: 'qux', type: 'WARNING' }
+    ]
+    const delAlert = jest.fn()
+    const alert = new RawNotificationAlert({ alerts, delAlert })
+    alert.setState = jest.fn(update => {
+      alert.state = { ...alert.state, ...update }
+    })
+
+    const rendered = alert.render()
+    expect(React.Children.count(rendered.props.children)).toBe(4)
+
+    expect(alert.state.containerFix).toBe('')
+    Object.defineProperty(window, 'scrollY', { value: 60, configurable: true })
+    alert.handleScroll()
+    expect(alert.state.containerFix).toBe('fix')
+
+    Object.defineProperty(window, 'scrollY', { value: 0, configurable: true })
+    alert.handleScroll()
+    expect(alert.state.containerFix).toBe('')
+  })
+
+  it('<AlertItem /> closes on click and timeout', () => {
+    jest.useFakeTimers()
     const close = jest.fn()
-    const alert = {
+    const notification = {
       ts: 1538562753,
       content: 'foo',
       type: 'WARNING'
     }
-    const wrapper = shallow(<AlertItem notification={alert} close={close} />)
+    const item = new AlertItem({ notification, close })
+    item.setState = jest.fn(update => {
+      item.state = { ...item.state, ...update }
+    })
 
-    wrapper
-      .find('button')
-      .first()
-      .simulate('click')
+    item.componentDidMount()
+    item.handleClose()
     jest.runAllTimers()
-    expect(close.mock.calls.length).toBe(1)
-    shallow(<AlertItem notification={alert} close={close} />)
+    expect(close).toHaveBeenCalledTimes(1)
+
+    const timedItem = new AlertItem({ notification, close })
+    timedItem.setState = jest.fn(update => {
+      timedItem.state = { ...timedItem.state, ...update }
+    })
+    timedItem.componentDidMount()
     jest.runAllTimers()
-    expect(close.mock.calls.length).toBe(2)
+    expect(close).toHaveBeenCalledTimes(2)
   })
 })

--- a/front-end/src/temperature/calibration.test.js
+++ b/front-end/src/temperature/calibration.test.js
@@ -1,126 +1,123 @@
 import React from 'react'
-import { shallow } from 'enzyme'
-import CalibrationModal, { CalibrationForm } from './calibration_modal'
+import {
+  CalibrationForm,
+  mapCalibrationPropsToValues,
+  submitCalibrationForm
+} from './calibration_modal'
 import 'isomorphic-fetch'
-import * as Alert from '../utils/alert'
-
 
 describe('Temperature Calibration', () => {
-  let values = { enable: true }
-  let fn = jest.fn()
-  const probe={
+  const values = { enable: true }
+  const probe = {
     id: 1,
     name: 'probe'
   }
-  const currentReading = [ 77, 76 ]
-
+  const currentReading = [77, 76]
+  const fn = jest.fn()
 
   beforeEach(() => {
-    jest.spyOn(Alert, 'showError')
+    jest.spyOn(window, 'setInterval').mockReturnValue(123)
+    jest.spyOn(window, 'clearInterval').mockImplementation(() => {})
   })
 
   afterEach(() => {
+    jest.restoreAllMocks()
     jest.clearAllMocks()
   })
 
-  it('<CalibrationModal /> should render form', () => {
-    const submitFn = jest.fn()
+  it('maps modal props into default form values', () => {
+    expect(
+      mapCalibrationPropsToValues({
+        probe,
+        currentReading,
+        defaultValue: 77
+      })
+    ).toEqual({ value: 77 })
 
-    const wrapper = shallow(
-      <CalibrationModal
-        probe={probe}
-        currentReading={currentReading}
-        defaultValue={77}
-        readProbe={fn}
-        calibrateProbe={fn}
-        cancel={fn}
-        onSubmit={submitFn}
-      />).dive()
-
-    expect(wrapper.find(CalibrationForm).length).toBe(1)
-    wrapper.find(CalibrationForm).dive().find('form').simulate('submit', {})
+    expect(
+      mapCalibrationPropsToValues({
+        probe,
+        currentReading
+      })
+    ).toEqual({ value: currentReading[probe.id] })
   })
 
-  it('<CalibrationModal /> should default to currentReading', () => {
-    const submitFn = jest.fn()
+  it('submits parsed calibration values', () => {
+    const onSubmit = jest.fn()
 
-    const wrapper = shallow(
-      <CalibrationModal
-        probe={probe}
-        currentReading={currentReading}
-        readProbe={fn}
-        calibrateProbe={fn}
-        cancel={fn}
-        onSubmit={submitFn}
-      />).dive()
+    submitCalibrationForm({ value: '77.5' }, { onSubmit, probe })
 
-    expect(wrapper.find(CalibrationForm).prop('values').value).toEqual(currentReading[1])
+    expect(onSubmit).toHaveBeenCalledWith(probe, 77.5)
   })
 
-  it('<CalibrationForm /> should submit', () => {
+  it('renders the calibration form and wires submit', () => {
+    const handleSubmit = jest.fn()
+    const form = new CalibrationForm({
+      values,
+      probe,
+      currentReading,
+      defaultValue: 77,
+      readProbe: fn,
+      calibrateProbe: fn,
+      cancel: fn,
+      handleSubmit,
+      touched: {},
+      errors: {}
+    })
 
-    const submitFn = jest.fn()
+    const element = form.render()
+    const renderedForm = element.props.children
 
-    const wrapper = shallow(
-      <CalibrationForm
-        values={values}
-        probe={probe}
-        currentReading={currentReading}
-        defaultValue={77}
-        readProbe={fn}
-        calibrateProbe={fn}
-        cancel={fn}
-        handleSubmit={submitFn}
-      />)
+    expect(renderedForm.type).toBe('form')
 
-    wrapper.find('form').simulate('submit', {})
-    expect(submitFn).toHaveBeenCalled()
-
+    renderedForm.props.onSubmit({})
+    expect(handleSubmit).toHaveBeenCalled()
   })
 
-  it('<CalibrationForm /> should cancel', () => {
+  it('cancels calibration', () => {
+    const cancel = jest.fn()
+    const form = new CalibrationForm({
+      values,
+      probe,
+      currentReading,
+      defaultValue: 77,
+      readProbe: fn,
+      calibrateProbe: fn,
+      cancel,
+      handleSubmit: fn,
+      touched: {},
+      errors: {}
+    })
 
-    const cancelFn = jest.fn()
+    form.handleCancel()
 
-    const wrapper = shallow(
-      <CalibrationForm
-        values={values}
-        probe={probe}
-        currentReading={currentReading}
-        defaultValue={77}
-        readProbe={fn}
-        calibrateProbe={fn}
-        cancel={cancelFn}
-        handleSubmit={fn}
-      />)
-
-    wrapper.find('button[role="abort"]').simulate('click', () => {})
-    expect(cancelFn).toHaveBeenCalled()
-    wrapper.unmount()
-
+    expect(cancel).toHaveBeenCalled()
   })
 
-  it('<CalibrationForm /> should update readings', () => {
-
-    const readFn = jest.fn()
+  it('starts and stops polling readings', () => {
+    const readProbe = jest.fn()
     jest.useFakeTimers()
+    const clearIntervalSpy = jest.spyOn(window, 'clearInterval')
 
-    const wrapper = shallow(
-      <CalibrationForm
-        values={values}
-        probe={probe}
-        currentReading={currentReading}
-        defaultValue={77}
-        readProbe={readFn}
-        calibrateProbe={fn}
-        cancel={fn}
-        handleSubmit={fn}
-      />)
+    const form = new CalibrationForm({
+      values,
+      probe,
+      currentReading,
+      defaultValue: 77,
+      readProbe,
+      calibrateProbe: fn,
+      cancel: fn,
+      handleSubmit: fn,
+      touched: {},
+      errors: {}
+    })
 
+    form.componentDidMount()
     jest.runOnlyPendingTimers()
-    expect(readFn).toHaveBeenCalled()
-    wrapper.unmount()
+    expect(readProbe).toHaveBeenCalledWith(probe.id)
 
+    form.componentWillUnmount()
+    expect(clearIntervalSpy).toHaveBeenCalledWith(form.timer)
+    jest.useRealTimers()
   })
-
 })

--- a/front-end/src/temperature/calibration_modal.jsx
+++ b/front-end/src/temperature/calibration_modal.jsx
@@ -93,16 +93,22 @@ const CalibrateSchema = Yup.object().shape({
     .required(i18n.t('validation:number_required'))
 })
 
+export const mapCalibrationPropsToValues = props => {
+  return {
+    value: props.defaultValue || props.currentReading[props.probe.id]
+  }
+}
+
+export const submitCalibrationForm = (values, props) => {
+  props.onSubmit(props.probe, parseFloat(values.value))
+}
+
 const CalibrationModal = withFormik({
   displayName: 'CalibrateForm',
-  mapPropsToValues: props => {
-    return {
-      value: props.defaultValue || props.currentReading[props.probe.id]
-    }
-  },
+  mapPropsToValues: mapCalibrationPropsToValues,
   validationSchema: CalibrateSchema,
   handleSubmit: (values, { props }) => {
-    props.onSubmit(props.probe, parseFloat(values.value))
+    submitCalibrationForm(values, props)
   }
 })(CalibrationForm)
 

--- a/front-end/src/ui_components/useDatepicker.test.js
+++ b/front-end/src/ui_components/useDatepicker.test.js
@@ -1,87 +1,133 @@
 import React, { act } from 'react'
-import { mount } from 'enzyme'
-import { Form, Formik } from 'formik'
+import { createRoot } from 'react-dom/client'
+import { useFormikContext } from 'formik'
 import { useDatepicker } from './useDatepicker'
 
+jest.mock('formik', () => ({
+  useFormikContext: jest.fn()
+}))
 
-// Test component that exposes hook handlers via refs
 const TestComponent = ({ name, onHandlers }) => {
   const [handleChangeRaw, handleChange] = useDatepicker(name)
-  if (onHandlers) onHandlers({ handleChangeRaw, handleChange })
-  return <input name={name} onChange={handleChangeRaw} />
+  onHandlers({ handleChangeRaw, handleChange })
+  return null
 }
 
-const wrap = (name, onHandlers) => mount(
-  <Formik
-    initialValues={{ [name]: '' }}
-    onSubmit={() => {}}
-    validateOnBlur={false}
-    validateOnChange={false}
-  >
-    <Form>
-      <TestComponent name={name} onHandlers={onHandlers} />
-    </Form>
-  </Formik>
-)
-
 describe('useDatepicker', () => {
+  let container
+  let root
+  let setFieldValue
+  let setFieldTouched
+  let handlers
+
+  const renderHook = name => {
+    act(() => {
+      root.render(
+        <TestComponent
+          name={name}
+          onHandlers={nextHandlers => {
+            handlers = nextHandlers
+          }}
+        />
+      )
+    })
+  }
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    setFieldValue = jest.fn().mockResolvedValue(undefined)
+    setFieldTouched = jest.fn()
+    handlers = undefined
+    useFormikContext.mockReturnValue({
+      setFieldValue,
+      setFieldTouched
+    })
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+    jest.clearAllMocks()
+  })
+
+  afterAll(() => {
+    delete globalThis.IS_REACT_ACT_ENVIRONMENT
+  })
+
   it('returns two handler functions', () => {
-    let handlers
-    wrap('date', (h) => { handlers = h })
+    renderHook('date')
+
     expect(typeof handlers.handleChangeRaw).toBe('function')
     expect(typeof handlers.handleChange).toBe('function')
   })
 
   it('handleChangeRaw accepts valid date characters', () => {
-    let handlers
-    wrap('date', (h) => { handlers = h })
+    renderHook('date')
     const event = {
       target: { name: 'date', value: '01/01/2023' },
       preventDefault: jest.fn()
     }
-    expect(() => {
-      act(() => {
-        handlers.handleChangeRaw(event)
-      })
-    }).not.toThrow()
+
+    act(() => {
+      handlers.handleChangeRaw(event)
+    })
+
     expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(setFieldValue).toHaveBeenCalledWith('date', '01/01/2023')
+    expect(setFieldTouched).toHaveBeenCalledWith('date', true)
   })
 
   it('handleChangeRaw calls preventDefault for invalid chars', () => {
-    let handlers
-    wrap('date', (h) => { handlers = h })
+    renderHook('date')
     const event = {
       target: { name: 'date', value: 'abc!@#' },
       preventDefault: jest.fn()
     }
+
     act(() => {
       handlers.handleChangeRaw(event)
     })
+
     expect(event.preventDefault).toHaveBeenCalled()
+    expect(setFieldValue).not.toHaveBeenCalled()
   })
 
   it('handleChange accepts a valid Date object', async () => {
-    let handlers
-    wrap('date', (h) => { handlers = h })
+    renderHook('date')
     const validDate = new Date(2023, 0, 1)
+
     await act(async () => {
       await handlers.handleChange(validDate)
     })
+
+    expect(setFieldValue).toHaveBeenCalledWith('date', validDate)
+    expect(setFieldTouched).toHaveBeenCalledWith('date', true)
   })
 
   it('handleChange handles null date gracefully', async () => {
-    let handlers
-    wrap('date', (h) => { handlers = h })
+    renderHook('date')
+
     await act(async () => {
       await handlers.handleChange(null)
     })
+
+    expect(setFieldValue).toHaveBeenCalledWith('date', '')
+    expect(setFieldTouched).toHaveBeenCalledWith('date', true)
   })
 
   it('handleChange handles invalid date string gracefully', async () => {
-    let handlers
-    wrap('date', (h) => { handlers = h })
+    renderHook('date')
+
     await act(async () => {
       await handlers.handleChange('not-a-date')
     })
+
+    expect(setFieldValue).toHaveBeenCalledWith('date', '')
+    expect(setFieldTouched).toHaveBeenCalledWith('date', true)
   })
 })


### PR DESCRIPTION
## Summary
- port more React 19 failing frontend tests off Enzyme wrapper assumptions
- add small raw-component/helper seams where needed for direct testing
- keep runtime behavior unchanged while reducing the remaining React 19 Jest tail

## Validation
- rtk yarn jest front-end/src/ato/edit_ato.test.js --runInBand
- rtk yarn jest front-end/src/ui_components/useDatepicker.test.js --runInBand
- rtk yarn jest front-end/src/health_chart.test.js --runInBand
- rtk yarn jest front-end/src/temperature/calibration.test.js --runInBand
- rtk yarn jest front-end/src/doser/calibration.test.js --runInBand
- rtk yarn jest front-end/src/notifications/notifications.test.js --runInBand
- rtk yarn jest front-end/src/notifications/alert.test.js --runInBand
- rtk yarn jest front-end/src/instances/instances.test.js --runInBand
- rtk yarn jest front-end/src/camera/camera.test.js --runInBand
- rtk yarn jest front-end/src/journal/main.test.js --runInBand