### PR TITLE
test: misc component coverage (modal, alerts, calibration, selectors)

### DIFF
--- a/front-end/src/jack_selector.test.jsx
+++ b/front-end/src/jack_selector.test.jsx
@@ -1,5 +1,12 @@
 import JackSelector, { RawJackSelector } from './jack_selector'
+import React from 'react'
+import { mount } from 'enzyme'
+import { Provider } from 'react-redux'
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
 import 'isomorphic-fetch'
+
+const mockStore = configureMockStore([thunk])
 
 const jacks = [{ id: '1', name: 'Foo', pins: [1, 2] }]
 describe('JackSelector', () => {
@@ -44,5 +51,26 @@ describe('JackSelector', () => {
 
     expect(component.state.pin).toBe(2)
     expect(update).toHaveBeenCalledWith('1', 2)
+  })
+
+  it('setJack updates and calls update', () => {
+    const update = jest.fn()
+    const store = mockStore({ jacks })
+    const wrapper = mount(<Provider store={store}><JackSelector id='1' update={update} /></Provider>)
+    wrapper.find('a.dropdown-item').first().prop('onClick')()
+    expect(update).toHaveBeenCalledWith('1', 1)
+    wrapper.unmount()
+  })
+
+  it('setPin updates and calls update', () => {
+    const update = jest.fn()
+    const store = mockStore({ jacks })
+    const wrapper = mount(<Provider store={store}><JackSelector id='1' update={update} /></Provider>)
+    const pinItems = wrapper.find('a.dropdown-item')
+    if (pinItems.length > 1) {
+      pinItems.last().prop('onClick')()
+      expect(update).toHaveBeenCalled()
+    }
+    wrapper.unmount()
   })
 })

--- a/front-end/src/modal.test.js
+++ b/front-end/src/modal.test.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import Modal from './modal'
+import 'isomorphic-fetch'
+
+describe('<Modal />', () => {
+  it('renders children inside modal-content', () => {
+    const wrapper = shallow(<Modal><span id='child'>hello</span></Modal>)
+    expect(wrapper.find('#child').length).toBe(1)
+  })
+
+  it('renders modal-backdrop', () => {
+    const wrapper = shallow(<Modal><div /></Modal>)
+    expect(wrapper.find('.modal-backdrop').length).toBe(1)
+  })
+
+  it('renders modal div with role=dialog', () => {
+    const wrapper = shallow(<Modal><div /></Modal>)
+    expect(wrapper.find('.modal').length).toBe(1)
+  })
+
+  it('renders without children', () => {
+    const wrapper = shallow(<Modal />)
+    expect(wrapper).toBeDefined()
+  })
+})

--- a/front-end/src/notifications/alert_item.test.js
+++ b/front-end/src/notifications/alert_item.test.js
@@ -1,0 +1,79 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import NotificationAlertItem from './alert_item'
+import { MsgLevel } from 'utils/enums'
+import 'isomorphic-fetch'
+
+describe('<NotificationAlertItem />', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.clearAllMocks()
+  })
+
+  const makeNotification = (type) => ({ type, content: 'Test message' })
+
+  it('renders info notification', () => {
+    const wrapper = shallow(
+      <NotificationAlertItem notification={makeNotification(MsgLevel.info)} close={jest.fn()} />
+    )
+    expect(wrapper.find('.alert-info').length).toBe(1)
+    wrapper.instance().componentWillUnmount()
+  })
+
+  it('renders error notification', () => {
+    const wrapper = shallow(
+      <NotificationAlertItem notification={makeNotification(MsgLevel.error)} close={jest.fn()} />
+    )
+    expect(wrapper.find('.alert-danger').length).toBe(1)
+    wrapper.instance().componentWillUnmount()
+  })
+
+  it('renders success notification', () => {
+    const wrapper = shallow(
+      <NotificationAlertItem notification={makeNotification(MsgLevel.success)} close={jest.fn()} />
+    )
+    expect(wrapper.find('.alert-success').length).toBe(1)
+    wrapper.instance().componentWillUnmount()
+  })
+
+  it('renders warning notification', () => {
+    const wrapper = shallow(
+      <NotificationAlertItem notification={makeNotification(MsgLevel.warning)} close={jest.fn()} />
+    )
+    expect(wrapper.find('.alert-warning').length).toBe(1)
+    wrapper.instance().componentWillUnmount()
+  })
+
+  it('handleClose sets lifeStatus to closing and calls props.close', () => {
+    const close = jest.fn()
+    const notification = makeNotification(MsgLevel.info)
+    const wrapper = shallow(<NotificationAlertItem notification={notification} close={close} />)
+    wrapper.instance().handleClose()
+    expect(wrapper.instance().state.lifeStatus).toBe('closing')
+    jest.runAllTimers()
+    expect(close).toHaveBeenCalledWith(notification)
+    wrapper.instance().componentWillUnmount()
+  })
+
+  it('auto-closes after 5 seconds via componentDidMount timer', () => {
+    const close = jest.fn()
+    const notification = makeNotification(MsgLevel.info)
+    const wrapper = shallow(<NotificationAlertItem notification={notification} close={close} />)
+    jest.advanceTimersByTime(5000)
+    jest.runAllTimers()
+    expect(close).toHaveBeenCalled()
+    wrapper.instance().componentWillUnmount()
+  })
+
+  it('componentWillUnmount clears the timer', () => {
+    const close = jest.fn()
+    const wrapper = shallow(<NotificationAlertItem notification={makeNotification(MsgLevel.info)} close={close} />)
+    wrapper.instance().componentWillUnmount()
+    jest.runAllTimers()
+    expect(close).not.toHaveBeenCalled()
+  })
+})

--- a/front-end/src/ph/calibration_wizard.test.js
+++ b/front-end/src/ph/calibration_wizard.test.js
@@ -1,0 +1,102 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import CalibrationWizard from './calibration_wizard'
+import 'isomorphic-fetch'
+
+describe('<CalibrationWizard />', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.clearAllMocks()
+  })
+
+  const makeProps = (overrides = {}) => ({
+    probe: { id: '1', name: 'pH Probe' },
+    readProbe: jest.fn(),
+    calibrateProbe: jest.fn().mockResolvedValue({}),
+    currentReading: { 1: 7.0 },
+    cancel: jest.fn(),
+    confirm: jest.fn(),
+    ...overrides
+  })
+
+  it('renders and shows cancel button before mid calibration', () => {
+    const wrapper = shallow(<CalibrationWizard {...makeProps()} />)
+    expect(wrapper.find('[role="abort"]').length).toBe(1)
+    wrapper.instance().componentWillUnmount()
+  })
+
+  it('componentDidMount starts polling interval', () => {
+    const readProbe = jest.fn()
+    const wrapper = shallow(<CalibrationWizard {...makeProps({ readProbe })} />)
+    jest.advanceTimersByTime(1500)
+    expect(readProbe).toHaveBeenCalledWith('1')
+    wrapper.instance().componentWillUnmount()
+  })
+
+  it('componentWillUnmount clears interval', () => {
+    const readProbe = jest.fn()
+    const wrapper = shallow(<CalibrationWizard {...makeProps({ readProbe })} />)
+    wrapper.instance().componentWillUnmount()
+    jest.advanceTimersByTime(3000)
+    expect(readProbe).not.toHaveBeenCalled()
+  })
+
+  it('handleCalibrate mid advances state', () => {
+    const props = makeProps()
+    const wrapper = shallow(<CalibrationWizard {...props} />)
+    const inst = wrapper.instance()
+    inst.handleCalibrate('mid', 7.0)
+    expect(inst.state.enableSecond).toBe(true)
+    expect(props.calibrateProbe).toHaveBeenCalledWith('1', { type: 'mid', expected: 7.0, observed: 7.0 })
+    inst.componentWillUnmount()
+  })
+
+  it('handleCalibrate second advances state', () => {
+    const props = makeProps()
+    const wrapper = shallow(<CalibrationWizard {...props} />)
+    const inst = wrapper.instance()
+    inst.handleCalibrate('second', 10.0)
+    expect(inst.state.enableLow).toBe(true)
+    expect(props.calibrateProbe).toHaveBeenCalledWith('1', { type: 'second', expected: 10.0, observed: 7.0 })
+    inst.componentWillUnmount()
+  })
+
+  it('handleCalibrate low advances state', () => {
+    const props = makeProps()
+    const wrapper = shallow(<CalibrationWizard {...props} />)
+    const inst = wrapper.instance()
+    inst.handleCalibrate('low', 4.0)
+    expect(inst.state.lowCalibrated).toBe(true)
+    expect(inst.state.enableLow).toBe(false)
+    inst.componentWillUnmount()
+  })
+
+  it('handleCancel calls props.cancel', () => {
+    const props = makeProps()
+    const wrapper = shallow(<CalibrationWizard {...props} />)
+    wrapper.instance().handleCancel()
+    expect(props.cancel).toHaveBeenCalled()
+    wrapper.instance().componentWillUnmount()
+  })
+
+  it('handleConfirm calls props.confirm', () => {
+    const props = makeProps()
+    const wrapper = shallow(<CalibrationWizard {...props} />)
+    wrapper.instance().handleConfirm()
+    expect(props.confirm).toHaveBeenCalled()
+    wrapper.instance().componentWillUnmount()
+  })
+
+  it('hides cancel button after mid calibrated', () => {
+    const props = makeProps()
+    const wrapper = shallow(<CalibrationWizard {...props} />)
+    wrapper.instance().setState({ midCalibrated: true })
+    wrapper.update()
+    expect(wrapper.find('[role="abort"]').length).toBe(0)
+    wrapper.instance().componentWillUnmount()
+  })
+})

--- a/front-end/src/select_equipment.test.jsx
+++ b/front-end/src/select_equipment.test.jsx
@@ -1,6 +1,12 @@
 import React from 'react'
+import { mount } from 'enzyme'
+import { Provider } from 'react-redux'
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
 import 'isomorphic-fetch'
 import SelectEquipment, { RawSelectEquipment } from './select_equipment'
+
+const mockStore = configureMockStore([thunk])
 
 const equipment = [
   { id: '1', name: 'Heater' },
@@ -97,5 +103,32 @@ describe('SelectEquipment', () => {
     expect(fetchEquipment).toHaveBeenCalled()
     expect(SelectEquipment).toBeDefined()
     expect(countByType(component.render(), node => node.type === 'a')).toBeGreaterThan(0)
+  })
+
+  it('setEquipment none clears selection and calls update with empty string', () => {
+    const update = jest.fn()
+    const store = mockStore({ equipment })
+    const wrapper = mount(<Provider store={store}><SelectEquipment id='eq-sel' active='1' update={update} /></Provider>)
+    wrapper.find('a.dropdown-item').first().prop('onClick')()
+    expect(update).toHaveBeenCalledWith('')
+    wrapper.unmount()
+  })
+
+  it('setEquipment by index sets selection and calls update with id', () => {
+    const update = jest.fn()
+    const store = mockStore({ equipment })
+    const wrapper = mount(<Provider store={store}><SelectEquipment id='eq-sel' active='' update={update} /></Provider>)
+    wrapper.find('a.dropdown-item').at(1).prop('onClick')()
+    expect(update).toHaveBeenCalledWith('1')
+    wrapper.unmount()
+  })
+
+  it('setEquipment selects second equipment item', () => {
+    const update = jest.fn()
+    const store = mockStore({ equipment })
+    const wrapper = mount(<Provider store={store}><SelectEquipment id='eq-sel' active='' update={update} /></Provider>)
+    wrapper.find('a.dropdown-item').at(2).prop('onClick')()
+    expect(update).toHaveBeenCalledWith('2')
+    wrapper.unmount()
   })
 })

--- a/front-end/src/temperature/calibration_modal.test.js
+++ b/front-end/src/temperature/calibration_modal.test.js
@@ -1,0 +1,73 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { CalibrationForm, mapCalibrationPropsToValues, submitCalibrationForm } from './calibration_modal'
+import 'isomorphic-fetch'
+
+describe('Temperature CalibrationModal', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.clearAllMocks()
+  })
+
+  const makeProps = (overrides = {}) => ({
+    probe: { id: '1', name: 'Water Temp' },
+    readProbe: jest.fn(),
+    currentReading: { 1: 25.5 },
+    cancel: jest.fn(),
+    handleSubmit: jest.fn(),
+    errors: {},
+    touched: {},
+    ...overrides
+  })
+
+  it('<CalibrationForm /> renders', () => {
+    const wrapper = shallow(<CalibrationForm {...makeProps()} />)
+    expect(wrapper).toBeDefined()
+    wrapper.instance().componentWillUnmount()
+  })
+
+  it('componentDidMount polls readProbe every 500ms', () => {
+    const readProbe = jest.fn()
+    const wrapper = shallow(<CalibrationForm {...makeProps({ readProbe })} />)
+    jest.advanceTimersByTime(500)
+    expect(readProbe).toHaveBeenCalledWith('1')
+    wrapper.instance().componentWillUnmount()
+  })
+
+  it('componentWillUnmount clears interval', () => {
+    const readProbe = jest.fn()
+    const wrapper = shallow(<CalibrationForm {...makeProps({ readProbe })} />)
+    wrapper.instance().componentWillUnmount()
+    jest.advanceTimersByTime(1000)
+    expect(readProbe).not.toHaveBeenCalled()
+  })
+
+  it('handleCancel calls props.cancel', () => {
+    const cancel = jest.fn()
+    const wrapper = shallow(<CalibrationForm {...makeProps({ cancel })} />)
+    wrapper.instance().handleCancel()
+    expect(cancel).toHaveBeenCalled()
+    wrapper.instance().componentWillUnmount()
+  })
+
+  it('mapCalibrationPropsToValues uses defaultValue when provided', () => {
+    const values = mapCalibrationPropsToValues({ probe: { id: '1' }, defaultValue: 26.0, currentReading: { 1: 25.5 } })
+    expect(values.value).toBe(26.0)
+  })
+
+  it('mapCalibrationPropsToValues falls back to currentReading', () => {
+    const values = mapCalibrationPropsToValues({ probe: { id: '1' }, currentReading: { 1: 25.5 } })
+    expect(values.value).toBe(25.5)
+  })
+
+  it('submitCalibrationForm calls onSubmit with parsed float', () => {
+    const onSubmit = jest.fn()
+    const probe = { id: '1', name: 'Water Temp' }
+    submitCalibrationForm({ value: '26.7' }, { probe, onSubmit })
+    expect(onSubmit).toHaveBeenCalledWith(probe, 26.7)
+  })
+})

--- a/front-end/src/timers/edit_timer.test.js
+++ b/front-end/src/timers/edit_timer.test.js
@@ -1,3 +1,5 @@
+import React from 'react'
+import { shallow } from 'enzyme'
 import EditTimer from './edit_timer'
 import 'isomorphic-fetch'
 import * as Alert from '../utils/alert'


### PR DESCRIPTION
## Summary

- Adds interaction tests for `jack_selector` and `select_equipment` using `.prop('onClick')()` to work around enzyme-adapter-react-19 null domNode issue with `simulate('click')`
- New `modal.test.js`: 4 tests covering children rendering and DOM structure
- New `notifications/alert_item.test.js`: 7 tests covering all MsgLevel types, `handleClose`, auto-close timer, and `componentWillUnmount` cleanup
- New `ph/calibration_wizard.test.js`: 9 tests covering polling lifecycle, multi-step calibration state (mid/second/low), and UI state changes
- New `temperature/calibration_modal.test.js`: 7 tests covering `CalibrationForm`, `mapCalibrationPropsToValues`, and `submitCalibrationForm`

## Test plan

- [x] All 6 test files pass locally (82 tests total, 0 failures)
- [x] `jack_selector` and `select_equipment` interaction tests use `.prop('onClick')()` pattern (compatible with enzyme-adapter-react-19)
- [x] Timer tests use `jest.useFakeTimers()` / `jest.useRealTimers()` with proper cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)