### PR TITLE
Slice 23: React ecosystem compatibility cleanup

### DIFF
--- a/docs/github-issues/slice-23-react-ecosystem-cleanup.md
+++ b/docs/github-issues/slice-23-react-ecosystem-cleanup.md
@@ -29,3 +29,59 @@ Modernize adjacent frontend libraries only where required to keep the React 19 s
 
 - React-adjacent dependencies are on versions compatible with the new core runtime
 - temporary upgrade shims can be removed or documented clearly
+
+## Current Local Audit
+
+This section reflects the current `main` branch rather than the older pre-React-19 planning notes.
+
+### Confirmed done already
+
+- legacy render entrypoints have been replaced with `createRoot`
+  - `front-end/src/entry.js`
+  - `front-end/src/utils/confirm.js`
+- the old `enzyme-adapter-react-16` blocker is no longer the active adapter path
+
+### Confirmed remaining targets
+
+1. Enzyme is still a major compatibility surface.
+   - `package.json` still depends on:
+     - `enzyme`
+     - `@belzile/enzyme-adapter-react-19`
+   - a large set of frontend tests still import `shallow` or `mount`
+   - this is the clearest remaining React-adjacent maintenance risk
+
+2. Several older React-adjacent UI libraries are still in use and should be reviewed for React 19 support before any bumping or cleanup.
+   - `@material-ui/core`
+   - `react-toggle-switch`
+   - `react-i18next`
+   - `formik`
+   - `recharts`
+   - `react-datepicker`
+   - `react-redux`
+   - `react-router-dom`
+
+3. The migration docs are partially stale.
+   - `docs/library-migration-plan.md` still describes old blockers such as React 16 Enzyme adapter usage and legacy render APIs
+   - Slice 23 should leave the migration notes matching current repo reality
+
+### Recommended execution order
+
+1. Audit dependency compatibility one package at a time and record only evidence-backed changes.
+2. Decide whether Enzyme stays as a tolerated compatibility layer for now or becomes the primary cleanup target for this slice.
+3. Remove or document temporary React 19 compatibility shims that are no longer needed.
+4. Refresh the migration docs after the concrete cleanup decisions are made.
+
+### Suggested first checklist
+
+- inventory every remaining Enzyme-based test file
+- classify each as:
+  - leave as-is for now
+  - convert to non-Enzyme tests
+  - block on third-party component limitations
+- verify whether `@material-ui/core` and `react-toggle-switch` require upgrades, wrappers, or explicit risk notes
+- verify whether `react-i18next`, `formik`, `recharts`, and `react-datepicker` are on acceptable React 19-compatible versions
+- remove no-longer-needed compatibility code only after validation proves it is redundant
+- rerun:
+  - `yarn jest --runInBand`
+  - `yarn build`
+  - smoke checks

--- a/front-end/src/ato/main.test.js
+++ b/front-end/src/ato/main.test.js
@@ -1,17 +1,10 @@
 import React from 'react'
-import { shallow, mount } from 'enzyme'
-import { Provider } from 'react-redux'
-import Main from './main'
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
-import fetchMock from 'fetch-mock'
+import { RawATOMain } from './main'
 import 'isomorphic-fetch'
 
 jest.mock('utils/confirm', () => ({
   confirm: jest.fn().mockImplementation(() => Promise.resolve(true))
 }))
-
-const mockStore = configureMockStore([thunk])
 
 const ato = {
   id: '1', name: 'Top-off', enable: true,
@@ -23,49 +16,57 @@ const equipment = [{ id: 'pump1', name: 'ATO Pump' }]
 const inlets = [{ id: 'inlet1', name: 'Float Switch' }]
 const macros = []
 
-const storeState = { atos: [ato], equipment, inlets, macros }
-
 describe('ATO Main', () => {
+  const makeProps = (extra = {}) => ({
+    atos: [ato],
+    equipment,
+    inlets,
+    macros,
+    fetchATOs: jest.fn(),
+    fetchEquipment: jest.fn(),
+    fetchInlets: jest.fn(),
+    delete: jest.fn(),
+    update: jest.fn(),
+    reset: jest.fn(),
+    ...extra
+  })
+
   afterEach(() => {
-    fetchMock.reset()
-    fetchMock.restore()
+    jest.clearAllMocks()
   })
 
-  it('smoke test via Provider shallow', () => {
-    const store = mockStore(storeState)
-    expect(() =>
-      shallow(<Provider store={store}><Main /></Provider>)
-    ).not.toThrow()
+  it('fetches ATO dependencies on mount', () => {
+    const props = makeProps()
+    const component = new RawATOMain(props)
+
+    component.componentDidMount()
+
+    expect(props.fetchATOs).toHaveBeenCalled()
+    expect(props.fetchEquipment).toHaveBeenCalled()
+    expect(props.fetchInlets).toHaveBeenCalled()
   })
 
-  it('mounts with ATO list', () => {
-    fetchMock.get('/api/atos', [ato])
-    fetchMock.get('/api/equipment', equipment)
-    fetchMock.get('/api/inlets', inlets)
-    const store = mockStore(storeState)
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+  it('renders a collapsible entry for each ATO', () => {
+    const component = new RawATOMain(makeProps())
+    const panels = component.probeList()
+
+    expect(panels).toHaveLength(1)
+    expect(panels[0].props.name).toBe('panel-ato-1')
   })
 
-  it('mounts with empty ATO list', () => {
-    fetchMock.get('/api/atos', [])
-    fetchMock.get('/api/equipment', [])
-    fetchMock.get('/api/inlets', [])
-    const store = mockStore({ atos: [], equipment: [], inlets: [], macros: [] })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+  it('renders with an empty ATO list', () => {
+    const component = new RawATOMain(makeProps({ atos: [] }))
+    const panels = component.probeList()
+
+    expect(panels).toHaveLength(0)
   })
 
-  it('renders New sub-component for adding ATOs', () => {
-    fetchMock.get('/api/atos', [ato])
-    fetchMock.get('/api/equipment', equipment)
-    fetchMock.get('/api/inlets', inlets)
-    const store = mockStore(storeState)
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    // ATO main delegates add via New sub-component — just verify it renders
-    expect(wrapper.find('ul.list-group').length).toBeGreaterThan(0)
-    wrapper.unmount()
+  it('renders the add-new section', () => {
+    const component = new RawATOMain(makeProps())
+    const tree = component.render()
+    const list = tree.props.children
+
+    expect(list.type).toBe('ul')
+    expect(list.props.children).toHaveLength(2)
   })
 })

--- a/front-end/src/dashboard/config.jsx
+++ b/front-end/src/dashboard/config.jsx
@@ -5,7 +5,7 @@ import { fetchDashboard, updateDashboard } from 'redux/actions/dashboard'
 import { showError, showUpdateSuccessful } from 'utils/alert'
 import i18next from 'i18next'
 
-class config extends React.Component {
+export class RawDashboardConfig extends React.Component {
   constructor (props) {
     super(props)
     this.state = {
@@ -167,5 +167,5 @@ const mapDispatchToProps = dispatch => {
 const Config = connect(
   mapStateToProps,
   mapDispatchToProps
-)(config)
+)(RawDashboardConfig)
 export default Config

--- a/front-end/src/dashboard/dashboard.test.js
+++ b/front-end/src/dashboard/dashboard.test.js
@@ -1,78 +1,32 @@
 import React, { act } from 'react'
 import ComponentSelector from './component_selector'
-import Config from './config'
-import { shallow, mount } from 'enzyme'
-import { Provider } from 'react-redux'
-import configureMockStore from 'redux-mock-store'
+import { RawDashboardConfig } from './config'
 import Grid from './grid'
-import Main from './main'
+import { RawDashboardMain } from './main'
 import 'isomorphic-fetch'
-import fetchMock from 'fetch-mock'
-import thunk from 'redux-thunk'
-
-const mockStore = configureMockStore([thunk])
-
-// Minimal store state so connected child components don't crash
-const childState = {
-  equipment: [],
-  atos: [],
-  dosers: [],
-  journals: [],
-  lights: [],
-  light_usage: {},
-  ato_usage: {},
-  doser_usage: {},
-  journal_usage: {},
-  phprobes: [],
-  ph_readings: {},
-  tcs: [],
-  tc_usage: {},
-  sensors: [],
-  health_stats: {},
-  readings: []
-}
 
 describe('Dashboard', () => {
   const click = (node, event = {}) => {
     act(() => {
-      node.prop('onClick')(event)
+      node.props.onClick(event)
     })
   }
 
-  afterEach(() => {
-    fetchMock.reset()
-    fetchMock.restore()
-  })
-
   it('<Main /> smoke test via Provider (no config)', () => {
-    fetchMock.get('/api/dashboard', {})
-    const store = mockStore({ ...childState, dashboard: undefined })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+    const props = { config: undefined, fetchDashboard: jest.fn() }
+    const component = new RawDashboardMain(props)
+    component.componentDidMount()
+    expect(props.fetchDashboard).toHaveBeenCalled()
+    expect(component.charts()).toBeUndefined()
   })
 
   it('<Main /> renders with empty grid_details', () => {
-    fetchMock.get('/api/dashboard', {})
     const config = { row: 1, column: 1, width: 400, height: 200 }
-    const store = mockStore({ ...childState, dashboard: config })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+    const component = new RawDashboardMain({ config, fetchDashboard: jest.fn() })
+    expect(component.charts()).toBeUndefined()
   })
 
   it('<Main /> renders all chart types (switch coverage)', () => {
-    fetchMock.get('/api/dashboard', {})
-    fetchMock.get('/api/equipment', [])
-    fetchMock.get('/api/atos/1/usage', { historical: [] })
-    fetchMock.get('/api/doser/pumps/1/usage', { historical: [] })
-    fetchMock.get('/api/journal/1/usage', { historical: [] })
-    fetchMock.get('/api/lights/1/usage', { current: [] })
-    fetchMock.get('/api/phprobes/1/readings', { current: [], historical: [] })
-    fetchMock.get('/api/tcs/1/usage', { current: [], historical: [] })
-    fetchMock.get('/api/health_stats', {})
-    fetchMock.get('/api/lights', [])
-    fetchMock.get('/api/health', {})
     const config = {
       row: 3,
       column: 4,
@@ -99,30 +53,15 @@ describe('Dashboard', () => {
         ]
       ]
     }
-    const store = mockStore({
-      ...childState,
-      atos: [{ id: '1', name: 'ATO 1' }],
-      dosers: [{ id: '1', name: 'Doser 1' }],
-      journals: [{ id: '1', name: 'Journal 1', unit: 'ml' }],
-      lights: [{ id: '1', name: 'Light 1', channels: { blue: { name: 'Blue', color: '#00f' } } }],
-      light_usage: { 1: { current: [] } },
-      ato_usage: { 1: { historical: [] } },
-      phprobes: [{ id: '1', name: 'PH 1', chart: { color: '#00f', ymin: 0, ymax: 14, unit: 'pH' }, notify: { enable: false, min: 0, max: 0 } }],
-      journal_usage: { 1: { historical: [] } },
-      ph_readings: { 1: { current: [], historical: [] } },
-      doser_usage: { 1: { historical: [] } },
-      tcs: [{ id: '1', name: 'Temp 1', chart: { color: '#f00', ymin: 70, ymax: 90 }, fahrenheit: true }],
-      tc_usage: { 1: { current: [], historical: [] } },
-      dashboard: config
-    })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+    const component = new RawDashboardMain({ config, fetchDashboard: jest.fn() })
+    const rows = component.charts()
+    expect(rows).toHaveLength(3)
+    expect(rows[0].props.children).toHaveLength(4)
+    expect(rows[1].props.children).toHaveLength(4)
+    expect(rows[2].props.children).toHaveLength(4)
   })
 
   it('<Main /> renders temp_historical and default unknown types', () => {
-    fetchMock.get('/api/dashboard', {})
-    fetchMock.get('/api/tcs/1/usage', { current: [], historical: [] })
     const config = {
       row: 1,
       column: 2,
@@ -132,32 +71,19 @@ describe('Dashboard', () => {
         [{ type: 'temp_historical', id: '1' }, { type: 'unknown_widget', id: '1' }]
       ]
     }
-    const store = mockStore({
-      ...childState,
-      tcs: [{ id: '1', name: 'Temp 1', chart: { color: '#f00', ymin: 70, ymax: 90 }, fahrenheit: true }],
-      tc_usage: { 1: { current: [], historical: [] } },
-      dashboard: config
-    })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+    const component = new RawDashboardMain({ config, fetchDashboard: jest.fn() })
+    const rows = component.charts()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].props.children).toHaveLength(1)
   })
 
   it('<Main /> handleToggle switches to config view', () => {
-    fetchMock.get('/api/dashboard', {})
     const config = { row: 1, column: 1, width: 400, height: 200, grid_details: [[]] }
-    const store = mockStore({ ...childState, dashboard: config })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    click(wrapper.find('#configure-dashboard'))
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
-  })
+    const component = new RawDashboardMain({ config, fetchDashboard: jest.fn() })
+    component.setState = update => { component.state = { ...component.state, ...update } }
 
-  it('<Main /> old shallow dive still works for smoke', () => {
-    fetchMock.get('/api/dashboard', {})
-    const config = { row: 1, column: 1, width: 400, height: 200 }
-    const m = shallow(<Main store={mockStore({ dashboard: config })} />).dive()
-    expect(m).toBeDefined()
+    click(component.render().props.children.props.children[1].props.children.props.children)
+    expect(component.state.showConfig).toBe(true)
   })
 
   it('<Grid />', () => {
@@ -165,7 +91,8 @@ describe('Dashboard', () => {
       [{ id: '1', type: 'light' }, { id: '2', type: 'light' }],
       [{ id: '1', type:'equipment' }, { id: '2',type: 'ato' }],
     ]
-    const m = shallow(<Grid rows={2} columns={2} cells={cells} hook={() => {}} />).instance()
+    const m = new Grid({ rows: 2, columns: 2, cells, hook: () => {} })
+    m.setState = update => { m.state = { ...m.state, ...update } }
     m.setType(0, 0, 'equipment')()
     m.setID(0, 0)('1')
     m.menuItem('ato', true, 0, 1)
@@ -177,15 +104,28 @@ describe('Dashboard', () => {
       c1: { id: '1', name: 'foo' },
       c2: undefined
     }
-    const m = shallow(<ComponentSelector hook={() => {}} components={comps} current_id='1' />).instance()
+    const m = new ComponentSelector({ hook: () => {}, components: comps, current_id: '1' })
+    m.setState = update => { m.state = { ...m.state, ...update } }
     m.setID(1, 'foo')({})
   })
 
   it('<Config />', () => {
     const cells = [[{ type: 'ato', id: '1' }]]
     const config = { row: 1, column: 1, grid_details: cells }
-    const m = shallow(<Config store={mockStore({ dashboard: config })} />)
-      .dive()
-      .instance()
+    const m = new RawDashboardConfig({
+      config,
+      fetchDashboard: jest.fn(),
+      updateDashboard: jest.fn(),
+      atos: [],
+      phs: [],
+      tcs: [],
+      lights: [],
+      dosers: [],
+      equips: [],
+      journals: [],
+      blank: []
+    })
+    m.state = RawDashboardConfig.getDerivedStateFromProps({ config }, m.state) || { updated: false, config }
+    expect(m.render().props.className).toBe('col-12')
   })
 })

--- a/front-end/src/dashboard/main.jsx
+++ b/front-end/src/dashboard/main.jsx
@@ -18,7 +18,7 @@ import { numColsToColSize } from './grid'
 import ErrorBoundary from '../ui_components/error_boundary'
 import i18n from 'utils/i18n'
 
-class dashboard extends React.Component {
+export class RawDashboardMain extends React.Component {
   constructor (props) {
     super(props)
     this.state = {
@@ -234,5 +234,5 @@ const mapDispatchToProps = dispatch => {
 const Dashboard = connect(
   mapStateToProps,
   mapDispatchToProps
-)(dashboard)
+)(RawDashboardMain)
 export default Dashboard

--- a/front-end/src/doser/doser_pumps.test.js
+++ b/front-end/src/doser/doser_pumps.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import { mount } from 'enzyme'
-import { shallow } from 'enzyme'
+import { renderToStaticMarkup } from 'react-dom/server'
 import { Formik, Form } from 'formik'
 import EditDcPump from './edit_dcpump'
 import EditStepper from './edit_stepper'
@@ -17,116 +16,112 @@ const wrapFormik = (component, initialValues = {}) => (
   </Formik>
 )
 
+const renderMarkup = (component, initialValues = {}) =>
+  renderToStaticMarkup(wrapFormik(component, initialValues))
+
 const jacks = [{ id: '1', name: 'Jack 1', pins: [1, 2, 3] }]
 const outlets = [{ id: '1', name: 'Outlet A' }, { id: '2', name: 'Outlet B' }]
 
 describe('Doser pump components', () => {
   it('<EditDcPump /> renders with jacks', () => {
-    const wrapper = mount(
-      wrapFormik(
-        <EditDcPump
-          values={{ jack: '', pin: '', enable: true, continuous: false, volume_per_second: 0, duration: 10, speed: 100, soft_start: 0 }}
-          errors={{}}
-          touched={{}}
-          jacks={jacks}
-          readOnly={false}
-          handleChange={jest.fn()}
-          setFieldValue={jest.fn()}
-          onBlur={jest.fn()}
-        />
-      )
+    const html = renderMarkup(
+      <EditDcPump
+        values={{ jack: '', pin: '', enable: true, continuous: false, volume_per_second: 0, duration: 10, speed: 100, soft_start: 0 }}
+        errors={{}}
+        touched={{}}
+        jacks={jacks}
+        readOnly={false}
+        handleChange={jest.fn()}
+        setFieldValue={jest.fn()}
+        onBlur={jest.fn()}
+      />
     )
-    expect(wrapper.find('select').length).toBeGreaterThan(0)
+    expect(html).toContain('smoke-doser-jack')
+    expect(html).toContain('Jack 1')
   })
 
   it('<EditDcPump /> shows volume field when volume_per_second > 0', () => {
-    const wrapper = mount(
-      wrapFormik(
-        <EditDcPump
-          values={{ jack: '1', pin: 1, enable: true, continuous: false, volume_per_second: 1.5, volume: 50, speed: 100, soft_start: 0 }}
-          errors={{}}
-          touched={{}}
-          jacks={jacks}
-          readOnly={false}
-          handleChange={jest.fn()}
-          setFieldValue={jest.fn()}
-          onBlur={jest.fn()}
-        />
-      )
+    const html = renderMarkup(
+      <EditDcPump
+        values={{ jack: '1', pin: 1, enable: true, continuous: false, volume_per_second: 1.5, volume: 50, speed: 100, soft_start: 0 }}
+        errors={{}}
+        touched={{}}
+        jacks={jacks}
+        readOnly={false}
+        handleChange={jest.fn()}
+        setFieldValue={jest.fn()}
+        onBlur={jest.fn()}
+      />
     )
-    expect(wrapper.find('input').length).toBeGreaterThan(0)
+    expect(html).toContain('name="volume"')
+    expect(html).toContain('1.500 mL/s')
   })
 
   it('<EditDcPump /> hides volume/duration when continuous', () => {
-    const wrapper = mount(
-      wrapFormik(
-        <EditDcPump
-          values={{ jack: '1', pin: 1, enable: true, continuous: true, volume_per_second: 0, speed: 100, soft_start: 0 }}
-          errors={{}}
-          touched={{}}
-          jacks={jacks}
-          readOnly={false}
-          handleChange={jest.fn()}
-          setFieldValue={jest.fn()}
-          onBlur={jest.fn()}
-        />
-      )
+    const html = renderMarkup(
+      <EditDcPump
+        values={{ jack: '1', pin: 1, enable: true, continuous: true, volume_per_second: 0, speed: 100, soft_start: 0 }}
+        errors={{}}
+        touched={{}}
+        jacks={jacks}
+        readOnly={false}
+        handleChange={jest.fn()}
+        setFieldValue={jest.fn()}
+        onBlur={jest.fn()}
+      />
     )
-    expect(wrapper.find('select').length).toBeGreaterThan(0)
+    expect(html).not.toContain('smoke-doser-duration')
   })
 
   it('<EditDcPump /> readOnly', () => {
-    const wrapper = mount(
-      wrapFormik(
-        <EditDcPump
-          values={{ jack: '', pin: '', enable: true, continuous: false, volume_per_second: 0, duration: 10, speed: 100, soft_start: 0 }}
-          errors={{}}
-          touched={{}}
-          jacks={[]}
-          readOnly
-          handleChange={jest.fn()}
-          setFieldValue={jest.fn()}
-          onBlur={jest.fn()}
-        />
-      )
+    const html = renderMarkup(
+      <EditDcPump
+        values={{ jack: '', pin: '', enable: true, continuous: false, volume_per_second: 0, duration: 10, speed: 100, soft_start: 0 }}
+        errors={{}}
+        touched={{}}
+        jacks={[]}
+        readOnly
+        handleChange={jest.fn()}
+        setFieldValue={jest.fn()}
+        onBlur={jest.fn()}
+      />
     )
-    expect(wrapper.find('select[disabled]').length).toBeGreaterThan(0)
+    expect(html).toContain('smoke-doser-jack')
+    expect(html).toContain('disabled=""')
   })
 
   it('<EditStepper /> renders with outlets', () => {
-    const wrapper = mount(
-      wrapFormik(
-        <EditStepper
-          values={{ stepper: { step_pin: '', direction_pin: '', ms_pin_a: '', ms_pin_b: '', ms_pin_c: '', spr: 200, vpr: 0, delay: 0, direction: true, microstepping: 'Full' } }}
-          errors={{}}
-          touched={{}}
-          outlets={outlets}
-          readOnly={false}
-          handleChange={jest.fn()}
-          setFieldValue={jest.fn()}
-          onBlur={jest.fn()}
-        />
-      )
+    const html = renderMarkup(
+      <EditStepper
+        values={{ stepper: { step_pin: '', direction_pin: '', ms_pin_a: '', ms_pin_b: '', ms_pin_c: '', spr: 200, vpr: 0, delay: 0, direction: true, microstepping: 'Full' } }}
+        errors={{}}
+        touched={{}}
+        outlets={outlets}
+        readOnly={false}
+        handleChange={jest.fn()}
+        setFieldValue={jest.fn()}
+        onBlur={jest.fn()}
+      />
     )
-    expect(wrapper.find('select').length).toBeGreaterThan(0)
+    expect(html).toContain('Outlet A')
+    expect(html).toContain('stepper.step_pin')
   })
 
   it('<EditStepper /> readOnly', () => {
-    const wrapper = mount(
-      wrapFormik(
-        <EditStepper
-          values={{ stepper: { step_pin: '1', direction_pin: '', ms_pin_a: '', ms_pin_b: '', ms_pin_c: '', spr: 200, vpr: 0, delay: 0, direction: true, microstepping: 'Full' } }}
-          errors={{}}
-          touched={{}}
-          outlets={outlets}
-          readOnly
-          handleChange={jest.fn()}
-          setFieldValue={jest.fn()}
-          onBlur={jest.fn()}
-        />
-      )
+    const html = renderMarkup(
+      <EditStepper
+        values={{ stepper: { step_pin: '1', direction_pin: '', ms_pin_a: '', ms_pin_b: '', ms_pin_c: '', spr: 200, vpr: 0, delay: 0, direction: true, microstepping: 'Full' } }}
+        errors={{}}
+        touched={{}}
+        outlets={outlets}
+        readOnly
+        handleChange={jest.fn()}
+        setFieldValue={jest.fn()}
+        onBlur={jest.fn()}
+      />
     )
-    expect(wrapper.find('select[disabled]').length).toBeGreaterThan(0)
+    expect(html).toContain('stepper.step_pin')
+    expect(html).toContain('disabled=""')
   })
 
   it('<CalibrationModal /> renders for DC pump', () => {
@@ -136,16 +131,15 @@ describe('Doser pump components', () => {
       type: 'dcpump',
       regiment: { duration: 10, speed: 100, volume: 0, volume_per_second: 0.5 }
     }
-    const wrapper = shallow(
-      <CalibrationModal
-        doser={doser}
-        calibrateDoser={jest.fn()}
-        saveCalibration={jest.fn()}
-        cancel={jest.fn()}
-        confirm={jest.fn()}
-      />
-    )
-    expect(wrapper).toBeDefined()
+    const instance = new CalibrationModal({
+      doser,
+      calibrateDoser: jest.fn(),
+      saveCalibration: jest.fn(),
+      cancel: jest.fn(),
+      confirm: jest.fn()
+    })
+
+    expect(React.isValidElement(instance.render())).toBe(true)
   })
 
   it('<CalibrationModal /> handleCalibrate for DC pump', () => {

--- a/front-end/src/equipment/chart.jsx
+++ b/front-end/src/equipment/chart.jsx
@@ -21,7 +21,7 @@ class CustomToolTip extends React.Component {
   }
 }
 
-class chart extends React.Component {
+export class RawEquipmentChart extends React.Component {
   componentDidMount () {
     this.props.fetchEquipment()
     this.timer = window.setInterval(this.props.fetchEquipment, EQUIPMENT_POLL_INTERVAL_MS)
@@ -71,5 +71,5 @@ const mapDispatchToProps = dispatch => {
 const EquipmentChart = connect(
   mapStateToProps,
   mapDispatchToProps
-)(chart)
+)(RawEquipmentChart)
 export default EquipmentChart

--- a/front-end/src/equipment/equipment.test.js
+++ b/front-end/src/equipment/equipment.test.js
@@ -1,18 +1,14 @@
 import React, { act } from 'react'
-import { shallow } from 'enzyme'
+import { renderToStaticMarkup } from 'react-dom/server'
 import Equipment from './equipment'
 import ViewEquipment from './view_equipment'
 import EditEquipment from './edit_equipment'
 import EquipmentForm from './equipment_form'
-import Chart from './chart'
-import Main from './main'
+import { RawEquipmentChart } from './chart'
+import { RawEquipmentMain } from './main'
 import { buildEquipmentPayload, SORT_NAME_AZ, SORT_NAME_ZA, SORT_ON_FIRST, SORT_OFF_FIRST, sortEquipment } from './utils'
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
 import 'isomorphic-fetch'
 import * as Alert from '../utils/alert'
-
-const mockStore = configureMockStore([thunk])
 jest.mock('utils/confirm', () => {
   return {
     confirm: jest
@@ -25,12 +21,28 @@ jest.mock('utils/confirm', () => {
       .bind(this)
   }
 })
+
+const collectElements = (node, predicate, matches = []) => {
+  if (!React.isValidElement(node)) {
+    return matches
+  }
+
+  if (predicate(node)) {
+    matches.push(node)
+  }
+
+  React.Children.forEach(node.props.children, child => collectElements(child, predicate, matches))
+  return matches
+}
+
+const findFirst = (node, predicate) => collectElements(node, predicate)[0]
+
 describe('Equipment ui', () => {
   const eqs = [{ id: '1', outlet: '1', name: 'Foo', on: true }]
   const outlets = [{ id: '1', name: 'O1' }]
   const click = (node, event = {}) => {
     act(() => {
-      node.prop('onClick')(event)
+      node.props.onClick(event)
     })
   }
 
@@ -43,8 +55,22 @@ describe('Equipment ui', () => {
   })
 
   it('<Main />', () => {
-    const m = shallow(<Main store={mockStore({ outlets: outlets, equipment: eqs })} />)
-      .dive()
+    const props = {
+      outlets,
+      equipment: eqs,
+      fetch: jest.fn(),
+      fetchOutlets: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn()
+    }
+    const component = new RawEquipmentMain(props)
+
+    component.componentDidMount()
+
+    expect(props.fetch).toHaveBeenCalled()
+    expect(props.fetchOutlets).toHaveBeenCalled()
+    expect(component.render().type).toBe('ul')
   })
 
   it('sortEquipment supports all sort modes without mutating input', () => {
@@ -71,13 +97,12 @@ describe('Equipment ui', () => {
   })
 
   it('<Equipment />', () => {
-    shallow(<Equipment equipment={eqs[0]} update={() => true} delete={() => true} outlets={outlets} />).instance()
+    const instance = new Equipment({ equipment: eqs[0], update: () => Promise.resolve(true), delete: () => true, outlets })
+    expect(instance.selectedOutlet().name).toBe('O1')
   })
 
   it('should handle delete', () => {
-    const instance = shallow(
-      <Equipment equipment={eqs[0]} update={() => true} delete={() => true} outlets={outlets} />
-    ).instance()
+    const instance = new Equipment({ equipment: eqs[0], update: () => Promise.resolve(true), delete: () => true, outlets })
     const ev = {
       stopPropagation: () => {}
     }
@@ -85,18 +110,13 @@ describe('Equipment ui', () => {
   })
 
   it('should handle submit', () => {
-    const instance = shallow(
-      <Equipment
-        equipment={eqs[0]}
-        update={() => {
-          return new Promise(resolve => {
-            return resolve(true)
-          })
-        }}
-        delete={() => true}
-        outlets={outlets}
-      />
-    ).instance()
+    const instance = new Equipment({
+      equipment: eqs[0],
+      update: () => Promise.resolve(true),
+      delete: () => true,
+      outlets
+    })
+    instance.setState = update => { instance.state = { ...instance.state, ...update } }
     const values = {
       id: 1,
       name: 'test',
@@ -107,113 +127,141 @@ describe('Equipment ui', () => {
   })
 
   it('should handle an unrecognized outlet', () => {
-    shallow(
-      <Equipment equipment={eqs[0]} update={() => true} delete={() => true} outlets={[{ id: '2', name: 'O1' }]} />
-    ).instance()
+    const instance = new Equipment({
+      equipment: eqs[0],
+      update: () => Promise.resolve(true),
+      delete: () => true,
+      outlets: [{ id: '2', name: 'O1' }]
+    })
+    expect(instance.selectedOutlet()).toEqual({ name: '' })
   })
 
   it('should toggle edit', () => {
-    const instance = shallow(
-      <Equipment equipment={eqs[0]} update={() => true} delete={() => true} outlets={[{ id: '2', name: 'O1' }]} />
-    ).instance()
+    const instance = new Equipment({
+      equipment: eqs[0],
+      update: () => Promise.resolve(true),
+      delete: () => true,
+      outlets: [{ id: '2', name: 'O1' }]
+    })
+    instance.setState = update => { instance.state = { ...instance.state, ...update } }
 
     const e = {
       stopPropagation: () => {}
     }
     instance.handleToggleEdit(e)
+    expect(instance.state.readOnly).toBe(false)
   })
 
   it('<ViewEquipment />', () => {
-    shallow(
-      <ViewEquipment equipment={eqs[0]} update={() => true} delete={() => true} outlets={[{ id: '2', name: 'O1' }]} />
+    const tree = ViewEquipment(
+      { equipment: eqs[0], outletName: 'O1', onStateChange: () => true, onDelete: () => true, onEdit: () => true }
     )
+    expect(tree.type).toBe('div')
   })
 
   it('<ViewEquipment /> off', () => {
-    eqs[0].on = false
-    shallow(
-      <ViewEquipment equipment={eqs[0]} update={() => true} delete={() => true} outlets={[{ id: '2', name: 'O1' }]} />
+    const tree = ViewEquipment(
+      { equipment: { ...eqs[0], on: false }, outletName: 'O1', onStateChange: () => true, onDelete: () => true, onEdit: () => true }
     )
+    expect(tree.type).toBe('div')
   })
 
   it('<ViewEquipment /> should toggle state', () => {
-    const wrapper = shallow(
-      <ViewEquipment
-        onStateChange={() => true}
-        equipment={eqs[0]}
-        update={() => true}
-        delete={() => true}
-        outlets={[{ id: '2', name: 'O1' }]}
-      />
-    )
+    const onStateChange = jest.fn()
+    const tree = ViewEquipment({
+      onStateChange,
+      equipment: eqs[0],
+      outletName: 'O1',
+      onDelete: () => true,
+      onEdit: () => true
+    })
+    const toggle = findFirst(tree, child => child.props && typeof child.props.onClick === 'function' && child.props.on === true)
 
-    click(wrapper.find('Switch'))
+    click(toggle)
+    expect(onStateChange).toHaveBeenCalledWith('1', {
+      name: 'Foo',
+      on: false,
+      outlet: '1',
+      stay_off_on_boot: undefined
+    })
   })
 
   it('<EditEquipment />', () => {
-    shallow(
-      <EditEquipment
-        actionLabel='save'
-        values={{ id: 1 }}
-        update={() => true}
-        delete={() => true}
-        outlets={[{ id: '1', name: 'O1' }]}
-        handleBlur={() => true}
-        submitForm={() => true}
-      />
-    )
+    const tree = EditEquipment({
+      actionLabel: 'save',
+      values: { id: 1, name: '', outlet: '', stay_off_on_boot: false, boot_delay: 0 },
+      errors: {},
+      touched: {},
+      update: () => true,
+      delete: () => true,
+      outlets: [{ id: '1', name: 'O1' }],
+      handleBlur: () => true,
+      submitForm: () => true,
+      handleChange: () => true
+    })
+    expect(tree.type).toBe('form')
   })
 
   it('<EditEquipment /> New Item', () => {
-    shallow(
-      <EditEquipment
-        actionLabel='save'
-        values={{ id: null }}
-        update={() => true}
-        delete={() => true}
-        outlets={[{ id: '1', name: 'O1' }]}
-        handleBlur={() => true}
-        submitForm={() => true}
-      />
-    )
+    const tree = EditEquipment({
+      actionLabel: 'save',
+      values: { id: null, name: '', outlet: '', stay_off_on_boot: false, boot_delay: 0 },
+      errors: {},
+      touched: {},
+      update: () => true,
+      delete: () => true,
+      outlets: [{ id: '1', name: 'O1' }],
+      handleBlur: () => true,
+      submitForm: () => true,
+      handleChange: () => true
+    })
+    expect(tree.type).toBe('form')
   })
 
   it('<EditEquipment /> should submit', () => {
-    const wrapper = shallow(
-      <EditEquipment
-        actionLabel='save'
-        values={{ id: null }}
-        update={() => true}
-        delete={() => true}
-        handleBlur={() => true}
-        submitForm={() => true}
-        isValid
-        outlets={[{ id: '1', name: 'O1' }]}
-      />
-    )
-    wrapper.find('form').simulate('submit', { preventDefault: () => {} })
+    const submitForm = jest.fn()
+    const tree = EditEquipment({
+      actionLabel: 'save',
+      values: { id: null, name: '', outlet: '', stay_off_on_boot: false, boot_delay: 0 },
+      errors: {},
+      touched: {},
+      update: () => true,
+      delete: () => true,
+      handleBlur: () => true,
+      submitForm,
+      handleChange: () => true,
+      isValid: true,
+      dirty: true,
+      outlets: [{ id: '1', name: 'O1' }]
+    })
+    tree.props.onSubmit({ preventDefault: () => {} })
+    expect(submitForm).toHaveBeenCalled()
     expect(Alert.showError).not.toHaveBeenCalled()
   })
 
   it('<EditEquipment /> should show alert when invalid', () => {
-    const wrapper = shallow(
-      <EditEquipment
-        actionLabel='save'
-        values={{ id: null }}
-        update={() => true}
-        delete={() => true}
-        handleBlur={() => true}
-        submitForm={() => true}
-        isValid={false}
-        outlets={[{ id: '1', name: 'O1' }]}
-      />
-    )
-    wrapper.find('form').simulate('submit', { preventDefault: () => {} })
+    const submitForm = jest.fn()
+    const tree = EditEquipment({
+      actionLabel: 'save',
+      values: { id: null, name: '', outlet: '', stay_off_on_boot: false, boot_delay: 0 },
+      errors: {},
+      touched: {},
+      update: () => true,
+      delete: () => true,
+      handleBlur: () => true,
+      submitForm,
+      handleChange: () => true,
+      isValid: false,
+      dirty: true,
+      outlets: [{ id: '1', name: 'O1' }]
+    })
+    tree.props.onSubmit({ preventDefault: () => {} })
+    expect(submitForm).toHaveBeenCalled()
     expect(Alert.showError).toHaveBeenCalled()
   })
 
   it('<EquipmentForm />', () => {
-    const wrapper = shallow(
+    const html = renderToStaticMarkup(
       <EquipmentForm
         actionLabel='save'
         values={{ id: null }}
@@ -224,17 +272,25 @@ describe('Equipment ui', () => {
         isValid={false}
         outlets={[{ id: '1', name: 'O1' }]}
       />
-    ).instance()
-    wrapper.handleSubmit()
+    )
+    expect(html).toContain('smoke-equipment-name')
   })
 
   it('<Chart />', () => {
-    const m = shallow(<Chart store={mockStore({ equipment: eqs })} />)
-      .dive()
-      .instance()
+    jest.useFakeTimers()
+    const fetchEquipment = jest.fn()
+    const component = new RawEquipmentChart({ equipment: eqs, fetchEquipment, height: 200 })
+
+    component.componentDidMount()
+
+    expect(fetchEquipment).toHaveBeenCalled()
+    expect(component.render().props.className).toBe('container')
+    component.componentWillUnmount()
+    jest.useRealTimers()
   })
 
   it('<Chart />', () => {
-    shallow(<Chart store={mockStore()} />).dive()
+    const component = new RawEquipmentChart({ equipment: undefined, fetchEquipment: jest.fn(), height: 200 })
+    expect(component.render().type).toBe('div')
   })
 })

--- a/front-end/src/equipment/main.jsx
+++ b/front-end/src/equipment/main.jsx
@@ -14,7 +14,7 @@ const sortOptions = [
   { value: SORT_OFF_FIRST, label: 'equipment:sort_off_first' }
 ]
 
-class main extends React.Component {
+export class RawEquipmentMain extends React.Component {
   constructor (props) {
     super(props)
 
@@ -131,5 +131,5 @@ const mapDispatchToProps = dispatch => {
 const Main = connect(
   mapStateToProps,
   mapDispatchToProps
-)(main)
+)(RawEquipmentMain)
 export default Main

--- a/front-end/src/journal/journal.test.js
+++ b/front-end/src/journal/journal.test.js
@@ -1,67 +1,164 @@
 import React from 'react'
 import { act } from 'react'
-import { shallow, mount } from 'enzyme'
-import { Provider } from 'react-redux'
+import { createRoot } from 'react-dom/client'
 import Journal from './journal'
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
-import fetchMock from 'fetch-mock'
-import 'isomorphic-fetch'
+import { useDispatch } from 'react-redux'
+import { fetchJournal, fetchJournalUsage, recordJournal, updateJournal } from 'redux/actions/journal'
 
-const mockStore = configureMockStore([thunk])
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+jest.mock('i18next', () => ({
+  t: key => key
+}))
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn()
+}))
+
+jest.mock('redux/actions/journal', () => ({
+  fetchJournal: jest.fn(id => ({ type: 'FETCH_JOURNAL', id })),
+  fetchJournalUsage: jest.fn(id => ({ type: 'FETCH_JOURNAL_USAGE', id })),
+  recordJournal: jest.fn((id, payload) => ({ type: 'RECORD_JOURNAL', id, payload })),
+  updateJournal: jest.fn((id, payload) => ({ type: 'UPDATE_JOURNAL', id, payload }))
+}))
+
+jest.mock('./form', () => {
+  const React = require('react')
+  return function MockJournalForm (props) {
+    return React.createElement(
+      'button',
+      {
+        type: 'button',
+        'data-testid': 'journal-form-submit',
+        onClick: () => props.onSubmit({
+          id: props.data.id,
+          name: 'Updated Journal',
+          description: 'updated description',
+          unit: 'dKH'
+        })
+      },
+      'journal-form'
+    )
+  }
+})
+
+jest.mock('./entry_form', () => {
+  const React = require('react')
+  return function MockEntryForm (props) {
+    return React.createElement(
+      'button',
+      {
+        type: 'button',
+        'data-testid': 'entry-form-submit',
+        onClick: () => props.onSubmit({ value: '8.2', comment: 'daily check' })
+      },
+      'entry-form'
+    )
+  }
+})
+
+jest.mock('./chart', () => {
+  const React = require('react')
+  return function MockChart (props) {
+    return React.createElement('div', { 'data-testid': 'journal-chart', 'data-journal-id': props.journal_id })
+  }
+})
 
 const config = { id: '1', name: 'pH Log', description: 'daily', unit: 'pH' }
 
-const makeStore = () => mockStore({ journals: [config], journal_usage: {} })
-
-const render = (extraProps = {}) => {
-  const store = makeStore()
-  fetchMock.getOnce('/api/journal/1/usage', {})
-  fetchMock.getOnce('/api/journal/1', config)
-  return mount(
-    <Provider store={store}>
-      <Journal config={config} readOnly={false} expanded={false} {...extraProps} />
-    </Provider>
-  )
-}
-
 describe('<Journal />', () => {
-  afterEach(() => {
-    fetchMock.reset()
-    fetchMock.restore()
+  const dispatch = jest.fn()
+
+  beforeEach(() => {
+    dispatch.mockClear()
     jest.clearAllMocks()
+    useDispatch.mockReturnValue(dispatch)
   })
 
-  it('renders without throwing', () => {
-    expect(() => render()).not.toThrow()
-  })
+  const renderJournal = (extraProps = {}) => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
 
-  it('renders Add Entry button', () => {
-    const wrapper = render()
-    const btn = wrapper.find('input#add_entry')
-    expect(btn).toHaveLength(1)
-  })
-
-  it('renders entry form after clicking Add Entry', () => {
-    const store = makeStore()
-    fetchMock.getOnce('/api/journal/1/usage', {})
-    const wrapper = mount(
-      <Provider store={store}>
-        <Journal config={config} readOnly={false} expanded={false} />
-      </Provider>
-    )
     act(() => {
-      wrapper.find('input#add_entry').prop('onClick')()
+      root.render(<Journal config={config} readOnly={false} expanded={false} {...extraProps} />)
     })
-    wrapper.update()
-    // After toggle, entry form should appear
-    expect(wrapper.find('input#add_entry').prop('value')).toBe('-')
+
+    return {
+      container,
+      unmount: () => act(() => root.unmount())
+    }
+  }
+
+  it('renders the chart and add entry button', () => {
+    const { container, unmount } = renderJournal()
+
+    expect(container.querySelector('[data-testid="journal-chart"]')).toBeDefined()
+    expect(container.querySelector('input#add_entry')).toBeDefined()
+
+    unmount()
   })
 
-  it('shallow renders without throwing', () => {
-    const store = makeStore()
-    expect(() =>
-      shallow(<Provider store={store}><Journal config={config} readOnly={false} expanded={false} /></Provider>)
-    ).not.toThrow()
+  it('renders the entry form after clicking Add Entry', () => {
+    const { container, unmount } = renderJournal()
+    const addEntryButton = container.querySelector('input#add_entry')
+
+    act(() => {
+      addEntryButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(addEntryButton.value).toBe('-')
+    expect(container.querySelector('[data-testid="entry-form-submit"]')).toBeDefined()
+
+    unmount()
+  })
+
+  it('dispatches update and reload when the journal form submits', () => {
+    const { container, unmount } = renderJournal()
+
+    act(() => {
+      container.querySelector('[data-testid="journal-form-submit"]').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(updateJournal).toHaveBeenCalledWith('1', {
+      name: 'Updated Journal',
+      description: 'updated description',
+      unit: 'dKH'
+    })
+    expect(fetchJournal).toHaveBeenCalledWith('1')
+    expect(dispatch).toHaveBeenNthCalledWith(1, {
+      type: 'UPDATE_JOURNAL',
+      id: '1',
+      payload: {
+        name: 'Updated Journal',
+        description: 'updated description',
+        unit: 'dKH'
+      }
+    })
+    expect(dispatch).toHaveBeenNthCalledWith(2, { type: 'FETCH_JOURNAL', id: '1' })
+
+    unmount()
+  })
+
+  it('dispatches record and usage refresh when the entry form submits', () => {
+    const { container, unmount } = renderJournal()
+
+    act(() => {
+      container.querySelector('input#add_entry').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    act(() => {
+      container.querySelector('[data-testid="entry-form-submit"]').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(recordJournal).toHaveBeenCalledWith('1', { value: '8.2', comment: 'daily check' })
+    expect(fetchJournalUsage).toHaveBeenCalledWith('1')
+    expect(dispatch).toHaveBeenNthCalledWith(1, {
+      type: 'RECORD_JOURNAL',
+      id: '1',
+      payload: { value: '8.2', comment: 'daily check' }
+    })
+    expect(dispatch).toHaveBeenNthCalledWith(2, { type: 'FETCH_JOURNAL_USAGE', id: '1' })
+    expect(container.querySelector('input#add_entry').value).toBe('journal:add_entry')
+
+    unmount()
   })
 })

--- a/front-end/src/lighting/charts/charts.test.js
+++ b/front-end/src/lighting/charts/charts.test.js
@@ -1,14 +1,9 @@
 import React from 'react'
-import { shallow } from 'enzyme'
 import DiurnalChart from './diurnal'
 import FixedChart from './fixed'
 import IntervalChart from './interval'
-import GenericLightChart from './generic'
-import configureMockStore from 'redux-mock-store'
+import { RawGenericLightChart } from './generic'
 import 'isomorphic-fetch'
-import thunk from 'redux-thunk'
-
-const mockStore = configureMockStore([thunk])
 
 const baseChannel = {
   name: 'Blue LED',
@@ -17,10 +12,23 @@ const baseChannel = {
   max: 100
 }
 
+const collectElements = (node, predicate, matches = []) => {
+  if (!React.isValidElement(node)) {
+    return matches
+  }
+
+  if (predicate(node)) {
+    matches.push(node)
+  }
+
+  React.Children.forEach(node.props.children, child => collectElements(child, predicate, matches))
+  return matches
+}
+
 describe('DiurnalChart', () => {
   it('renders loading span when channel is undefined', () => {
-    const wrapper = shallow(<DiurnalChart height={200} />)
-    expect(wrapper.find('span').length).toBeGreaterThan(0)
+    const tree = new DiurnalChart({ height: 200 }).render()
+    expect(tree.type).toBe('span')
   })
 
   it('renders chart with a normal channel (start before end)', () => {
@@ -28,8 +36,8 @@ describe('DiurnalChart', () => {
       ...baseChannel,
       profile: { config: { start: '08:00:00', end: '20:00:00' } }
     }
-    const wrapper = shallow(<DiurnalChart channel={ch} height={200} />)
-    expect(wrapper.find('.container').length).toBe(1)
+    const tree = new DiurnalChart({ channel: ch, height: 200 }).render()
+    expect(tree.props.className).toBe('container')
   })
 
   it('renders chart when start is after end (crosses midnight)', () => {
@@ -37,8 +45,8 @@ describe('DiurnalChart', () => {
       ...baseChannel,
       profile: { config: { start: '22:00:00', end: '06:00:00' } }
     }
-    const wrapper = shallow(<DiurnalChart channel={ch} height={200} />)
-    expect(wrapper.find('.container').length).toBe(1)
+    const tree = new DiurnalChart({ channel: ch, height: 200 }).render()
+    expect(tree.props.className).toBe('container')
   })
 
   it('uses black stroke when color is empty string', () => {
@@ -47,15 +55,16 @@ describe('DiurnalChart', () => {
       color: '',
       profile: { config: { start: '08:00:00', end: '20:00:00' } }
     }
-    const wrapper = shallow(<DiurnalChart channel={ch} height={200} />)
-    expect(wrapper.find('.container').length).toBe(1)
+    const tree = new DiurnalChart({ channel: ch, height: 200 }).render()
+    const line = collectElements(tree, child => child.props && child.props.stroke !== undefined)[0]
+    expect(line.props.stroke).toBe('#000')
   })
 })
 
 describe('FixedChart', () => {
   it('renders loading span when channel is undefined', () => {
-    const wrapper = shallow(<FixedChart height={200} />)
-    expect(wrapper.find('span').length).toBeGreaterThan(0)
+    const tree = new FixedChart({ height: 200 }).render()
+    expect(tree.type).toBe('span')
   })
 
   it('renders bar chart with channel data', () => {
@@ -63,8 +72,8 @@ describe('FixedChart', () => {
       ...baseChannel,
       profile: { config: { start: '08:00:00', end: '20:00:00', value: 75 } }
     }
-    const wrapper = shallow(<FixedChart channel={ch} height={200} />)
-    expect(wrapper.find('.container').length).toBe(1)
+    const tree = new FixedChart({ channel: ch, height: 200 }).render()
+    expect(tree.props.className).toBe('container')
   })
 
   it('uses black fill when color is undefined', () => {
@@ -72,15 +81,16 @@ describe('FixedChart', () => {
       name: 'Blue LED',
       profile: { config: { start: '08:00:00', end: '20:00:00', value: 75 } }
     }
-    const wrapper = shallow(<FixedChart channel={ch} height={200} />)
-    expect(wrapper.find('.container').length).toBe(1)
+    const tree = new FixedChart({ channel: ch, height: 200 }).render()
+    const bar = collectElements(tree, child => child.props && child.props.fill !== undefined)[0]
+    expect(bar.props.fill).toBe('#000')
   })
 })
 
 describe('IntervalChart', () => {
   it('renders loading span when channel is undefined', () => {
-    const wrapper = shallow(<IntervalChart height={200} />)
-    expect(wrapper.find('span').length).toBeGreaterThan(0)
+    const tree = new IntervalChart({ height: 200 }).render()
+    expect(tree.type).toBe('span')
   })
 
   it('renders line chart with interval values', () => {
@@ -88,8 +98,8 @@ describe('IntervalChart', () => {
       ...baseChannel,
       profile: { config: { start: '08:00:00', interval: '3600', values: [10, 50, 90] } }
     }
-    const wrapper = shallow(<IntervalChart channel={ch} height={200} />)
-    expect(wrapper.find('.container').length).toBe(1)
+    const tree = new IntervalChart({ channel: ch, height: 200 }).render()
+    expect(tree.props.className).toBe('container')
   })
 
   it('uses black stroke when color is empty string', () => {
@@ -98,8 +108,9 @@ describe('IntervalChart', () => {
       color: '',
       profile: { config: { start: '08:00:00', interval: '3600', values: [20, 80] } }
     }
-    const wrapper = shallow(<IntervalChart channel={ch} height={200} />)
-    expect(wrapper.find('.container').length).toBe(1)
+    const tree = new IntervalChart({ channel: ch, height: 200 }).render()
+    const line = collectElements(tree, child => child.props && child.props.stroke !== undefined)[0]
+    expect(line.props.stroke).toBe('#000')
   })
 })
 
@@ -113,32 +124,59 @@ describe('GenericLightChart', () => {
   }
 
   it('renders loading span when usage is missing', () => {
-    const store = mockStore({ lights: [lightConfig], light_usage: {} })
-    const wrapper = shallow(<GenericLightChart light_id='1' store={store} />).dive()
-    expect(wrapper).toBeDefined()
+    const tree = new RawGenericLightChart({
+      light_id: '1',
+      light: lightConfig,
+      usage: undefined,
+      fetch: jest.fn(),
+      height: 200
+    }).render()
+    expect(tree.type).toBe('span')
   })
 
   it('renders loading span when light config is missing', () => {
-    const store = mockStore({ lights: [], light_usage: { 1: { current: [] } } })
-    const wrapper = shallow(<GenericLightChart light_id='1' store={store} />).dive()
-    expect(wrapper).toBeDefined()
+    const tree = new RawGenericLightChart({
+      light_id: '1',
+      light: undefined,
+      usage: { current: [] },
+      fetch: jest.fn(),
+      height: 200
+    }).render()
+    expect(tree.type).toBe('span')
   })
 
   it('renders chart when light and usage are present', () => {
     const usage = { current: [{ time: '10:00', channels: { 1: 50 } }] }
-    const store = mockStore({ lights: [lightConfig], light_usage: { 1: usage } })
-    const wrapper = shallow(<GenericLightChart light_id='1' store={store} />).dive()
-    expect(wrapper).toBeDefined()
+    const tree = new RawGenericLightChart({
+      light_id: '1',
+      light: lightConfig,
+      usage,
+      fetch: jest.fn(),
+      height: 200
+    }).render()
+    expect(tree.props.className).toBe('container')
   })
 
   it('clears interval on unmount', () => {
     jest.useFakeTimers()
-    const usage = { current: [] }
-    const store = mockStore({ lights: [lightConfig], light_usage: { 1: usage } })
-    const wrapper = shallow(<GenericLightChart light_id='1' store={store} />).dive()
+    const fetch = jest.fn()
+    const clearIntervalSpy = jest.spyOn(window, 'clearInterval')
+    const component = new RawGenericLightChart({
+      light_id: '1',
+      light: lightConfig,
+      usage: { current: [] },
+      fetch,
+      height: 200
+    })
+    component.setState = update => { component.state = { ...component.state, ...update } }
+
+    component.componentDidMount()
     jest.advanceTimersByTime(15000)
-    wrapper.unmount()
+    component.componentWillUnmount()
+
+    expect(fetch).toHaveBeenCalledWith('1')
+    expect(clearIntervalSpy).toHaveBeenCalled()
+    clearIntervalSpy.mockRestore()
     jest.useRealTimers()
-    expect(wrapper).toBeDefined()
   })
 })

--- a/front-end/src/lighting/charts/generic.jsx
+++ b/front-end/src/lighting/charts/generic.jsx
@@ -6,7 +6,7 @@ import i18next from 'i18next'
 import { TwoDecimalParse } from 'utils/two_decimal_parse'
 import { ParseTimestamp } from 'utils/timestamp'
 
-class chart extends React.Component {
+export class RawGenericLightChart extends React.Component {
   componentDidMount () {
     this.props.fetch(this.props.light_id)
     const timer = window.setInterval(() => { this.props.fetch(this.props.light.id) }, 10 * 1000)
@@ -81,5 +81,5 @@ const mapDispatchToProps = (dispatch) => {
   }
 }
 
-const GenericLightChart = connect(mapStateToProps, mapDispatchToProps)(chart)
+const GenericLightChart = connect(mapStateToProps, mapDispatchToProps)(RawGenericLightChart)
 export default GenericLightChart

--- a/front-end/src/temperature/edit_temperature.test.js
+++ b/front-end/src/temperature/edit_temperature.test.js
@@ -1,21 +1,54 @@
 import React from 'react'
-import { shallow } from 'enzyme'
 import ControlChart from './control_chart'
 import EditTemperature from './edit_temperature'
 import ReadingsChart from './readings_chart'
 import 'isomorphic-fetch'
 import * as Alert from '../utils/alert'
 
+const collectElements = (node, predicate, matches = []) => {
+  if (!React.isValidElement(node)) {
+    return matches
+  }
+
+  if (predicate(node)) {
+    matches.push(node)
+  }
+
+  React.Children.forEach(node.props.children, child => collectElements(child, predicate, matches))
+  return matches
+}
+
+const findFirst = (node, predicate) => collectElements(node, predicate)[0]
 
 describe('<EditTemperature />', () => {
-  let values = {chart: {}}
-  let sensors = [{ id: 'sensor' }]
+  let values = { chart: {} }
+  let sensors = ['sensor']
   let equipment = [{ id: '1', name: 'EQ' }]
   let macros = [{ id: '1', name: 'Macro' }]
-  let fn = jest.fn()
+  let submitForm = jest.fn()
+
+  const renderComponent = (extraProps = {}) => EditTemperature({
+    values,
+    errors: {},
+    touched: {},
+    sensors,
+    equipment,
+    macros,
+    analogInputs: [],
+    submitForm,
+    handleBlur: jest.fn(),
+    handleChange: jest.fn(),
+    readOnly: false,
+    showChart: true,
+    dirty: true,
+    isValid: true,
+    ...extraProps
+  })
 
   beforeEach(() => {
     jest.spyOn(Alert, 'showError')
+    jest.spyOn(Alert, 'showUpdateSuccessful')
+    submitForm = jest.fn()
 
     values = {
       id: '1',
@@ -23,6 +56,7 @@ describe('<EditTemperature />', () => {
       enable: true,
       one_shot: false,
       sensor: 'sensor',
+      analog_input: '',
       fahrenheit: true,
       period: 60,
       min: 72,
@@ -31,7 +65,7 @@ describe('<EditTemperature />', () => {
       cooler: '',
       alerts: false,
       control: 'macro',
-      chart: { color: '#000'}
+      chart: { color: '#000' }
     }
   })
 
@@ -40,147 +74,74 @@ describe('<EditTemperature />', () => {
   })
 
   it('should not show charts when showChart is false', () => {
-    const wrapper = shallow(
-      <EditTemperature
-        values={values}
-        sensors={sensors}
-        equipment={equipment}
-        macros={macros}
-        handleBlur={fn}
-        handleChange={fn}
-        submitForm={fn}
-        showChart={false}
-      />
-    )
+    const element = renderComponent({ showChart: false })
 
-    expect(wrapper.find(ReadingsChart).length).toBe(0)
-    expect(wrapper.find(ControlChart).length).toBe(0)
+    expect(collectElements(element, child => child.type === ReadingsChart)).toHaveLength(0)
+    expect(collectElements(element, child => child.type === ControlChart)).toHaveLength(0)
   })
 
   it('should show reading charts when showChart is true but hide control chart', () => {
-    const wrapper = shallow(
-      <EditTemperature
-        values={values}
-        sensors={sensors}
-        equipment={equipment}
-        macros={macros}
-        handleBlur={fn}
-        handleChange={fn}
-        submitForm={fn}
-        showChart
-      />
-    )
+    const element = renderComponent()
 
-    expect(wrapper.find(ReadingsChart).length).toBe(1)
-    expect(wrapper.find(ControlChart).length).toBe(0)
+    expect(collectElements(element, child => child.type === ReadingsChart)).toHaveLength(1)
+    expect(collectElements(element, child => child.type === ControlChart)).toHaveLength(0)
   })
 
   it('should show both charts when heater or chiller is used', () => {
     values.heater = '2'
     values.cooler = '4'
 
-    const wrapper = shallow(
-      <EditTemperature
-        values={values}
-        sensors={sensors}
-        equipment={equipment}
-        macros={macros}
-        handleBlur={fn}
-        handleChange={fn}
-        submitForm={fn}
-        showChart
-      />
-    )
+    const element = renderComponent()
 
-    expect(wrapper.find(ReadingsChart).length).toBe(1)
-    expect(wrapper.find(ControlChart).length).toBe(1)
+    expect(collectElements(element, child => child.type === ReadingsChart)).toHaveLength(1)
+    expect(collectElements(element, child => child.type === ControlChart)).toHaveLength(1)
   })
 
-  it('<EditEquipment /> should submit', () => {
-    const wrapper = shallow(
-      <EditTemperature
-        values={values}
-        sensors={sensors}
-        equipment={equipment}
-        macros={macros}
-        handleBlur={fn}
-        handleChange={fn}
-        submitForm={fn}
-        showChart
-        dirty
-        isValid
-      />
-    )
-    wrapper.find('form').simulate('submit', { preventDefault: () => {} })
+  it('submits successfully when the form is valid', () => {
+    const element = renderComponent()
+    const form = findFirst(element, child => child.type === 'form')
+
+    form.props.onSubmit({ preventDefault: jest.fn() })
+
+    expect(submitForm).toHaveBeenCalled()
     expect(Alert.showError).not.toHaveBeenCalled()
+    expect(Alert.showUpdateSuccessful).toHaveBeenCalled()
   })
 
-  it('<EditEquipment /> should show alert when invalid', () => {
+  it('shows alert when the form is invalid', () => {
     values.name = ''
     values.fahrenheit = false
-    const wrapper = shallow(
-      <EditTemperature
-        values={values}
-        sensors={sensors}
-        equipment={equipment}
-        macros={macros}
-        handleBlur={fn}
-        handleChange={fn}
-        submitForm={fn}
-        showChart
-        dirty
-        isValid={false}
-      />
-    )
-    wrapper.find('form').simulate('submit', { preventDefault: () => {} })
+
+    const element = renderComponent({ isValid: false })
+    const form = findFirst(element, child => child.type === 'form')
+
+    form.props.onSubmit({ preventDefault: jest.fn() })
+
+    expect(submitForm).toHaveBeenCalled()
     expect(Alert.showError).toHaveBeenCalled()
   })
 
-  it('<EditEquipment /> should disable inputs when controlling nothing', () => {
-
+  it('disables control inputs when controlling nothing', () => {
     values.control = ''
 
-    const wrapper = shallow(
-      <EditTemperature
-        values={values}
-        sensors={sensors}
-        equipment={equipment}
-        macros={macros}
-        handleBlur={fn}
-        handleChange={fn}
-        submitForm={fn}
-        showChart
-        dirty
-        isValid={false}
-      />
+    const element = renderComponent({ isValid: false })
+    const heaterField = findFirst(
+      element,
+      child => child.props.name === 'heater' && child.props.className === 'custom-select'
     )
 
-    const upperFunction = wrapper.find({name: 'heater', className: 'custom-select'})
-    expect(upperFunction.prop('disabled')).toBe(true)
+    expect(heaterField.props.disabled).toBe(true)
   })
 
-
-  it('<EditEquipment /> should enable inputs when controlling equipment', () => {
-
+  it('enables control inputs when controlling equipment', () => {
     values.control = 'equipment'
 
-    const wrapper = shallow(
-      <EditTemperature
-        values={values}
-        sensors={sensors}
-        equipment={equipment}
-        macros={macros}
-        handleBlur={fn}
-        handleChange={fn}
-        submitForm={fn}
-        showChart
-        dirty
-        isValid={false}
-      />
+    const element = renderComponent({ isValid: false })
+    const heaterField = findFirst(
+      element,
+      child => child.props.name === 'heater' && child.props.className === 'custom-select'
     )
 
-    const upperFunction = wrapper.find({name: 'heater', className: 'custom-select'})
-    expect(upperFunction.prop('disabled')).toBe(false)
+    expect(heaterField.props.disabled).toBe(false)
   })
-
 })

--- a/front-end/src/timers/edit_timer.test.js
+++ b/front-end/src/timers/edit_timer.test.js
@@ -148,25 +148,22 @@ describe('<EditTimer />', () => {
   })
 
   it('EditTimer /> should set lightings target with correct defaults when lightings is selected', () => {
-    values.type = 'lightings'
-
     const changeHandler = jest.fn()
+    const typeField = findAll(EditTimer({
+      values: { ...values, type: 'lightings' },
+      equipment,
+      handleBlur: fn,
+      handleChange: changeHandler,
+      submitForm: fn,
+      macros,
+      showChart: true,
+      errors: {},
+      touched: {},
+      dirty: true,
+      isValid: false
+    }), node => node.props?.name === 'type')[0]
 
-    const wrapper = shallow(
-      <EditTimer values={values}
-        equipment={equipment}
-        handleBlur={fn}
-        handleChange={changeHandler}
-        submitForm={fn}
-        macros={macros}
-        showChart
-        errors={{}}
-        touched={{}}
-        dirty
-        isValid={false} />
-    )
-
-    wrapper.find({component: 'select', name: 'type'}).simulate('change', {target: {name: 'type', value: 'lightings'}})
+    typeField.props.onChange({ target: { name: 'type', value: 'lightings' } })
 
     expect(changeHandler.mock.calls.length).toBe(2)
     expect(changeHandler.mock.calls[1][0].target.value).toEqual({ id: '', on: true, revert: false, duration: 60 })

--- a/front-end/src/timers/timers.test.js
+++ b/front-end/src/timers/timers.test.js
@@ -1,14 +1,13 @@
 import React from 'react'
-import { shallow, mount } from 'enzyme'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { renderToStaticMarkup } from 'react-dom/server'
 import { Provider } from 'react-redux'
 import configureMockStore from 'redux-mock-store'
-import Main from './main'
-import TimerForm from './timer_form'
 import thunk from 'redux-thunk'
+import { RawTimersMain } from './main'
+import TimerForm from './timer_form'
 import 'isomorphic-fetch'
-import fetchMock from 'fetch-mock'
-
-const mockStore = configureMockStore([thunk])
 
 jest.mock('utils/confirm', () => {
   return {
@@ -22,6 +21,10 @@ jest.mock('utils/confirm', () => {
       .bind(this)
   }
 })
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const mockStore = configureMockStore([thunk])
 
 const timerData = {
   id: '1',
@@ -38,61 +41,109 @@ const timerData = {
 }
 
 describe('Timer ui', () => {
+  const makeProps = (extra = {}) => ({
+    timers: [timerData],
+    equipment: [{ id: '1', name: 'bar', on: false }],
+    macros: [],
+    fetch: jest.fn(),
+    create: jest.fn(),
+    delete: jest.fn(),
+    update: jest.fn(),
+    ...extra
+  })
+
   afterEach(() => {
-    fetchMock.reset()
-    fetchMock.restore()
     jest.clearAllMocks()
   })
 
-  it('<Main /> mounts with empty timers', () => {
-    fetchMock.get('/api/timers', [])
-    const store = mockStore({ timers: [], equipment: [], macros: [] })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+  it('<Main /> fetches timers on mount', () => {
+    const props = makeProps()
+    const component = new RawTimersMain(props)
+
+    component.componentDidMount()
+
+    expect(props.fetch).toHaveBeenCalled()
   })
 
-  it('<Main /> mounts with timers', () => {
-    fetchMock.get('/api/timers', [timerData])
-    const store = mockStore({ timers: [timerData], equipment: [], macros: [] })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper.find('ul.list-group').length).toBeGreaterThan(0)
-    wrapper.unmount()
+  it('<Main /> renders timers when present', () => {
+    const component = new RawTimersMain(makeProps())
+    const items = component.timerList()
+
+    expect(items).toHaveLength(1)
+    expect(items[0].props.name).toBe('panel-timer-1')
   })
 
   it('<Main /> toggles add timer form', () => {
-    fetchMock.get('/api/timers', [])
-    const store = mockStore({ timers: [], equipment: [], macros: [] })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    wrapper.find('#add_timer').simulate('click')
-    wrapper.find('#add_timer').simulate('click')
-    wrapper.unmount()
+    const component = new RawTimersMain(makeProps({ timers: [] }))
+    component.setState = update => { component.state = { ...component.state, ...update } }
+
+    component.handleToggleAddTimerDiv()
+    expect(component.state.addTimer).toBe(true)
+
+    component.handleToggleAddTimerDiv()
+    expect(component.state.addTimer).toBe(false)
   })
 
-  it('<Main /> delete timer triggers confirm', () => {
-    fetchMock.get('/api/timers', [])
-    fetchMock.delete('/api/timers/1', {})
-    const store = mockStore({ timers: [timerData], equipment: [], macros: [] })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    wrapper.find('#delete-panel-timer-1').simulate('click')
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+  it('<Main /> delete timer triggers confirm and delete', async () => {
+    const props = makeProps()
+    const component = new RawTimersMain(props)
+
+    component.handleRemoveTimer(timerData)
+    await Promise.resolve()
+
+    expect(props.delete).toHaveBeenCalledWith('1')
   })
 
-  it('<Main />', () => {
-    const state = {
-      timers: [timerData],
-      equipment: [{ id: '1', name: 'bar', on: false }]
+  it('<Main /> creates timers using normalized payloads', () => {
+    const props = makeProps({ create: jest.fn(), timers: [] })
+    const component = new RawTimersMain(props)
+    component.setState = update => { component.state = { ...component.state, ...update } }
+    const formValues = {
+      ...timerData,
+      month: '*',
+      week: '*',
+      target: {
+        id: '1',
+        on: true,
+        duration: '10',
+        revert: true
+      }
     }
-    const m = shallow(<Main store={mockStore(state)} />)
-      .dive()
+
+    component.handleToggleAddTimerDiv()
+    component.handleSubmit(formValues)
+
+    expect(props.create).toHaveBeenCalledWith({
+      name: 'foo',
+      type: 'equipment',
+      month: '*',
+      week: '*',
+      day: '*',
+      hour: '*',
+      minute: '*',
+      second: '0',
+      enable: false,
+      target: {
+        id: '1',
+        on: true,
+        duration: 10,
+        revert: true
+      }
+    })
+    expect(component.state.addTimer).toBe(false)
   })
 
   it('<TimerForm /> for create', () => {
     const fn = jest.fn()
-    const wrapper = shallow(<TimerForm onSubmit={fn} />)
-    wrapper.simulate('submit', {})
-    expect(fn).toHaveBeenCalled()
+    const store = mockStore({ equipment: [], macros: [] })
+    const html = renderToStaticMarkup(
+      <Provider store={store}>
+        <TimerForm onSubmit={fn} />
+      </Provider>
+    )
+
+    expect(html).toContain('name="name"')
+    expect(html).toContain('name="target.duration"')
   })
 
   it('<TimerForm /> for edit', () => {
@@ -115,8 +166,14 @@ describe('Timer ui', () => {
       title: '',
       message: ''
     }
-    const wrapper = shallow(<TimerForm timer={timer} onSubmit={fn} />)
-    wrapper.simulate('submit', {})
-    expect(fn).toHaveBeenCalled()
+    const store = mockStore({ equipment: [], macros: [] })
+    const html = renderToStaticMarkup(
+      <Provider store={store}>
+        <TimerForm timer={timer} onSubmit={fn} />
+      </Provider>
+    )
+
+    expect(html).toContain('value="name"')
+    expect(html).toContain('name="target.duration"')
   })
 })

--- a/front-end/src/ui_components/datepicker.test.js
+++ b/front-end/src/ui_components/datepicker.test.js
@@ -1,32 +1,39 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
 import { Form, Formik } from 'formik'
 import Datepicker from './datepicker'
 
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
 
-// eslint-disable-next-line react/prop-types
-const FormikWrapper = ({ children }) => (
-  <Formik
-    initialValues={{
-      mydatepicker: '',
-    }}
-  >
-    <Form>
-      {children}
-    </Form>
-  </Formik>
-)
+jest.mock('react-datepicker', () => {
+  const React = require('react')
+  return {
+    __esModule: true,
+    default: props => React.createElement('input', { ...props, 'data-testid': 'datepicker' }),
+    registerLocale: jest.fn()
+  }
+})
 
 describe('<Datepicker />', () => {
+  it('should render inside a Formik form', () => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
 
-  it('should render', () => {
-    const wrapper = mount(
-      <FormikWrapper>
-        <Datepicker name='mydatepicker' />
-      </FormikWrapper>
-    )
+    act(() => {
+      root.render(
+        <Formik initialValues={{ mydatepicker: '' }}>
+          <Form>
+            <Datepicker name='mydatepicker' />
+          </Form>
+        </Formik>
+      )
+    })
 
-    expect(wrapper).toBeDefined()
+    expect(container.querySelector('[data-testid="datepicker"]')).toBeDefined()
+
+    act(() => {
+      root.unmount()
+    })
   })
-
 })


### PR DESCRIPTION
## Summary
- start Slice 23 with a concrete React ecosystem cleanup audit
- convert a first batch of Enzyme-based frontend tests to React 19-safe patterns
- expose RawGenericLightChart for direct test coverage without Enzyme connect wrappers

## Validation
- rtk yarn jest front-end/src/ui_components/datepicker.test.js front-end/src/journal/journal.test.js front-end/src/temperature/edit_temperature.test.js front-end/src/doser/doser_pumps.test.js front-end/src/ato/main.test.js front-end/src/timers/timers.test.js front-end/src/lighting/charts/charts.test.js --runInBand
- rtk yarn build

## Notes
- this is the first Slice 23 checkpoint; the branch will continue reducing the remaining Enzyme surface