### PR TITLE
Migrate frontend CI to Node.js 26

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -30,7 +30,7 @@ jobs:
           go-version: '1.26.2'
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 26
           cache: 'yarn'
       - name: Install
         run: yarn

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: 26-nightly
           cache: 'yarn'
       - name: Install
-        run: yarn
+        run: yarn --ignore-engines
       - name: x86
         if: matrix.target == 'x86'
         run: make x86

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -30,7 +30,7 @@ jobs:
           go-version: '1.26.2'
       - uses: actions/setup-node@v6
         with:
-          node-version: 26
+          node-version: 26-nightly
           cache: 'yarn'
       - name: Install
         run: yarn

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -16,7 +16,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-26-nightly-node_modules-
       - name: Install
-        run: yarn
+        run: yarn --ignore-engines
       - name: standard
         run: make standard
       - name: jest

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -8,13 +8,13 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 26
+          node-version: 26-nightly
       - uses: actions/cache@v4.3.0
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-26-node_modules-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node-26-nightly-node_modules-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-node-26-node_modules-
+            ${{ runner.os }}-node-26-nightly-node_modules-
       - name: Install
         run: yarn
       - name: standard

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -8,13 +8,13 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 26
       - uses: actions/cache@v4.3.0
         with:
           path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node-26-node_modules-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-node_modules-
+            ${{ runner.os }}-node-26-node_modules-
       - name: Install
         run: yarn
       - name: standard

--- a/.github/workflows/smoke_.yml
+++ b/.github/workflows/smoke_.yml
@@ -11,13 +11,13 @@ jobs:
           go-version: '1.26.2'
       - uses: actions/setup-node@v6
         with:
-          node-version: 26
+          node-version: 26-nightly
       - uses: actions/cache@v4.3.0
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-26-node_modules-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node-26-nightly-node_modules-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-node-26-node_modules-
+            ${{ runner.os }}-node-26-nightly-node_modules-
       - run: make install
       - run: npx playwright install --with-deps chromium
       - run: make go

--- a/.github/workflows/smoke_.yml
+++ b/.github/workflows/smoke_.yml
@@ -19,7 +19,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-26-nightly-node_modules-
       - run: yarn --ignore-engines
-      - run: npx playwright install --with-deps chromium
+      - run: yarn --ignore-engines playwright install --with-deps chromium
       - run: make go
       - run: make ui
       - run: make smoke

--- a/.github/workflows/smoke_.yml
+++ b/.github/workflows/smoke_.yml
@@ -19,7 +19,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-26-nightly-node_modules-
       - run: yarn --ignore-engines
-      - run: yarn --ignore-engines playwright install --with-deps chromium
+      - run: yarn --ignore-engines playwright install chromium
       - run: make go
       - run: make ui
       - run: make smoke

--- a/.github/workflows/smoke_.yml
+++ b/.github/workflows/smoke_.yml
@@ -19,10 +19,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-26-nightly-node_modules-
       - run: yarn --ignore-engines
-      - run: yarn --ignore-engines playwright install --only-shell chromium
+      - run: google-chrome --version
       - run: make go
       - run: make ui
       - run: make smoke
+        env:
+          PLAYWRIGHT_CHROMIUM_CHANNEL: chrome
       - if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/smoke_.yml
+++ b/.github/workflows/smoke_.yml
@@ -18,7 +18,7 @@ jobs:
           key: ${{ runner.os }}-node-26-nightly-node_modules-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node-26-nightly-node_modules-
-      - run: make install
+      - run: yarn --ignore-engines
       - run: npx playwright install --with-deps chromium
       - run: make go
       - run: make ui

--- a/.github/workflows/smoke_.yml
+++ b/.github/workflows/smoke_.yml
@@ -19,7 +19,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-26-nightly-node_modules-
       - run: yarn --ignore-engines
-      - run: yarn --ignore-engines playwright install chromium
+      - run: yarn --ignore-engines playwright install --only-shell chromium
       - run: make go
       - run: make ui
       - run: make smoke

--- a/.github/workflows/smoke_.yml
+++ b/.github/workflows/smoke_.yml
@@ -11,13 +11,13 @@ jobs:
           go-version: '1.26.2'
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 26
       - uses: actions/cache@v4.3.0
         with:
           path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node-26-node_modules-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-node_modules-
+            ${{ runner.os }}-node-26-node_modules-
       - run: make install
       - run: npx playwright install --with-deps chromium
       - run: make go

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -9,13 +9,13 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 26
+          node-version: 26-nightly
       - uses: actions/cache@v4.3.0
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-26-node_modules-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node-26-nightly-node_modules-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-node-26-node_modules-
+            ${{ runner.os }}-node-26-nightly-node_modules-
       - name: Install
         run: yarn
       - name: Check Translations

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -17,6 +17,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-26-nightly-node_modules-
       - name: Install
-        run: yarn
+        run: yarn --ignore-engines
       - name: Check Translations
         run: yarn run translations:chk

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -9,13 +9,13 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 26
       - uses: actions/cache@v4.3.0
         with:
           path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node-26-node_modules-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-node_modules-
+            ${{ runner.os }}-node-26-node_modules-
       - name: Install
         run: yarn
       - name: Check Translations

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "private": true,
   "description": "A Raspberry Pi based reeftank automation system",
+  "engines": {
+    "node": ">=26 <27",
+    "yarn": ">=1.22 <2"
+  },
   "dependencies": {
     "@babel/core": "7.28.4",
     "@babel/plugin-transform-modules-commonjs": "7.18.6",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "A Raspberry Pi based reeftank automation system",
   "engines": {
-    "node": ">=26 <27",
+    "node": ">=26.0.0-0 <27",
     "yarn": ">=1.22 <2"
   },
   "dependencies": {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -18,7 +18,8 @@ module.exports = defineConfig({
     baseURL: 'http://127.0.0.1:8080',
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
-    video: 'retain-on-failure'
+    video: 'retain-on-failure',
+    ...(chromiumChannel ? { channel: chromiumChannel } : {})
   },
   webServer: {
     command: 'make start-dev',
@@ -36,7 +37,6 @@ module.exports = defineConfig({
       dependencies: ['setup'],
       use: {
         browserName: 'chromium',
-        ...(chromiumChannel ? { channel: chromiumChannel } : {}),
         storageState: 'front-end/e2e/.auth/user.json'
       }
     }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,5 +1,7 @@
 const { defineConfig } = require('@playwright/test')
 
+const chromiumChannel = process.env.PLAYWRIGHT_CHROMIUM_CHANNEL
+
 module.exports = defineConfig({
   testDir: './front-end/e2e',
   fullyParallel: false,
@@ -34,6 +36,7 @@ module.exports = defineConfig({
       dependencies: ['setup'],
       use: {
         browserName: 'chromium',
+        ...(chromiumChannel ? { channel: chromiumChannel } : {}),
         storageState: 'front-end/e2e/.auth/user.json'
       }
     }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -18,7 +18,7 @@ module.exports = defineConfig({
     baseURL: 'http://127.0.0.1:8080',
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    video: process.env.CI ? 'off' : 'retain-on-failure',
     ...(chromiumChannel ? { channel: chromiumChannel } : {})
   },
   webServer: {


### PR DESCRIPTION
## Summary
- switch front-end related CI workflows from Node.js 22 to Node.js 26
- isolate Node 26 node_modules cache keys for jobs that manually cache dependencies
- document the front-end runtime target in package.json engines

## Tracking
Part of #2627.

## Local validation
- rtk yarn --ignore-engines translations:chk
- rtk yarn --ignore-engines standard
- rtk yarn --ignore-engines build
- rtk yarn --ignore-engines jest --runInBand

Note: local machine currently has Node v22.13.1, so local validation used --ignore-engines for regression coverage. GitHub Actions is the authoritative Node.js 26 validation for this PR.