### PR TITLE
test: remove enzyme from frontend src

### DIFF
--- a/front-end/src/configuration/about.jsx
+++ b/front-end/src/configuration/about.jsx
@@ -71,4 +71,5 @@ const About = connect(
   mapStateToProps,
   mapDispatchToProps
 )(about)
+export { about as RawAbout }
 export default About

--- a/front-end/src/configuration/configuration.test.js
+++ b/front-end/src/configuration/configuration.test.js
@@ -1,26 +1,32 @@
-import React, { act } from 'react'
-import { shallow, mount } from 'enzyme'
-import { Provider } from 'react-redux'
-import configureMockStore from 'redux-mock-store'
-import Admin from './admin'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { RawAdmin } from './admin'
 import Capabilities from './capabilities'
-import Display from './display'
-import Errors from './errors'
-import About from './about'
+import { RawDisplay } from './display'
+import { RawErrors } from './errors'
+import { RawAbout } from './about'
 import HealthNotify from './health_notify'
-import Main from './main'
-import Settings from './settings'
-import thunk from 'redux-thunk'
-import 'isomorphic-fetch'
-import fetchMock from 'fetch-mock'
+import Main, { configRoutes } from './main'
+import { RawSettings } from './settings'
 import SignIn from 'sign_in'
+import 'isomorphic-fetch'
+import * as Alert from 'utils/alert'
+import i18n from 'utils/i18n'
 
 jest.mock('utils/alert', () => ({
   showError: jest.fn(),
   showUpdateSuccessful: jest.fn()
 }))
 
-const mockStore = configureMockStore([thunk])
+jest.mock('utils/confirm', () => {
+  return {
+    confirm: jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(true))
+      .bind(this)
+  }
+})
 
 const fullCapabilities = { health_check: true, equipment: true }
 const fullSettings = {
@@ -29,236 +35,309 @@ const fullSettings = {
   address: 'localhost:8080',
   https: false,
   capabilities: { health_check: true },
-  health_check: { notify: false },
+  health_check: { enable: false, max_memory: 100, max_cpu: 80, max_cpu_temp: 70, report_enable: false, report_schedule: '' },
   display: false,
   notification: false,
   pprof: false,
   prometheus: false,
-  cors: false
+  cors: false,
+  rpi_pwm_freq: 1000
+}
+
+const patchSetState = component => {
+  component.setState = update => {
+    component.state = {
+      ...component.state,
+      ...(typeof update === 'function' ? update(component.state) : update)
+    }
+  }
 }
 
 describe('Configuration ui', () => {
-  const click = (node, event = {}) => {
-    act(() => {
-      node.prop('onClick')(event)
-    })
-  }
-
-  const change = (node, event) => {
-    act(() => {
-      node.prop('onChange')(event)
-    })
-  }
+  beforeEach(() => {
+    jest.spyOn(Alert, 'showError')
+    jest.spyOn(Alert, 'showUpdateSuccessful')
+  })
 
   afterEach(() => {
-    fetchMock.reset()
-    fetchMock.restore()
+    jest.clearAllMocks()
   })
 
   it('<Main />', () => {
-    const m = shallow(<Main store={mockStore()} />).instance()
+    const component = new Main({})
+    const tree = component.render()
+    const panels = tree.props.children[0].props.children.props.children
+    expect(panels).toHaveLength(configRoutes.length)
+    expect(panels[0].props.children.props.id).toBe('config-nomatch')
+    expect(panels[6].props.children.props.id).toBe('config-admin')
   })
 
   it('<Admin />', () => {
-    const m = shallow(<Admin store={mockStore()} />)
-      .dive()
-      .instance()
-    fetchMock.postOnce('/api/admin/reload', {})
-    fetchMock.postOnce('/api/admin/reboot', {})
-    fetchMock.postOnce('/api/admin/poweroff', {})
-    SignIn.logout = jest.fn().mockImplementation(() => {
-      return true
-    })
+    const reload = jest.fn()
+    const reboot = jest.fn()
+    const powerOff = jest.fn()
+    const dbImport = jest.fn().mockReturnValue(jest.fn())
+    const upgrade = jest.fn()
+    const m = new RawAdmin({ reload, reboot, powerOff, dbImport, upgrade })
+    patchSetState(m)
+    SignIn.logout = jest.fn().mockImplementation(() => true)
+
     m.handleReload()
     m.handlePowerOff()
     m.handleReboot()
     m.handleSignout()
-    m.props.reload()
-    m.props.reboot()
-    m.props.powerOff()
-  })
+    m.handleVersionChange({ target: { value: '4.0.0' } })
+    m.handleInstall()
+    expect(SignIn.logout).toHaveBeenCalled()
 
-  it('<Display /> mounts with on:true state', () => {
-    fetchMock.get('/api/display', { brightness: 50, on: true })
-    fetchMock.post('/api/display/off', {})
-    fetchMock.post('/api/display/on', {})
-    fetchMock.post('/api/display', {})
-    const store = mockStore({ display: { brightness: 50, on: true } })
-    const wrapper = mount(<Provider store={store}><Display /></Provider>)
-    click(wrapper.find('button').first())
-    change(wrapper.find('input[type="range"]'), { target: { value: '100' } })
-    wrapper.unmount()
-  })
-
-  it('<Display /> mounts with on:false state', () => {
-    fetchMock.get('/api/display', { brightness: 80, on: false })
-    fetchMock.post('/api/display/on', {})
-    const store = mockStore({ display: { brightness: 80, on: false } })
-    const wrapper = mount(<Provider store={store}><Display /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
-  })
-
-  it('<Display /> mounts with no config (getDerivedStateFromProps guard)', () => {
-    fetchMock.get('/api/display', {})
-    const store = mockStore({ display: undefined })
-    const wrapper = mount(<Provider store={store}><Display /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
-  })
-
-  it('<Capabilities />', () => {
-    const caps = {
-      equipment: true,
-      timer: false,
-      dashboard: true
-    }
-    const m = shallow(<Capabilities capabilities={caps} update={() => true} />).instance()
-    m.updateCapability('dashboard')({ target: { checked: true } })
-  })
-
-  it('<Settings /> renders loading when settings/capabilities missing', () => {
-    fetchMock.get('/api/settings', {})
-    const store = mockStore({ settings: {}, capabilities: {} })
-    const wrapper = mount(<Provider store={store}><Settings /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
-  })
-
-  it('<Settings /> renders full form with valid settings and capabilities', () => {
-    fetchMock.get('/api/settings', fullSettings)
-    const store = mockStore({ settings: fullSettings, capabilities: fullCapabilities })
-    const wrapper = mount(<Provider store={store}><Settings /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
-  })
-
-  it('<Settings /> renders with display enabled (showDisplay branch)', () => {
-    fetchMock.get('/api/settings', {})
-    fetchMock.get('/api/display', { brightness: 50, on: true })
-    const s = { ...fullSettings, display: true }
-    const store = mockStore({ settings: s, capabilities: fullCapabilities, display: { brightness: 50, on: true } })
-    const wrapper = mount(<Provider store={store}><Settings /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
-  })
-
-  it('<Settings /> handleUpdate — valid settings calls updateSettings', () => {
-    fetchMock.get('/api/settings', fullSettings)
-    fetchMock.post('/api/settings', fullSettings)
-    const store = mockStore({ settings: fullSettings, capabilities: fullCapabilities })
-    const wrapper = mount(<Provider store={store}><Settings /></Provider>)
-    click(wrapper.find('#systemUpdateSettings'))
-    wrapper.unmount()
-  })
-
-  it('<Settings /> handleSetAddress updates address', () => {
-    fetchMock.get('/api/settings', {})
-    const store = mockStore({ settings: fullSettings, capabilities: fullCapabilities })
-    const wrapper = mount(<Provider store={store}><Settings /></Provider>)
-    change(wrapper.find('#to-row-address'), { target: { value: 'localhost:9090' } })
-    wrapper.unmount()
-  })
-
-  it('<Settings /> toRow (name) input updates settings', () => {
-    fetchMock.get('/api/settings', {})
-    const store = mockStore({ settings: fullSettings, capabilities: fullCapabilities })
-    const wrapper = mount(<Provider store={store}><Settings /></Provider>)
-    change(wrapper.find('#to-row-name'), { target: { value: 'new-name' } })
-    wrapper.unmount()
-  })
-
-  it('<Settings /> handleSetProtocolHttps removes port 80', () => {
-    fetchMock.get('/api/settings', {})
-    const s = { ...fullSettings, address: 'localhost:80', https: false }
-    const store = mockStore({ settings: s, capabilities: fullCapabilities })
-    const wrapper = mount(<Provider store={store}><Settings /></Provider>)
-    click(wrapper.find('a.dropdown-item').last(), { preventDefault: () => {} })
-    wrapper.unmount()
-  })
-
-  it('<Settings /> handleSetProtocolHttp removes port 443', () => {
-    fetchMock.get('/api/settings', {})
-    const s = { ...fullSettings, address: 'localhost:443', https: true }
-    const store = mockStore({ settings: s, capabilities: fullCapabilities })
-    const wrapper = mount(<Provider store={store}><Settings /></Provider>)
-    click(wrapper.find('a.dropdown-item').first(), { preventDefault: () => {} })
-    wrapper.unmount()
-  })
-
-  it('<Settings /> handleSetProtocol no port change when not 80 or 443', () => {
-    fetchMock.get('/api/settings', {})
-    const s = { ...fullSettings, address: 'localhost:8080', https: false }
-    const store = mockStore({ settings: s, capabilities: fullCapabilities })
-    const wrapper = mount(<Provider store={store}><Settings /></Provider>)
-    click(wrapper.find('a.dropdown-item').last(), { preventDefault: () => {} })
-    wrapper.unmount()
-  })
-
-  it('<Settings /> checkBoxComponent toggles a setting', () => {
-    fetchMock.get('/api/settings', {})
-    const store = mockStore({ settings: fullSettings, capabilities: fullCapabilities })
-    const wrapper = mount(<Provider store={store}><Settings /></Provider>)
-    change(wrapper.find('#notification'), { target: { checked: true } })
-    wrapper.unmount()
-  })
-
-  it('<HealthNotify />', () => {
-    const m = shallow(<HealthNotify state={{}} update={() => true} />).instance()
-    m.handleUpdateEnable({ target: {} })
-    m.update('foo')({ target: {} })
-    m.setState({
-      notify: {
-        enable: true
-      }
+    return Promise.resolve().then(() => {
+      expect(reload).toHaveBeenCalled()
+      expect(reboot).toHaveBeenCalled()
+      expect(powerOff).toHaveBeenCalled()
+      expect(upgrade).toHaveBeenCalledWith('4.0.0')
+      expect(Alert.showUpdateSuccessful).toHaveBeenCalled()
     })
   })
 
+  it('<Display /> mounts with on:true state', () => {
+    const props = {
+      config: { brightness: 50, on: true },
+      fetchDisplay: jest.fn(),
+      switchDisplay: jest.fn(),
+      setBrightness: jest.fn()
+    }
+    const component = new RawDisplay(props)
+    patchSetState(component)
+    component.componentDidMount()
+    component.handleToggle()
+    component.handleSetBrightness({ target: { value: '100' } })
+    expect(props.fetchDisplay).toHaveBeenCalled()
+    expect(props.switchDisplay).toHaveBeenCalled()
+    expect(props.setBrightness).toHaveBeenCalledWith(100)
+  })
+
+  it('<Display /> mounts with on:false state', () => {
+    const component = new RawDisplay({
+      config: { brightness: 80, on: false },
+      fetchDisplay: jest.fn(),
+      switchDisplay: jest.fn(),
+      setBrightness: jest.fn()
+    })
+    expect(component.render().props.className).toBe('container')
+  })
+
+  it('<Display /> mounts with no config (getDerivedStateFromProps guard)', () => {
+    expect(RawDisplay.getDerivedStateFromProps({ config: undefined }, {})).toBeNull()
+  })
+
+  it('<Capabilities />', () => {
+    const update = jest.fn()
+    const m = new Capabilities({
+      capabilities: {
+        equipment: true,
+        timer: false,
+        dashboard: true
+      },
+      update
+    })
+    patchSetState(m)
+    m.updateCapability('dashboard')({ target: { checked: true } })
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({ dashboard: true }))
+  })
+
+  it('<Settings /> renders loading when settings/capabilities missing', () => {
+    const component = new RawSettings({
+      settings: {},
+      capabilities: {},
+      fetchSettings: jest.fn(),
+      updateSettings: jest.fn()
+    })
+    expect(renderToStaticMarkup(component.render())).toContain('loading')
+  })
+
+  it('<Settings /> renders full form with valid settings and capabilities', () => {
+    const component = new RawSettings({
+      settings: fullSettings,
+      capabilities: fullCapabilities,
+      fetchSettings: jest.fn(),
+      updateSettings: jest.fn()
+    })
+    expect(renderToStaticMarkup(component.render())).toContain('systemUpdateSettings')
+  })
+
+  it('<Settings /> renders with display enabled (showDisplay branch)', () => {
+    const s = { ...fullSettings, display: true }
+    const component = new RawSettings({
+      settings: s,
+      capabilities: fullCapabilities,
+      fetchSettings: jest.fn(),
+      updateSettings: jest.fn()
+    })
+    const display = component.showDisplay()
+    expect(display.type).toBe('div')
+  })
+
+  it('<Settings /> handleUpdate valid settings calls updateSettings', () => {
+    const updateSettings = jest.fn()
+    const component = new RawSettings({
+      settings: { ...fullSettings },
+      capabilities: fullCapabilities,
+      fetchSettings: jest.fn(),
+      updateSettings
+    })
+    patchSetState(component)
+    component.handleUpdate()
+    expect(updateSettings).toHaveBeenCalled()
+    expect(Alert.showUpdateSuccessful).toHaveBeenCalled()
+  })
+
+  it('<Settings /> handleSetAddress updates address', () => {
+    const component = new RawSettings({
+      settings: { ...fullSettings },
+      capabilities: fullCapabilities,
+      fetchSettings: jest.fn(),
+      updateSettings: jest.fn()
+    })
+    patchSetState(component)
+    component.handleSetAddress({ target: { value: 'localhost:9090' } })
+    expect(component.state.settings.address).toBe('localhost:9090')
+  })
+
+  it('<Settings /> toRow (name) input updates settings', () => {
+    const component = new RawSettings({
+      settings: { ...fullSettings },
+      capabilities: fullCapabilities,
+      fetchSettings: jest.fn(),
+      updateSettings: jest.fn()
+    })
+    patchSetState(component)
+    const row = component.toRow('name')
+    row.props.children[1].props.onChange({ target: { value: 'new-name' } })
+    expect(component.state.settings.name).toBe('new-name')
+  })
+
+  it('<Settings /> handleSetProtocolHttps removes port 80', () => {
+    const s = { ...fullSettings, address: 'localhost:80', https: false }
+    const component = new RawSettings({
+      settings: s,
+      capabilities: fullCapabilities,
+      fetchSettings: jest.fn(),
+      updateSettings: jest.fn()
+    })
+    patchSetState(component)
+    component.handleSetProtocolHttps()
+    expect(component.state.settings.address).toBe('localhost')
+    expect(component.state.settings.https).toBe(true)
+  })
+
+  it('<Settings /> handleSetProtocolHttp removes port 443', () => {
+    const s = { ...fullSettings, address: 'localhost:443', https: true }
+    const component = new RawSettings({
+      settings: s,
+      capabilities: fullCapabilities,
+      fetchSettings: jest.fn(),
+      updateSettings: jest.fn()
+    })
+    patchSetState(component)
+    component.handleSetProtocolHttp()
+    expect(component.state.settings.address).toBe('localhost')
+    expect(component.state.settings.https).toBe(false)
+  })
+
+  it('<Settings /> handleSetProtocol no port change when not 80 or 443', () => {
+    const s = { ...fullSettings, address: 'localhost:8080', https: false }
+    const component = new RawSettings({
+      settings: s,
+      capabilities: fullCapabilities,
+      fetchSettings: jest.fn(),
+      updateSettings: jest.fn()
+    })
+    patchSetState(component)
+    component.handleSetProtocolHttps()
+    expect(component.state.settings.address).toBe('localhost:8080')
+    expect(component.state.settings.https).toBe(true)
+  })
+
+  it('<Settings /> checkBoxComponent toggles a setting', () => {
+    const component = new RawSettings({
+      settings: { ...fullSettings },
+      capabilities: fullCapabilities,
+      fetchSettings: jest.fn(),
+      updateSettings: jest.fn()
+    })
+    patchSetState(component)
+    const checkbox = component.checkBoxComponent('notification')
+    checkbox.props.children.props.children[0].props.onChange({ target: { checked: true } })
+    expect(component.state.settings.notification).toBe(true)
+  })
+
+  it('<HealthNotify />', () => {
+    const update = jest.fn()
+    const m = new HealthNotify({
+      state: {
+        enable: false,
+        max_memory: 10,
+        max_cpu: 20,
+        max_cpu_temp: 30,
+        report_enable: false,
+        report_schedule: ''
+      },
+      update
+    })
+    patchSetState(m)
+    m.handleUpdateEnable({ target: { checked: true } })
+    m.update('max_cpu')({ target: { value: '11' } })
+    m.setState({ notify: { ...m.state.notify, enable: true } })
+    expect(update).toHaveBeenCalled()
+  })
+
   it('<About /> mounts and renders info', () => {
-    fetchMock.get('/api/info', { version: '2.0', current_time: '2026-04-18', uptime: '1 day', ip: '192.168.1.1', model: 'Pi 4' })
     const info = { current_time: '2026-04-18', version: '2.0', uptime: '1 day', ip: '192.168.1.1', model: 'Pi 4' }
-    const store = mockStore({ info, errors: [] })
-    const wrapper = mount(<Provider store={store}><About /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+    const component = new RawAbout({ info, fetchInfo: jest.fn(), errors: [] })
+    patchSetState(component)
+    expect(renderToStaticMarkup(component.render())).toContain('reef-pi')
+    component.componentWillUnmount()
   })
 
   it('<About /> mounts with empty info', () => {
-    fetchMock.get('/api/info', {})
-    const store = mockStore({ info: {}, errors: [] })
-    const wrapper = mount(<Provider store={store}><About /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+    const component = new RawAbout({ info: {}, fetchInfo: jest.fn(), errors: [] })
+    patchSetState(component)
+    expect(renderToStaticMarkup(component.render())).toContain('reef-pi')
+    component.componentWillUnmount()
   })
 
-  it('<Errors /> mounts with error list — renders items and handles clear', () => {
-    fetchMock.get('/api/errors', [])
-    fetchMock.delete('/api/errors/clear', {})
-    const errs = [
-      { id: '1', time: '2026-04-18', message: 'something broke', count: 1 },
-      { id: 'alert:2', time: '2026-04-18', message: 'alert item', count: 3 }
-    ]
-    const store = mockStore({ errors: errs })
-    const wrapper = mount(<Provider store={store}><Errors /></Provider>)
-    click(wrapper.find('button').first())
-    wrapper.unmount()
+  it('<Errors /> mounts with error list renders items and handles clear', () => {
+    const clear = jest.fn()
+    const component = new RawErrors({
+      errors: [
+        { id: '1', time: '2026-04-18', message: 'something broke', count: 1 },
+        { id: 'alert:2', time: '2026-04-18', message: 'alert item', count: 3 }
+      ],
+      clear,
+      fetch: jest.fn(),
+      delete: jest.fn()
+    })
+    component.componentDidMount()
+    component.handleClear()
+    expect(clear).toHaveBeenCalled()
+    expect(renderToStaticMarkup(component.render())).toContain('alert item')
   })
 
   it('<Errors /> mounts with empty error list', () => {
-    fetchMock.get('/api/errors', [])
-    const store = mockStore({ errors: [] })
-    const wrapper = mount(<Provider store={store}><Errors /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+    const component = new RawErrors({ errors: [], clear: jest.fn(), fetch: jest.fn(), delete: jest.fn() })
+    expect(renderToStaticMarkup(component.render())).toContain('btn btn-outline-secondary')
   })
 
   it('<Errors /> delete button dispatches deleteError', () => {
-    fetchMock.get('/api/errors', [])
-    fetchMock.delete('/api/errors/1', {})
-    const errs = [{ id: '1', time: '2026-04-18', message: 'err', count: 1 }]
-    const store = mockStore({ errors: errs })
-    const wrapper = mount(<Provider store={store}><Errors /></Provider>)
-    click(wrapper.find('input.btn-outline-secondary'))
-    wrapper.unmount()
+    const deleteError = jest.fn()
+    const component = new RawErrors({
+      errors: [{ id: '1', time: '2026-04-18', message: 'err', count: 1 }],
+      clear: jest.fn(),
+      fetch: jest.fn(),
+      delete: deleteError
+    })
+    const row = component.render().props.children[0][0]
+    row.props.children[2].props.children.props.onClick()
+    expect(deleteError).toHaveBeenCalledWith('1')
   })
 })

--- a/front-end/src/configuration/errors.jsx
+++ b/front-end/src/configuration/errors.jsx
@@ -72,4 +72,5 @@ const Errors = connect(
   mapStateToProps,
   mapDispatchToProps
 )(errors)
+export { errors as RawErrors }
 export default Errors

--- a/front-end/src/connectors/analog_inputs.jsx
+++ b/front-end/src/connectors/analog_inputs.jsx
@@ -233,4 +233,5 @@ const AnalogInputs = connect(
   mapStateToProps,
   mapDispatchToProps
 )(analogInputs)
+export { analogInputs as RawAnalogInputs }
 export default AnalogInputs

--- a/front-end/src/connectors/connectors.test.js
+++ b/front-end/src/connectors/connectors.test.js
@@ -1,27 +1,24 @@
-import React, { act } from 'react'
-import { shallow, mount } from 'enzyme'
-import Main from './main'
-import Inlets from './inlets'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { RawConnectors } from './main'
+import { RawInlets } from './inlets'
 import Inlet from './inlet'
 import Outlet from './outlet'
-import InletSelector from './inlet_selector'
-import Jacks from './jacks'
+import { RawInletSelector } from './inlet_selector'
+import { RawJacks } from './jacks'
 import Jack from './jack'
-import Outlets from './outlets'
+import { RawOutlets } from './outlets'
 import Pin from './pin'
 import AnalogInput from './analog_input'
-import AnalogInputs from './analog_inputs'
+import { RawAnalogInputs } from './analog_inputs'
 import { byCapability } from './driver_filter'
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
 import 'isomorphic-fetch'
-import { Provider } from 'react-redux'
 
-const mockStore = configureMockStore([thunk])
 const stockDrivers = [
-  { id: 'rpi', name: 'Rasoverry Pi',pinmap: {'digital-output': [1,2,3,4,5]}},
-  { id: '1', name: 'PCA9685', pinmap: {'digital-output':[0,1,2,3,4], 'pwm':[0,1,2,3]} }
+  { id: 'rpi', name: 'Rasoverry Pi', pinmap: { 'digital-output': [1, 2, 3, 4, 5], 'digital-input': [1, 2, 3], 'analog-input': [0, 1] } },
+  { id: '1', name: 'PCA9685', pinmap: { 'digital-output': [0, 1, 2, 3, 4], pwm: [0, 1, 2, 3] } }
 ]
+
 jest.mock('utils/confirm', () => {
   return {
     confirm: jest
@@ -34,154 +31,173 @@ jest.mock('utils/confirm', () => {
       .bind(this)
   }
 })
+
+jest.mock('utils/alert', () => ({
+  showError: jest.fn(),
+  showUpdateSuccessful: jest.fn()
+}))
+
+const patchSetState = component => {
+  component.setState = update => {
+    component.state = {
+      ...component.state,
+      ...(typeof update === 'function' ? update(component.state) : update)
+    }
+  }
+}
+
 describe('Connectors', () => {
-  const click = (node, event = {}) => {
-    act(() => {
-      node.prop('onClick')(event)
-    })
-  }
-
-  const change = (node, event) => {
-    act(() => {
-      node.prop('onChange')(event)
-    })
-  }
-
   it('<Main />', () => {
-    shallow(<Provider store={mockStore({})}><Main /></Provider>)
+    expect(new RawConnectors({ drivers: [] }).render().props.className).toBe('container')
+    expect(new RawConnectors({ drivers: stockDrivers }).render().props.className).toBe('container')
   })
 
   it('<InletSelector />', () => {
-    const state = {
+    const update = jest.fn()
+    const component = new RawInletSelector({
       inlets: [{ id: '1', name: 'foo', pin: 1 }, { id: '2', name: 'bar', pin: 2 }],
-      drivers: stockDrivers
-    }
-    const m = mount(
-      <Provider store={mockStore(state)}>
-        <InletSelector active='1' update={() => true} />
-      </Provider>
-    )
-    click(m.find('a').first())
+      active: '1',
+      update,
+      fetchInlets: jest.fn(),
+      name: 'test'
+    })
+    patchSetState(component)
+    component.componentDidMount()
+    component.set(0)()
+    expect(update).toHaveBeenCalledWith('1')
+    expect(renderToStaticMarkup(component.inlets())).toContain('foo')
   })
 
   it('<Inlets />', () => {
-    const state = {
-      inlets: [{ id: '1', name: 'foo', pin: 1, reverse: true }],
+    const create = jest.fn()
+    const component = new RawInlets({
+      inlets: [{ id: '1', name: 'foo', pin: 1, reverse: true, driver: 'rpi' }],
       drivers: stockDrivers,
-      driver: stockDrivers[0]
-    }
-    const wrapper = mount(<Provider store={mockStore(state)}>
-        <Inlets />
-      </Provider>
-    )
-    click(wrapper.find('#add_inlet'))
-    wrapper.update()
-    change(wrapper.find('#inletName'), { target: { value: 'foo' } })
-    change(wrapper.find('.custom-select').slice(1, 2), { target: { value: 'rpi' } })
-    change(wrapper.find('#inletReverse'), {})
-    click(wrapper.find('#createInlet'))
-    wrapper.update()
-    expect(wrapper.find(Inlet).length).toBe(1)
+      fetch: jest.fn(),
+      create,
+      delete: jest.fn(),
+      update: jest.fn()
+    })
+    patchSetState(component)
+    component.componentDidMount()
+    component.handleAdd()
+    component.handleNameChange({ target: { value: 'foo' } })
+    component.handleDriverChange({ target: { value: 'rpi' } })
+    component.handleReverseChange()
+    component.handleSave()
+    expect(create).toHaveBeenCalled()
+    expect(component.list().length).toBeGreaterThan(0)
   })
 
   it('<Inlet />', () => {
-    const m = shallow(
-      <Inlet
-        inlet_id='1'
-        name='foo'
-        pin={1}
-        reverse={false}
-        update={() => true}
-        remove={() => true}
-        drivers={stockDrivers}
-        driver={stockDrivers[0]}
-      />)
-    click(m.find('.edit-inlet'))
-    m.update()
-    change(m.find('.inlet-name'), { target: { value: 'foo' } })
-    change(m.find('.custom-select'), { target: { value: 'rpi' } })
-    change(m.find('.inlet-reverse'), {})
-    click(m.find('.edit-inlet'))
+    const update = jest.fn()
+    const remove = jest.fn()
+    const m = new Inlet({
+      inlet_id: '1',
+      name: 'foo',
+      pin: 1,
+      reverse: false,
+      update,
+      remove,
+      drivers: stockDrivers,
+      driver: stockDrivers[0]
+    })
+    patchSetState(m)
+    m.handleEdit()
+    m.handleNameChange({ target: { value: 'foo' } })
+    m.handleDriverChange({ target: { value: 'rpi' } })
+    m.handleReverseChange()
+    m.handleEdit()
+    expect(update).toHaveBeenCalled()
   })
 
   it('<Jacks />', () => {
-    const state = {
-      jacks: [{ id: '1', name: 'J2', pins: [0, 2], reverse: false }],
-      drivers: stockDrivers
-    }
-    //const m = shallow(<Jacks store={mockStore(state)} />).dive()
-    const m = mount(<Provider store={mockStore(state)}>
-      <Jacks />
-    </Provider>
-    )
-    click(m.find('#add_jack'))
-    m.update()
-    change(m.find('#jackName'), { target: { value: 'foo' } })
-    change(m.find('#jackPins'), { target: { value: '4,L' } })
-    change(m.find('.jack-type [name*="driver"]'), { target: { value: '1' } })
-    click(m.find('#createJack'))
-    change(m.find('#jackPins'), { target: { value: '4' } })
-    click(m.find('#createJack'))
+    const create = jest.fn()
+    const component = new RawJacks({
+      jacks: [{ id: '1', name: 'J2', pins: [0, 2], reverse: false, driver: '1' }],
+      drivers: stockDrivers,
+      fetch: jest.fn(),
+      create,
+      delete: jest.fn(),
+      update: jest.fn()
+    })
+    patchSetState(component)
+    component.componentDidMount()
+    component.handleAdd()
+    component.handleNameChange({ target: { value: 'foo' } })
+    component.handlePinChange({ target: { value: '4,L' } })
+    component.handleSetDriver({ target: { value: '1' } })
+    component.handleSave()
+    expect(create).not.toHaveBeenCalled()
+    component.handlePinChange({ target: { value: '4' } })
+    component.handleSave()
+    expect(create).toHaveBeenCalled()
   })
 
   it('<Jack />', () => {
-    const m = shallow(
-      <Jack
-        jack_id='1'
-        name='foo'
-        pins={[1, 2]}
-        update={() => true}
-        remove={() => true}
-        driver='rpi'
-        drivers={stockDrivers}
-        reverse={false}
-      />
-    )
-    click(m.find('.jack-edit'))
-    m.update()
-    change(m.find('.jack-name'), { target: { value: 'foo' } })
-    change(m.find('.jack-pin'), { target: { value: '4,L' } })
-    click(m.find('.jack-edit'))
-    change(m.find('#jack-1-driver-select'), { target: { value: '1' } })
-    change(m.find('.jack-pin'), { target: { value: '4' } })
-    click(m.find('.jack-edit'))
+    const update = jest.fn()
+    const m = new Jack({
+      jack_id: '1',
+      name: 'foo',
+      pins: [1, 2],
+      update,
+      remove: () => true,
+      driver: 'rpi',
+      drivers: stockDrivers,
+      reverse: false
+    })
+    patchSetState(m)
+    m.handleEdit()
+    m.handleNameChange({ target: { value: 'foo' } })
+    m.handlePinChange({ target: { value: '4,L' } })
+    m.handleEdit()
+    expect(update).not.toHaveBeenCalled()
+    m.handleSetDriver({ target: { value: '1' } })
+    m.handlePinChange({ target: { value: '4' } })
+    m.handleEdit()
+    expect(update).toHaveBeenCalled()
   })
+
   it('<Outlets />', () => {
-    const state = {
-      outlets: [{ id: '1', name: 'J2', pin: 1, reverse: true }],
-      drivers: stockDrivers
-    }
-    //const wrapper = shallow(<Outlets store={mockStore(state)} />).dive()
-    const wrapper = mount(<Provider store={mockStore(state)}>
-      <Outlets />
-    </Provider>
-    )
-    click(wrapper.find('#add_outlet'))
-    wrapper.update()
-    change(wrapper.find('#outletName'), { target: { value: 'foo' } })
-    change(wrapper.find('.custom-select').slice(1, 2), { target: { value: '1' } })
-    change(wrapper.find('#outletReverse'), {})
-    click(wrapper.find('#createOutlet'))
-    wrapper.update()
-    expect(wrapper.find(Outlet).length).toBe(1)
+    const create = jest.fn()
+    const component = new RawOutlets({
+      outlets: [{ id: '1', name: 'J2', pin: 1, reverse: true, driver: 'rpi' }],
+      drivers: stockDrivers,
+      fetch: jest.fn(),
+      create,
+      delete: jest.fn(),
+      update: jest.fn()
+    })
+    patchSetState(component)
+    component.componentDidMount()
+    component.handleAdd()
+    component.handleNameChange({ target: { value: 'foo' } })
+    component.handleDriverChange({ target: { value: '1' } })
+    component.handleReverseChange()
+    component.handleSave()
+    expect(create).toHaveBeenCalled()
+    expect(component.list().length).toBeGreaterThan(0)
   })
+
   it('<Outlet />', () => {
-    const m = shallow(
-      <Outlet
-        name='foo'
-        reverse pin={1}
-        outlet_id='1'
-        update={() => true}
-        remove={() => true}
-        driver={stockDrivers[0]}
-        drivers={stockDrivers}
-      />)
-    click(m.find('.edit-outlet'))
-    m.update()
-    change(m.find('.outlet-name'), { target: { value: 'foo' } })
-    change(m.find('.custom-select'), { target: { value: '1' } })
-    change(m.find('.outlet-reverse'), {})
-    click(m.find('.edit-outlet'))
+    const update = jest.fn()
+    const m = new Outlet({
+      name: 'foo',
+      reverse: true,
+      pin: 1,
+      outlet_id: '1',
+      update,
+      remove: () => true,
+      driver: stockDrivers[0],
+      drivers: stockDrivers
+    })
+    patchSetState(m)
+    m.handleEdit()
+    m.handleNameChange({ target: { value: 'foo' } })
+    m.handleDriverChange({ target: { value: '1' } })
+    m.handleReverseChange()
+    m.handleEdit()
+    expect(update).toHaveBeenCalled()
   })
 
   it('byCapability returns true for matching capability', () => {
@@ -198,79 +214,70 @@ describe('Connectors', () => {
 
   it('<Pin /> renders select with options for driver pins', () => {
     const driver = { id: 'rpi', pinmap: { 'digital-output': [1, 2, 3] } }
-    const m = shallow(<Pin driver={driver} update={() => {}} type='digital-output' current={1} />)
-    expect(m.find('select').length).toBe(1)
-    expect(m.find('option').length).toBe(3)
+    const html = renderToStaticMarkup(<Pin driver={driver} update={() => {}} type='digital-output' current={1} />)
+    expect(html).toContain('<select')
+    expect((html.match(/<option/g) || []).length).toBe(3)
   })
 
   it('<Pin /> calls update on change', () => {
     const driver = { id: 'rpi', pinmap: { 'digital-output': [1, 2, 3] } }
     const update = jest.fn()
-    const m = shallow(<Pin driver={driver} update={update} type='digital-output' current={1} />)
-    change(m.find('select'), { target: { value: '2' } })
+    const m = new Pin({ driver, update, type: 'digital-output', current: 1 })
+    m.handleChange({ target: { value: '2' } })
     expect(update).toHaveBeenCalledWith(2)
   })
 
   it('<Pin /> renders empty for undefined driver', () => {
-    const m = shallow(<Pin driver={undefined} update={() => {}} type='digital-output' />)
-    expect(m.find('option').length).toBe(0)
+    const m = new Pin({ driver: undefined, update: () => {}, type: 'digital-output' })
+    expect(m.options()).toBeUndefined()
   })
 
   it('<AnalogInput /> renders view mode by default', () => {
-    const m = shallow(
-      <AnalogInput
-        name='pH Sensor'
-        pin={0}
-        analog_input_id='1'
-        driver={stockDrivers[0]}
-        drivers={stockDrivers}
-        update={() => {}}
-        remove={() => {}}
-      />
-    )
-    expect(m.find('.analog_input-edit').length).toBe(1)
+    const m = new AnalogInput({
+      name: 'pH Sensor',
+      pin: 0,
+      analog_input_id: '1',
+      driver: stockDrivers[0],
+      drivers: stockDrivers,
+      update: () => {},
+      remove: () => {}
+    })
+    expect(renderToStaticMarkup(m.render())).toContain('analog_input-edit')
   })
 
   it('<AnalogInput /> toggles to edit and saves', () => {
     const update = jest.fn()
-    const m = shallow(
-      <AnalogInput
-        name='pH Sensor'
-        pin={0}
-        analog_input_id='1'
-        driver={stockDrivers[0]}
-        drivers={stockDrivers}
-        update={update}
-        remove={() => {}}
-      />
-    )
-    // click edit
-    click(m.find('.analog_input-edit'))
-    expect(m.instance().state.edit).toBe(true)
-    // change name
-    m.update()
-    change(m.find('.analog_input-name'), { target: { value: 'New Name' } })
-    expect(m.instance().state.name).toBe('New Name')
-    // save
-    click(m.find('.analog_input-edit'))
+    const m = new AnalogInput({
+      name: 'pH Sensor',
+      pin: 0,
+      analog_input_id: '1',
+      driver: stockDrivers[0],
+      drivers: stockDrivers,
+      update,
+      remove: () => {}
+    })
+    patchSetState(m)
+    m.handleEdit()
+    expect(m.state.edit).toBe(true)
+    m.handleNameChange({ target: { value: 'New Name' } })
+    expect(m.state.name).toBe('New Name')
+    m.handleEdit()
     expect(update).toHaveBeenCalled()
-    expect(m.instance().state.edit).toBe(false)
+    expect(m.state.edit).toBe(false)
   })
 
   it('<AnalogInput /> handleRemove calls remove', () => {
     const remove = jest.fn()
-    const m = shallow(
-      <AnalogInput
-        name='Test'
-        pin={0}
-        analog_input_id='1'
-        driver={stockDrivers[0]}
-        drivers={stockDrivers}
-        update={() => {}}
-        remove={remove}
-      />
-    )
-    click(m.find('.analog_input-remove'))
+    const m = new AnalogInput({
+      name: 'Test',
+      pin: 0,
+      analog_input_id: '1',
+      driver: stockDrivers[0],
+      drivers: stockDrivers,
+      update: () => {},
+      remove
+    })
+    m.handleRemove()
     expect(remove).toHaveBeenCalled()
   })
 
@@ -278,20 +285,21 @@ describe('Connectors', () => {
     const aiDrivers = [
       { id: 'ads', name: 'ADS1115', pinmap: { 'analog-input': [0, 1, 2, 3] } }
     ]
-    const state = {
+    const create = jest.fn()
+    const component = new RawAnalogInputs({
       analog_inputs: [{ id: '1', name: 'pH', pin: 0, driver: 'ads' }],
-      drivers: aiDrivers
-    }
-    const wrapper = mount(
-      <Provider store={mockStore(state)}>
-        <AnalogInputs />
-      </Provider>
-    )
-    click(wrapper.find('#add_analog_input'))
-    wrapper.update()
-    change(wrapper.find('#analog_inputName'), { target: { value: 'New Sensor' } })
-    click(wrapper.find('#createAnalogInput'))
-    wrapper.update()
-    expect(wrapper.find(AnalogInput).length).toBe(1)
+      drivers: aiDrivers,
+      fetch: jest.fn(),
+      create,
+      delete: jest.fn(),
+      update: jest.fn()
+    })
+    patchSetState(component)
+    component.componentDidMount()
+    component.handleAdd()
+    component.handleNameChange({ target: { value: 'New Sensor' } })
+    component.handleSave()
+    expect(create).toHaveBeenCalled()
+    expect(component.list().length).toBeGreaterThan(0)
   })
 })

--- a/front-end/src/connectors/inlet_selector.jsx
+++ b/front-end/src/connectors/inlet_selector.jsx
@@ -114,4 +114,5 @@ const InletSelector = connect(
   mapStateToProps,
   mapDispatchToProps
 )(inletSelector)
+export { inletSelector as RawInletSelector }
 export default InletSelector

--- a/front-end/src/connectors/inlets.jsx
+++ b/front-end/src/connectors/inlets.jsx
@@ -245,4 +245,5 @@ const Inlets = connect(
   mapStateToProps,
   mapDispatchToProps
 )(inlets)
+export { inlets as RawInlets }
 export default Inlets

--- a/front-end/src/connectors/jacks.jsx
+++ b/front-end/src/connectors/jacks.jsx
@@ -263,4 +263,5 @@ const Jacks = connect(
   mapStateToProps,
   mapDispatchToProps
 )(jacks)
+export { jacks as RawJacks }
 export default Jacks

--- a/front-end/src/connectors/main.jsx
+++ b/front-end/src/connectors/main.jsx
@@ -57,4 +57,5 @@ const Connectors = connect(
   mapStateToProps,
   mapDispatchToProps
 )(connectors)
+export { connectors as RawConnectors }
 export default Connectors

--- a/front-end/src/connectors/outlets.jsx
+++ b/front-end/src/connectors/outlets.jsx
@@ -249,4 +249,5 @@ const Outlets = connect(
   mapDispatchToProps
 )(outlets)
 
+export { outlets as RawOutlets }
 export default Outlets

--- a/front-end/src/jack_selector.test.jsx
+++ b/front-end/src/jack_selector.test.jsx
@@ -1,14 +1,21 @@
 import JackSelector, { RawJackSelector } from './jack_selector'
 import React from 'react'
-import { mount } from 'enzyme'
-import { Provider } from 'react-redux'
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
 import 'isomorphic-fetch'
 
-const mockStore = configureMockStore([thunk])
-
 const jacks = [{ id: '1', name: 'Foo', pins: [1, 2] }]
+
+const findAll = (node, predicate, acc = []) => {
+  if (!node || typeof node !== 'object') {
+    return acc
+  }
+  if (predicate(node)) {
+    acc.push(node)
+  }
+  const children = React.Children.toArray(node.props?.children)
+  children.forEach(child => findAll(child, predicate, acc))
+  return acc
+}
+
 describe('JackSelector', () => {
   it('renders without throwing with matching jack', () => {
     const component = new RawJackSelector({ id: '1', jacks, update: jest.fn(), fetchJacks: jest.fn() })
@@ -55,22 +62,29 @@ describe('JackSelector', () => {
 
   it('setJack updates and calls update', () => {
     const update = jest.fn()
-    const store = mockStore({ jacks })
-    const wrapper = mount(<Provider store={store}><JackSelector id='1' update={update} /></Provider>)
-    wrapper.find('a.dropdown-item').first().prop('onClick')()
+    const component = new RawJackSelector({ id: '1', jacks, update, fetchJacks: jest.fn() })
+    component.setState = jest.fn(updateState => {
+      component.state = { ...component.state, ...updateState }
+    })
+
+    const items = findAll(component.jacks(), node => node.type === 'a')
+    items[0].props.onClick()
+
     expect(update).toHaveBeenCalledWith('1', 1)
-    wrapper.unmount()
+    expect(JackSelector).toBeDefined()
   })
 
   it('setPin updates and calls update', () => {
     const update = jest.fn()
-    const store = mockStore({ jacks })
-    const wrapper = mount(<Provider store={store}><JackSelector id='1' update={update} /></Provider>)
-    const pinItems = wrapper.find('a.dropdown-item')
+    const component = new RawJackSelector({ id: '1', jacks, update, fetchJacks: jest.fn() })
+    component.setState = jest.fn(updateState => {
+      component.state = { ...component.state, ...updateState }
+    })
+
+    const pinItems = findAll(component.pins(), node => node.type === 'a')
     if (pinItems.length > 1) {
-      pinItems.last().prop('onClick')()
-      expect(update).toHaveBeenCalled()
+      pinItems[1].props.onClick()
+      expect(update).toHaveBeenCalledWith('1', 2)
     }
-    wrapper.unmount()
   })
 })

--- a/front-end/src/lighting/chart.jsx
+++ b/front-end/src/lighting/chart.jsx
@@ -40,4 +40,5 @@ const Chart = connect(
   mapStateToProps,
   null
 )(chart)
+export { chart as RawLightingChart }
 export default Chart

--- a/front-end/src/lighting/lighting.test.js
+++ b/front-end/src/lighting/lighting.test.js
@@ -1,9 +1,9 @@
 import React from 'react'
-import { shallow, mount } from 'enzyme'
+import { renderToStaticMarkup } from 'react-dom/server'
 import { Formik, Form } from 'formik'
 import Channel from './channel'
-import Chart from './chart'
-import Main, {TestMain} from './main'
+import { RawLightingChart } from './chart'
+import { TestMain } from './main'
 import LightForm from './light_form'
 import Light from './light'
 import ProfileSelector from './profile_selector'
@@ -17,17 +17,15 @@ import CircadianProfile from './circadian_profile'
 import CyclicProfile from './cyclic_profile'
 import Profile from './profile'
 import Percent from '../ui_components/percent'
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
+import * as Alert from 'utils/alert'
 import 'isomorphic-fetch'
 
-const wrapFormik = (component, initialValues = {}) => (
+const wrapFormik = (component, initialValues = {}) => renderToStaticMarkup(
   <Formik initialValues={initialValues} onSubmit={() => {}}>
     <Form>{component}</Form>
   </Formik>
 )
 
-const mockStore = configureMockStore([thunk])
 jest.mock('utils/confirm', () => {
   return {
     confirm: jest
@@ -40,6 +38,7 @@ jest.mock('utils/confirm', () => {
       .bind(this)
   }
 })
+
 describe('Lighting ui', () => {
   const ev = {
     target: { value: 10.5 }
@@ -48,11 +47,14 @@ describe('Lighting ui', () => {
     id: '1',
     name: 'foo',
     jack: '1',
+    enable: true,
     channels: {
       1: {
         pin: 0,
         color: '',
         manual: false,
+        min: 0,
+        max: 100,
         profile: {
           type: 'interval',
           config: {
@@ -65,16 +67,30 @@ describe('Lighting ui', () => {
     }
   }
 
+  const createMain = overrides => new TestMain({
+    fetchLights: jest.fn(),
+    fetchJacks: jest.fn(),
+    lights: [light, light],
+    jacks: [{ id: '1', name: 'foo', pins: [1, 2] }],
+    updateLight: jest.fn(),
+    createLight: jest.fn(),
+    deleteLight: jest.fn(),
+    ...overrides
+  })
+
   beforeEach(() => {
     light = {
       id: '1',
       name: 'foo',
       jack: '1',
+      enable: true,
       channels: {
         1: {
           pin: 0,
           color: '',
           manual: false,
+          min: 0,
+          max: 100,
           profile: {
             type: 'interval',
             config: {
@@ -86,64 +102,50 @@ describe('Lighting ui', () => {
         }
       }
     }
+    jest.spyOn(Alert, 'showError')
+    jest.spyOn(Alert, 'showUpdateSuccessful')
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
   })
 
   it('<Main />', () => {
-    const jacks = [{ id: '1', name: 'foo', pins: [1,2] }]
-    const m = shallow(<Main store={mockStore({ lights: [light, light], jacks: jacks })} />)
-      .dive()
-      .instance()
+    const m = createMain()
+    expect(m.lightsList()).toHaveLength(2)
   })
 
   it('<Main /> should change mode from auto to manual', () => {
-    const fn = jest.fn()
     const fnUpdateLight = jest.fn()
-
-    const m = shallow(<TestMain
-      fetchLights = {fn}
-      fetchJacks = {fn}
-      lights = {[light, light]}
-      updateLight = {fnUpdateLight}
-    />).instance()
+    const m = createMain({ updateLight: fnUpdateLight })
 
     expect.assertions(2)
-    return (m.handleChangeMode(light)()).then(() => {
-
+    return m.handleChangeMode(light)().then(() => {
       expect(fnUpdateLight).toHaveBeenCalledTimes(1)
-      const actualArgs = fnUpdateLight.mock.calls[0][1]
-      expect(actualArgs.channels[1].manual).toBe(true)
+      expect(fnUpdateLight.mock.calls[0][1].channels[1].manual).toBe(true)
     })
   })
 
   it('<Main /> should change mode from manual to auto', () => {
-    const fn = jest.fn()
     const fnUpdateLight = jest.fn()
-
     light.channels[1].manual = true
-
-    const m = shallow(<TestMain
-      fetchLights = {fn}
-      fetchJacks = {fn}
-      lights = {[light, light]}
-      updateLight = {fnUpdateLight}
-    />).instance()
+    const m = createMain({ updateLight: fnUpdateLight })
 
     expect.assertions(2)
-    return (m.handleChangeMode(light)()).then(() => {
+    return m.handleChangeMode(light)().then(() => {
       expect(fnUpdateLight).toHaveBeenCalledTimes(1)
-      const actualArgs = fnUpdateLight.mock.calls[0][1]
-      expect(actualArgs.channels[1].manual).toBe(false)
+      expect(fnUpdateLight.mock.calls[0][1].channels[1].manual).toBe(false)
     })
   })
 
   it('<Main /> should change mode from mixed to auto', () => {
-    const fn = jest.fn()
     const fnUpdateLight = jest.fn()
-
     light.channels[2] = {
-      pin: 0,
+      pin: 1,
       color: '',
       manual: true,
+      min: 0,
+      max: 100,
       profile: {
         type: 'interval',
         config: {
@@ -153,89 +155,63 @@ describe('Lighting ui', () => {
         }
       }
     }
-
-    const m = shallow(<TestMain
-      fetchLights = {fn}
-      fetchJacks = {fn}
-      lights = {[light, light]}
-      updateLight = {fnUpdateLight}
-    />).instance()
+    const m = createMain({ updateLight: fnUpdateLight })
 
     expect.assertions(3)
-    return (m.handleChangeMode(light)()).then(() => {
-
+    return m.handleChangeMode(light)().then(() => {
       expect(fnUpdateLight).toHaveBeenCalledTimes(1)
-      const actualArgs = fnUpdateLight.mock.calls[0][1]
-      expect(actualArgs.channels[1].manual).toBe(false)
-      expect(actualArgs.channels[2].manual).toBe(false)
+      expect(fnUpdateLight.mock.calls[0][1].channels[1].manual).toBe(false)
+      expect(fnUpdateLight.mock.calls[0][1].channels[2].manual).toBe(false)
     })
   })
 
   it('<Main /> should set the interval when start is before end', () => {
-    const fn = jest.fn()
     const fnUpdateLight = jest.fn()
-
     light.channels[1].profile.config.start = '14:00:00'
     light.channels[1].profile.config.end = '16:00:00'
-    light.channels[1].profile.config.values = [1,2,3.6,4,5]
-    const m = shallow(<TestMain
-      fetchLights = {fn}
-      fetchJacks = {fn}
-      lights = {[light, light]}
-      updateLight = {fnUpdateLight}
-    />).instance()
+    light.channels[1].profile.config.values = [1, 2, 3.6, 4, 5]
+    const m = createMain({ updateLight: fnUpdateLight })
 
-    const values = {
+    m.handleUpdateLight({
       config: {
         id: 1,
         name: 'light',
         channels: light.channels,
         jack: light.jack
       }
-    }
-    m.handleUpdateLight(values)
+    })
 
     expect(fnUpdateLight).toHaveBeenCalledTimes(1)
-    const actualArgs = fnUpdateLight.mock.calls[0][1]
-    expect(actualArgs.channels[1].profile.config.interval).toBe(30 * 60)
+    expect(fnUpdateLight.mock.calls[0][1].channels[1].profile.config.interval).toBe(30 * 60)
   })
 
-
   it('<Main /> should set the interval when end is before start', () => {
-    const fn = jest.fn()
     const fnUpdateLight = jest.fn()
-
     light.channels[1].profile.type = 'auto'
     light.channels[1].profile.config.start = '23:00:00'
     light.channels[1].profile.config.end = '01:00:00'
-    light.channels[1].profile.config.values = [1,2,3,4,5]
-    const m = shallow(<TestMain
-      fetchLights = {fn}
-      fetchJacks = {fn}
-      lights = {[light, light]}
-      updateLight = {fnUpdateLight}
-    />).instance()
+    light.channels[1].profile.config.values = [1, 2, 3, 4, 5]
+    const m = createMain({ updateLight: fnUpdateLight })
 
-    const values = {
+    m.handleUpdateLight({
       config: {
         id: 1,
         name: 'light',
         channels: light.channels,
         jack: light.jack
       }
-    }
-    m.handleUpdateLight(values)
+    })
 
     expect(fnUpdateLight).toHaveBeenCalledTimes(1)
-    const actualArgs = fnUpdateLight.mock.calls[0][1]
-    expect(actualArgs.channels[1].profile.config.interval).toBe(30 * 60)
+    expect(fnUpdateLight.mock.calls[0][1].channels[1].profile.config.interval).toBe(30 * 60)
   })
 
   it('<LightForm />', () => {
-    const fn = jest.fn()
     light.channels[2] = {
-      pin: 0,
+      pin: 1,
       color: '',
+      min: 0,
+      max: 100,
       profile: {
         type: 'interval',
         config: {
@@ -245,189 +221,213 @@ describe('Lighting ui', () => {
         }
       }
     }
-    const wrapper = shallow(<LightForm onSubmit={fn} config={light} />)
-    wrapper.simulate('submit', { preventDefault: () => {} })
-    expect(fn).toHaveBeenCalled()
+    expect(renderToStaticMarkup(
+      <LightForm onSubmit={jest.fn()} config={light} jacks={[{ id: '1', name: 'foo' }]} />
+    )).toContain('form-light-1')
   })
 
   it('<Light /> should submit', () => {
     const fn = jest.fn()
     const values = { config: light }
-    const m = shallow(
-      <Light values={values} config={light} save={() => {}} remove={() => true} submitForm={fn} isValid={true} />
-    )
-    m.find('form').simulate('submit', { preventDefault: () => {} })
+    const form = Light({
+      values,
+      config: light,
+      save: () => {},
+      remove: () => true,
+      submitForm: fn,
+      isValid: true,
+      dirty: true,
+      jacks: [{ id: '1', name: 'foo' }],
+      touched: {},
+      errors: {},
+      handleBlur: jest.fn(),
+      handleChange: jest.fn()
+    })
+    form.props.onSubmit({ preventDefault: () => {} })
     expect(fn).toHaveBeenCalled()
+    expect(Alert.showUpdateSuccessful).toHaveBeenCalled()
   })
 
   it('<Light /> should show error on submit if not valid', () => {
     const fn = jest.fn()
     const values = { config: light }
-    const m = shallow(
-      <Light values={values} config={light} save={() => {}} remove={() => true} submitForm={fn} isValid={false} />
-    )
-    m.find('form').simulate('submit', { preventDefault: () => {} })
+    const form = Light({
+      values,
+      config: light,
+      save: () => {},
+      remove: () => true,
+      submitForm: fn,
+      isValid: false,
+      dirty: true,
+      jacks: [{ id: '1', name: 'foo' }],
+      touched: {},
+      errors: {},
+      handleBlur: jest.fn(),
+      handleChange: jest.fn()
+    })
+    form.props.onSubmit({ preventDefault: () => {} })
     expect(fn).toHaveBeenCalled()
+    expect(Alert.showError).toHaveBeenCalled()
   })
 
   it('<Chart />', () => {
-    shallow(<Chart store={mockStore({ lights: [light] })} light_id='1' />).dive()
-    shallow(<Chart store={mockStore({ lights: [] })} light_id='1' />)
-      .dive()
-      .instance()
+    expect(new RawLightingChart({ config: undefined, light_id: '1' }).render().type).toBe('span')
+    expect(new RawLightingChart({ config: light, light_id: '1', width: 100, height: 100 }).render().type).toBeDefined()
   })
 
   it('<Channel />', () => {
-    const m = shallow(<Channel name='' channel={light.channels['1']} onChangeHandler={() => {}} />)
-    expect(m).toBeDefined()
+    expect(wrapFormik(
+      <Channel
+        name='config.channels.1'
+        channel={light.channels['1']}
+        channelNum='1'
+        onChangeHandler={() => {}}
+        onBlur={() => {}}
+        touched={{}}
+        errors={{}}
+      />,
+      { config: light }
+    )).toContain('channel_name')
   })
 
   it('<Profile /> fixed', () => {
-    const fn = jest.fn()
-    const wrapper = shallow(<Profile name="name" type='fixed' onChangeHandler={fn} />)
-    expect(wrapper.find(FixedProfile).length).toBe(1)
-    expect(wrapper.find(AutoProfile).length).toBe(0)
-    expect(wrapper.find(DiurnalProfile).length).toBe(0)
+    expect(Profile({ name: 'name', type: 'fixed', onChangeHandler: jest.fn() }).type).toBe(FixedProfile)
   })
 
   it('<Profile /> interval', () => {
-    const wrapper = shallow(<Profile name="name" type='interval' onChangeHandler={() => true} />)
-    expect(wrapper.find(FixedProfile).length).toBe(0)
-    expect(wrapper.find(AutoProfile).length).toBe(1)
-    expect(wrapper.find(DiurnalProfile).length).toBe(0)
+    expect(Profile({ name: 'name', type: 'interval', onChangeHandler: () => true }).type).toBe(AutoProfile)
   })
 
   it('<Profile /> diurnal', () => {
-    const wrapper = shallow(<Profile name="name" type='diurnal' onChangeHandler={() => true} />)
-    expect(wrapper.find(FixedProfile).length).toBe(0)
-    expect(wrapper.find(AutoProfile).length).toBe(0)
-    expect(wrapper.find(DiurnalProfile).length).toBe(1)
+    expect(Profile({ name: 'name', type: 'diurnal', onChangeHandler: () => true }).type).toBe(DiurnalProfile)
   })
 
   it('<DiurnalProfile />', () => {
-    shallow(<DiurnalProfile name='testDiurnal' onChangeHandler={() => true} />).instance()
+    expect(wrapFormik(
+      <DiurnalProfile name='testDiurnal' onChangeHandler={() => true} touched={{}} errors={{}} />
+    )).toContain('start_time')
   })
 
   it('<FixedProfile />', () => {
-    const m = shallow(<FixedProfile onChangeHandler={() => true} config={{ config: { value: '1' } }} />).instance()
+    const onChangeHandler = jest.fn()
+    const m = new FixedProfile({ onChangeHandler, config: { value: '1' } })
+    m.setState = update => { m.state = { ...m.state, ...update } }
     m.handleChange(ev)
     m.handleChange({ target: { value: 'foo' } })
+    expect(onChangeHandler).toHaveBeenCalled()
   })
 
   it('<FixedProfile /> should not allow empty value', () => {
-    const m = shallow(<FixedProfile onChangeHandler={() => true} config={{ config: { value: '1' } }} />).instance()
-    m.handleChange(ev)
+    const onChangeHandler = jest.fn()
+    const m = new FixedProfile({ onChangeHandler, config: { value: '1' } })
+    m.setState = update => { m.state = { ...m.state, ...update } }
     m.handleChange({ target: { value: '' } })
+    expect(onChangeHandler).toHaveBeenCalledWith({
+      start: undefined,
+      end: undefined,
+      value: ''
+    })
   })
 
   it('<SineProfile />', () => {
-    const config = { config: { value: '1'} }
-    const wrapper = shallow(
+    const config = { config: { value: '1' } }
+    expect(wrapFormik(
       <SineProfile
         name='testsine'
         config={config}
         readOnly={false}
         onChangeHandler={() => {}}
-      />)
-    expect(wrapper).toBeDefined()
+      />,
+      { testsine: { start: '08:00:00', end: '20:00:00' } }
+    )).toContain('start_time')
   })
 
   it('<RandomProfile />', () => {
-    const config = { config: { value: '1'} }
-    const wrapper = shallow(
+    const config = { config: { value: '1' } }
+    expect(wrapFormik(
       <RandomProfile
         name='testrandom'
         config={config}
         readOnly={false}
         onChangeHandler={() => {}}
-      />)
-    expect(wrapper).toBeDefined()
+      />,
+      { testrandom: { start: '08:00:00', end: '20:00:00' } }
+    )).toContain('start_time')
   })
 
   it('<LunarProfile />', () => {
-    const config = { config: { value: '1'} }
-    const wrapper = shallow(
+    const config = { config: { value: '1' } }
+    expect(wrapFormik(
       <LunarProfile
         name='testLunar'
         config={config}
         readOnly={false}
         onChangeHandler={() => {}}
-      />)
-    expect(wrapper).toBeDefined()
+      />,
+      { testLunar: { start: '08:00:00', end: '20:00:00', full_moon: null } }
+    )).toContain('full_moon')
   })
 
   it('<Percent />', () => {
-    const wrapper = shallow(<Percent value='4' onChange={() => true} />)
-    wrapper.find('input').simulate('change', { target: { value: 34 } })
+    const onChange = jest.fn()
+    const field = Percent({ value: '4', onChange, name: 'foo' })
+    field.props.onChange({ target: { name: 'foo', value: 34 } })
+    expect(onChange).toHaveBeenCalledWith({ target: { name: 'foo', value: 34 } })
   })
 
   it('<ProfileSelector />', () => {
     const fn = jest.fn()
-    const wrapper = shallow(<ProfileSelector name='name' value='fixed' onChangeHandler={fn} />)
-    expect(wrapper.find('input').length).toBe(10)
-    wrapper.find('select').simulate('change', { target: { value: 'diurnal' } })
+    const selector = ProfileSelector({ name: 'name', value: 'fixed', onChangeHandler: fn })
+    expect(React.Children.count(selector.props.children[1].props.children)).toBe(10)
+    selector.props.children[0].props.children.props.onChange({ target: { value: 'diurnal' } })
+    expect(fn).toHaveBeenCalled()
   })
 
   it('<Profile /> circadian', () => {
-    const wrapper = shallow(<Profile name='name' type='circadian' onChangeHandler={() => true} />)
-    expect(wrapper.find(CircadianProfile).length).toBe(1)
+    expect(Profile({ name: 'name', type: 'circadian', onChangeHandler: () => true }).type).toBe(CircadianProfile)
   })
 
   it('<Profile /> cyclic', () => {
-    const wrapper = shallow(<Profile name='name' type='cyclic' onChangeHandler={() => true} />)
-    expect(wrapper.find(CyclicProfile).length).toBe(1)
+    expect(Profile({ name: 'name', type: 'cyclic', onChangeHandler: () => true }).type).toBe(CyclicProfile)
   })
 
   it('<CircadianProfile />', () => {
-    const wrapper = mount(
-      wrapFormik(
-        <CircadianProfile
-          name='channels[1].profile.config'
-          onChangeHandler={() => {}}
-          readOnly={false}
-          touched={{}}
-          errors={{}}
-        />,
-        { 'channels[1].profile.config': { start: '08:00:00', end: '20:00:00', dawn_value: 10, noon_value: 80 } }
-      )
-    )
-    expect(wrapper.find('input').length).toBeGreaterThan(0)
+    expect(wrapFormik(
+      <CircadianProfile
+        name='channels[1].profile.config'
+        onChangeHandler={() => {}}
+        readOnly={false}
+        touched={{}}
+        errors={{}}
+      />,
+      { 'channels[1].profile.config': { start: '08:00:00', end: '20:00:00', dawn_value: 10, noon_value: 80 } }
+    )).toContain('circadian_dawn_value')
   })
 
   it('<CircadianProfile /> readOnly', () => {
-    const wrapper = mount(
-      wrapFormik(
-        <CircadianProfile name='circadian' onChangeHandler={() => {}} readOnly touched={{}} errors={{}} />,
-        {}
-      )
-    )
-    expect(wrapper.find('input').length).toBeGreaterThan(0)
+    expect(wrapFormik(
+      <CircadianProfile name='circadian' onChangeHandler={() => {}} readOnly touched={{}} errors={{}} />,
+      {}
+    )).toContain('readOnly=""')
   })
 
   it('<CyclicProfile />', () => {
-    const wrapper = mount(
-      wrapFormik(
-        <CyclicProfile
-          name='channels[1].profile.config'
-          onChangeHandler={() => {}}
-          readOnly={false}
-          touched={{}}
-          errors={{}}
-        />,
-        { 'channels[1].profile.config': { period: 3600, phase_shift: 0 } }
-      )
-    )
-    expect(wrapper.find('input').length).toBeGreaterThan(0)
+    expect(wrapFormik(
+      <CyclicProfile
+        name='channels[1].profile.config'
+        onChangeHandler={() => {}}
+        readOnly={false}
+        touched={{}}
+        errors={{}}
+      />,
+      { 'channels[1].profile.config': { period: 3600, phase_shift: 0 } }
+    )).toContain('cyclic_period')
   })
 
   it('<CyclicProfile /> readOnly', () => {
-    const wrapper = mount(
-      wrapFormik(
-        <CyclicProfile name='cyclic' onChangeHandler={() => {}} readOnly touched={{}} errors={{}} />,
-        {}
-      )
-    )
-    expect(wrapper.find('input').length).toBeGreaterThan(0)
+    expect(wrapFormik(
+      <CyclicProfile name='cyclic' onChangeHandler={() => {}} readOnly touched={{}} errors={{}} />,
+      {}
+    )).toContain('readOnly=""')
   })
-
 })

--- a/front-end/src/macro/edit_macro.test.js
+++ b/front-end/src/macro/edit_macro.test.js
@@ -1,10 +1,38 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { Formik } from 'formik'
+import { Provider } from 'react-redux'
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
 import EditMacro from './edit_macro'
 import 'isomorphic-fetch'
 import * as Alert from '../utils/alert'
-import { FieldArray } from 'formik'
 
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const mockStore = configureMockStore([thunk])
+
+const renderMacro = props => {
+  const container = document.createElement('div')
+  const root = createRoot(container)
+  const store = mockStore({ equipment: [], macros: [], lights: [], atos: [], tcs: [], phprobes: [], cameras: [], dosers: [] })
+
+  act(() => {
+    root.render(
+      <Provider store={store}>
+        <Formik initialValues={props.values} onSubmit={() => {}}>
+          <EditMacro {...props} />
+        </Formik>
+      </Provider>
+    )
+  })
+
+  return {
+    container,
+    unmount: () => act(() => root.unmount())
+  }
+}
 
 describe('<EditMacro />', () => {
   let values = {
@@ -34,51 +62,59 @@ describe('<EditMacro />', () => {
   })
 
   it('<EditMacro />', () => {
-    const wrapper = shallow(
-      <EditMacro
-        values={values}
-        errors={{}}
-        touched={{}}
-        handleBlur={fn}
-        handleChange={fn}
-        submitForm={fn}
-      />
-    )
-    let arrayField = wrapper.find(FieldArray).shallow()
-    expect(arrayField.length).toBe(1)
+    const { container, unmount } = renderMacro({
+      values,
+      errors: {},
+      touched: {},
+      onBlur: fn,
+      handleChange: fn,
+      submitForm: fn
+    })
+    expect(container.querySelectorAll('.macro-step').length).toBe(2)
+    unmount()
   })
 
   it('<EditMacro /> should submit', () => {
-    const wrapper = shallow(
-      <EditMacro
-        values={values}
-        handleBlur={fn}
-        handleChange={fn}
-        submitForm={fn}
-        errors={{}}
-        touched={{}}
-        dirty
-        isValid
-      />
-    )
-    wrapper.find('form').simulate('submit', { preventDefault: () => {} })
+    const submitForm = jest.fn()
+    const { container, unmount } = renderMacro({
+      values,
+      onBlur: fn,
+      handleChange: fn,
+      submitForm,
+      errors: {},
+      touched: {},
+      dirty: true,
+      isValid: true
+    })
+
+    act(() => {
+      container.querySelector('form').dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    })
+
+    expect(submitForm).toHaveBeenCalled()
     expect(Alert.showError).not.toHaveBeenCalled()
+    unmount()
   })
 
   it('<EditMacro /> should show alert when invalid', () => {
-    const wrapper = shallow(
-      <EditMacro
-        values={values}
-        handleBlur={fn}
-        handleChange={fn}
-        submitForm={fn}
-        errors={{}}
-        touched={{}}
-        dirty
-        isValid={false}
-      />
-    )
-    wrapper.find('form').simulate('submit', { preventDefault: () => {} })
+    const submitForm = jest.fn()
+    const { container, unmount } = renderMacro({
+      values,
+      onBlur: fn,
+      handleChange: fn,
+      submitForm,
+      errors: {},
+      touched: {},
+      dirty: true,
+      isValid: false
+    })
+
+    act(() => {
+      container.querySelector('form').dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    })
+
+    expect(submitForm).toHaveBeenCalled()
     expect(Alert.showError).toHaveBeenCalled()
+    unmount()
   })
 })

--- a/front-end/src/macro/pwm_step.jsx
+++ b/front-end/src/macro/pwm_step.jsx
@@ -71,4 +71,5 @@ PWMStep.propTypes = {
 const mapStateToProps = state => ({ jacks: state.jacks })
 const mapDispatchToProps = dispatch => ({ fetch: () => dispatch(fetchJacks()) })
 
+export { PWMStep as RawPWMStep }
 export default connect(mapStateToProps, mapDispatchToProps)(PWMStep)

--- a/front-end/src/macro/steps.test.js
+++ b/front-end/src/macro/steps.test.js
@@ -1,21 +1,20 @@
 import React from 'react'
-import { shallow, mount } from 'enzyme'
+import { renderToStaticMarkup } from 'react-dom/server'
 import { Provider } from 'react-redux'
 import { Formik, Form } from 'formik'
 import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
 import 'isomorphic-fetch'
 
 import WaitStep from './wait_step'
 import AlertStep from './alert_step'
-import GenericStep from './generic_step'
+import { RawGenericStep } from './generic_step'
 import StepSelector from './step_selector'
 import SelectType from './select_type'
-import PWMStep from './pwm_step'
-import MacroForm from './macro_form'
+import { RawPWMStep } from './pwm_step'
 import MacroSchema from './macro_schema'
+import { mapMacroPropsToValues } from './macro_form'
 
-const mockStore = configureMockStore([thunk])
+const mockStore = configureMockStore([])
 
 const storeState = {
   equipment: [{ id: '1', name: 'Return Pump' }],
@@ -29,162 +28,152 @@ const storeState = {
 }
 
 // Wrap a component that needs Formik context
-const withFormik = (component, initialValues = {}) => (
-  <Formik initialValues={initialValues} onSubmit={() => {}}>
-    <Form>{component}</Form>
-  </Formik>
+const withFormik = (component, initialValues = {}, store = null) => {
+  const tree = (
+    <Formik initialValues={initialValues} onSubmit={() => {}}>
+      <Form>{component}</Form>
+    </Formik>
+  )
+  return store ? <Provider store={store}>{tree}</Provider> : tree
+}
+
+const renderMarkup = (component, initialValues = {}, store = null) => renderToStaticMarkup(
+  withFormik(component, initialValues, store)
 )
 
 describe('Macro step components', () => {
   it('<WaitStep /> renders duration field', () => {
-    const wrapper = mount(
-      withFormik(
-        <WaitStep name='steps[0]' errors={{}} touched={{}} readOnly={false} />,
-        { 'steps[0]': { duration: 30 } }
-      )
-    )
-    expect(wrapper.find('input').length).toBeGreaterThan(0)
+    expect(renderMarkup(
+      <WaitStep name='steps[0]' errors={{}} touched={{}} readOnly={false} />,
+      { 'steps[0]': { duration: 30 } }
+    )).toContain('aria-label="Duration"')
   })
 
   it('<WaitStep /> renders in readOnly mode', () => {
-    const wrapper = mount(
-      withFormik(
-        <WaitStep name='steps[0]' errors={{}} touched={{}} readOnly />,
-        { 'steps[0]': { duration: 5 } }
-      )
-    )
-    expect(wrapper.find('input').length).toBeGreaterThan(0)
+    expect(renderMarkup(
+      <WaitStep name='steps[0]' errors={{}} touched={{}} readOnly />,
+      { 'steps[0]': { duration: 5 } }
+    )).toContain('readOnly=""')
   })
 
   it('<AlertStep /> renders title and message fields', () => {
-    const wrapper = mount(
-      withFormik(
-        <AlertStep name='steps[0]' errors={{}} touched={{}} readOnly={false} />,
-        { 'steps[0]': { title: '', message: '' } }
-      )
+    const html = renderMarkup(
+      <AlertStep name='steps[0]' errors={{}} touched={{}} readOnly={false} />,
+      { 'steps[0]': { title: '', message: '' } }
     )
-    expect(wrapper.find('input').length).toBeGreaterThanOrEqual(2)
+    expect(html).toContain('aria-label="Title"')
+    expect((html.match(/<input/g) || [])).toHaveLength(2)
   })
 
   it('<SelectType /> renders all valid type options', () => {
-    const wrapper = mount(
-      withFormik(
-        <SelectType name='steps[0].type' className='custom-select' readOnly={false} />,
-        { 'steps[0]': { type: 'wait' } }
-      )
+    const html = renderMarkup(
+      <SelectType name='steps[0].type' className='custom-select' readOnly={false} />,
+      { 'steps[0]': { type: 'wait' } }
     )
-    const options = wrapper.find('option')
-    // 11 valid types + 1 placeholder
-    expect(options.length).toBeGreaterThanOrEqual(11)
+    expect((html.match(/<option/g) || []).length).toBeGreaterThanOrEqual(11)
   })
 
   it('<SelectType /> renders as disabled when readOnly', () => {
-    const wrapper = mount(
-      withFormik(
-        <SelectType name='steps[0].type' className='' readOnly />,
-        { 'steps[0]': { type: 'wait' } }
-      )
-    )
-    expect(wrapper.find('select').prop('disabled')).toBe(true)
+    expect(renderMarkup(
+      <SelectType name='steps[0].type' className='' readOnly />,
+      { 'steps[0]': { type: 'wait' } }
+    )).toContain('disabled=""')
   })
 
   it('<StepSelector /> returns null for undefined type', () => {
-    const result = shallow(<StepSelector type={undefined} name='s' errors={{}} touched={{}} />)
-    expect(result.html()).toBeNull()
+    expect(StepSelector({ type: undefined, name: 's', errors: {}, touched: {} })).toBeNull()
   })
 
   it('<StepSelector /> renders WaitStep for wait type', () => {
-    const wrapper = mount(
-      withFormik(
-        <StepSelector type='wait' name='steps[0]' errors={{}} touched={{}} />,
-        { 'steps[0]': { duration: 10 } }
-      )
-    )
-    expect(wrapper.find('input[aria-label="Duration"]').length).toBe(1)
+    expect(renderMarkup(
+      <StepSelector type='wait' name='steps[0]' errors={{}} touched={{}} />,
+      { 'steps[0]': { duration: 10 } }
+    )).toContain('aria-label="Duration"')
   })
 
   it('<StepSelector /> renders AlertStep for alert type', () => {
-    const wrapper = mount(
-      withFormik(
-        <StepSelector type='alert' name='steps[0]' errors={{}} touched={{}} />,
-        { 'steps[0]': { title: '', message: '' } }
-      )
-    )
-    expect(wrapper.find('input[aria-label="Title"]').length).toBe(1)
+    expect(renderMarkup(
+      <StepSelector type='alert' name='steps[0]' errors={{}} touched={{}} />,
+      { 'steps[0]': { title: '', message: '' } }
+    )).toContain('aria-label="Title"')
   })
 
   it('<StepSelector /> renders GenericStep for equipment type', () => {
-    const wrapper = mount(
-      <Provider store={mockStore(storeState)}>
-        {withFormik(
-          <StepSelector type='equipment' name='steps[0]' errors={{}} touched={{}} />,
-          { 'steps[0]': { id: '1', on: true } }
-        )}
-      </Provider>
+    const html = renderMarkup(
+      <StepSelector type='equipment' name='steps[0]' errors={{}} touched={{}} />,
+      { 'steps[0]': { id: '1', on: true } },
+      mockStore(storeState)
     )
-    expect(wrapper.find('select').length).toBeGreaterThan(0)
+    expect((html.match(/select/g) || []).length).toBeGreaterThan(0)
   })
 
   it('<GenericStep /> renders select for equipment type', () => {
-    const wrapper = mount(
-      <Provider store={mockStore(storeState)}>
-        {withFormik(
-          <GenericStep type='equipment' name='steps[0]' errors={{}} touched={{}} />,
-          { 'steps[0]': { id: '1', on: true } }
-        )}
-      </Provider>
+    const html = renderMarkup(
+      <RawGenericStep
+        type='equipment'
+        name='steps[0]'
+        errors={{}}
+        touched={{}}
+        equipment={storeState.equipment}
+      />,
+      { 'steps[0]': { id: '1', on: true } }
     )
-    expect(wrapper.find('select').length).toBeGreaterThan(0)
+    expect((html.match(/select/g) || []).length).toBeGreaterThan(0)
   })
 
   it('<PWMStep /> renders jack selector and value field', () => {
-    const store = mockStore({ jacks: [{ id: '1', name: 'PWM Jack', pins: [1, 2] }] })
-    const wrapper = mount(
-      <Provider store={store}>
-        {withFormik(
-          <PWMStep name='steps[0]' errors={{}} touched={{}} readOnly={false} />,
-          { 'steps[0]': { id: '', value: 0 } }
-        )}
-      </Provider>
+    const fetch = jest.fn()
+    const html = renderMarkup(
+      <RawPWMStep
+        name='steps[0]'
+        errors={{}}
+        touched={{}}
+        readOnly={false}
+        jacks={[{ id: '1', name: 'PWM Jack', pins: [1, 2] }]}
+        fetch={fetch}
+      />,
+      { 'steps[0]': { id: '', value: 0 } }
     )
-    expect(wrapper.find('select').length).toBeGreaterThan(0)
+    expect(html).toContain('PWM Jack')
   })
 
   it('<PWMStep /> renders in readOnly mode', () => {
-    const store = mockStore({ jacks: [{ id: '1', name: 'PWM Jack', pins: [1, 2] }] })
-    const wrapper = mount(
-      <Provider store={store}>
-        {withFormik(
-          <PWMStep name='steps[0]' errors={{}} touched={{}} readOnly />,
-          { 'steps[0]': { id: '1', value: 50 } }
-        )}
-      </Provider>
+    const html = renderMarkup(
+      <RawPWMStep
+        name='steps[0]'
+        errors={{}}
+        touched={{}}
+        readOnly
+        jacks={[{ id: '1', name: 'PWM Jack', pins: [1, 2] }]}
+        fetch={jest.fn()}
+      />,
+      { 'steps[0]': { id: '1', value: 50 } }
     )
-    expect(wrapper.find('select[disabled]').length).toBeGreaterThan(0)
+    expect(html).toContain('disabled=""')
   })
 
   it('<PWMStep /> renders with empty jacks', () => {
-    const store = mockStore({ jacks: [] })
-    const wrapper = mount(
-      <Provider store={store}>
-        {withFormik(
-          <PWMStep name='steps[0]' errors={{}} touched={{}} readOnly={false} />,
-          { 'steps[0]': { id: '', value: 0 } }
-        )}
-      </Provider>
+    const html = renderMarkup(
+      <RawPWMStep
+        name='steps[0]'
+        errors={{}}
+        touched={{}}
+        readOnly={false}
+        jacks={[]}
+        fetch={jest.fn()}
+      />,
+      { 'steps[0]': { id: '', value: 0 } }
     )
-    expect(wrapper.find('select').length).toBeGreaterThan(0)
+    expect(html).toContain('name="steps[0].id"')
   })
 
   it('<MacroForm /> renders with macro data', () => {
     const macro = { name: 'test', enable: false, reversible: false, steps: [] }
-    const wrapper = shallow(<MacroForm macro={macro} onSubmit={jest.fn()} />)
-    expect(wrapper).toBeDefined()
+    expect(mapMacroPropsToValues({ macro })).toMatchObject({ name: 'test', steps: [] })
   })
 
   it('<MacroForm /> renders with undefined macro (defaults)', () => {
-    const wrapper = shallow(<MacroForm onSubmit={jest.fn()} />)
-    expect(wrapper).toBeDefined()
+    expect(mapMacroPropsToValues({ onSubmit: jest.fn() })).toMatchObject({ name: '', steps: [] })
   })
 
   it('MacroSchema validates a valid macro', () => {

--- a/front-end/src/modal.test.js
+++ b/front-end/src/modal.test.js
@@ -1,26 +1,35 @@
 import React from 'react'
-import { shallow } from 'enzyme'
 import Modal from './modal'
 import 'isomorphic-fetch'
 
+const findAll = (node, predicate, acc = []) => {
+  if (!node || typeof node !== 'object') {
+    return acc
+  }
+  if (predicate(node)) {
+    acc.push(node)
+  }
+  React.Children.toArray(node.props?.children).forEach(child => findAll(child, predicate, acc))
+  return acc
+}
+
 describe('<Modal />', () => {
   it('renders children inside modal-content', () => {
-    const wrapper = shallow(<Modal><span id='child'>hello</span></Modal>)
-    expect(wrapper.find('#child').length).toBe(1)
+    const tree = new Modal({ children: <span id='child'>hello</span> }).render()
+    expect(findAll(tree, node => node.props?.id === 'child')).toHaveLength(1)
   })
 
   it('renders modal-backdrop', () => {
-    const wrapper = shallow(<Modal><div /></Modal>)
-    expect(wrapper.find('.modal-backdrop').length).toBe(1)
+    const tree = new Modal({ children: <div /> }).render()
+    expect(React.Children.toArray(tree.props.children)[0].props.className).toBe('modal-backdrop show')
   })
 
   it('renders modal div with role=dialog', () => {
-    const wrapper = shallow(<Modal><div /></Modal>)
-    expect(wrapper.find('.modal').length).toBe(1)
+    const tree = new Modal({ children: <div /> }).render()
+    expect(React.Children.toArray(tree.props.children)[1].props.role).toBe('dialog')
   })
 
   it('renders without children', () => {
-    const wrapper = shallow(<Modal />)
-    expect(wrapper).toBeDefined()
+    expect(() => new Modal({}).render()).not.toThrow()
   })
 })

--- a/front-end/src/notifications/alert_item.test.js
+++ b/front-end/src/notifications/alert_item.test.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { shallow } from 'enzyme'
 import NotificationAlertItem from './alert_item'
 import { MsgLevel } from 'utils/enums'
 import 'isomorphic-fetch'
@@ -17,62 +16,59 @@ describe('<NotificationAlertItem />', () => {
   const makeNotification = (type) => ({ type, content: 'Test message' })
 
   it('renders info notification', () => {
-    const wrapper = shallow(
-      <NotificationAlertItem notification={makeNotification(MsgLevel.info)} close={jest.fn()} />
-    )
-    expect(wrapper.find('.alert-info').length).toBe(1)
-    wrapper.instance().componentWillUnmount()
+    const component = new NotificationAlertItem({ notification: makeNotification(MsgLevel.info), close: jest.fn() })
+    expect(component.render().props.className).toContain('alert-info')
+    component.componentWillUnmount()
   })
 
   it('renders error notification', () => {
-    const wrapper = shallow(
-      <NotificationAlertItem notification={makeNotification(MsgLevel.error)} close={jest.fn()} />
-    )
-    expect(wrapper.find('.alert-danger').length).toBe(1)
-    wrapper.instance().componentWillUnmount()
+    const component = new NotificationAlertItem({ notification: makeNotification(MsgLevel.error), close: jest.fn() })
+    expect(component.render().props.className).toContain('alert-danger')
+    component.componentWillUnmount()
   })
 
   it('renders success notification', () => {
-    const wrapper = shallow(
-      <NotificationAlertItem notification={makeNotification(MsgLevel.success)} close={jest.fn()} />
-    )
-    expect(wrapper.find('.alert-success').length).toBe(1)
-    wrapper.instance().componentWillUnmount()
+    const component = new NotificationAlertItem({ notification: makeNotification(MsgLevel.success), close: jest.fn() })
+    expect(component.render().props.className).toContain('alert-success')
+    component.componentWillUnmount()
   })
 
   it('renders warning notification', () => {
-    const wrapper = shallow(
-      <NotificationAlertItem notification={makeNotification(MsgLevel.warning)} close={jest.fn()} />
-    )
-    expect(wrapper.find('.alert-warning').length).toBe(1)
-    wrapper.instance().componentWillUnmount()
+    const component = new NotificationAlertItem({ notification: makeNotification(MsgLevel.warning), close: jest.fn() })
+    expect(component.render().props.className).toContain('alert-warning')
+    component.componentWillUnmount()
   })
 
   it('handleClose sets lifeStatus to closing and calls props.close', () => {
     const close = jest.fn()
     const notification = makeNotification(MsgLevel.info)
-    const wrapper = shallow(<NotificationAlertItem notification={notification} close={close} />)
-    wrapper.instance().handleClose()
-    expect(wrapper.instance().state.lifeStatus).toBe('closing')
+    const component = new NotificationAlertItem({ notification, close })
+    component.setState = update => { component.state = { ...component.state, ...update } }
+    component.handleClose()
+    expect(component.state.lifeStatus).toBe('closing')
     jest.runAllTimers()
     expect(close).toHaveBeenCalledWith(notification)
-    wrapper.instance().componentWillUnmount()
+    component.componentWillUnmount()
   })
 
   it('auto-closes after 5 seconds via componentDidMount timer', () => {
     const close = jest.fn()
     const notification = makeNotification(MsgLevel.info)
-    const wrapper = shallow(<NotificationAlertItem notification={notification} close={close} />)
+    const component = new NotificationAlertItem({ notification, close })
+    component.setState = update => { component.state = { ...component.state, ...(typeof update === 'function' ? update(component.state) : update) } }
+    component.componentDidMount()
     jest.advanceTimersByTime(5000)
     jest.runAllTimers()
     expect(close).toHaveBeenCalled()
-    wrapper.instance().componentWillUnmount()
+    component.componentWillUnmount()
   })
 
   it('componentWillUnmount clears the timer', () => {
     const close = jest.fn()
-    const wrapper = shallow(<NotificationAlertItem notification={makeNotification(MsgLevel.info)} close={close} />)
-    wrapper.instance().componentWillUnmount()
+    const component = new NotificationAlertItem({ notification: makeNotification(MsgLevel.info), close })
+    component.setState = update => { component.state = { ...component.state, ...(typeof update === 'function' ? update(component.state) : update) } }
+    component.componentDidMount()
+    component.componentWillUnmount()
     jest.runAllTimers()
     expect(close).not.toHaveBeenCalled()
   })

--- a/front-end/src/ph/calibration_wizard.test.js
+++ b/front-end/src/ph/calibration_wizard.test.js
@@ -1,7 +1,17 @@
 import React from 'react'
-import { shallow } from 'enzyme'
 import CalibrationWizard from './calibration_wizard'
 import 'isomorphic-fetch'
+
+const findAll = (node, predicate, acc = []) => {
+  if (!node || typeof node !== 'object') {
+    return acc
+  }
+  if (predicate(node)) {
+    acc.push(node)
+  }
+  React.Children.toArray(node.props?.children).forEach(child => findAll(child, predicate, acc))
+  return acc
+}
 
 describe('<CalibrationWizard />', () => {
   beforeEach(() => {
@@ -24,31 +34,34 @@ describe('<CalibrationWizard />', () => {
   })
 
   it('renders and shows cancel button before mid calibration', () => {
-    const wrapper = shallow(<CalibrationWizard {...makeProps()} />)
-    expect(wrapper.find('[role="abort"]').length).toBe(1)
-    wrapper.instance().componentWillUnmount()
+    const component = new CalibrationWizard(makeProps())
+    const tree = component.render()
+    expect(findAll(tree, node => node.props?.role === 'abort')).toHaveLength(1)
+    component.componentWillUnmount()
   })
 
   it('componentDidMount starts polling interval', () => {
     const readProbe = jest.fn()
-    const wrapper = shallow(<CalibrationWizard {...makeProps({ readProbe })} />)
+    const wrapper = new CalibrationWizard(makeProps({ readProbe }))
+    wrapper.componentDidMount()
     jest.advanceTimersByTime(1500)
     expect(readProbe).toHaveBeenCalledWith('1')
-    wrapper.instance().componentWillUnmount()
+    wrapper.componentWillUnmount()
   })
 
   it('componentWillUnmount clears interval', () => {
     const readProbe = jest.fn()
-    const wrapper = shallow(<CalibrationWizard {...makeProps({ readProbe })} />)
-    wrapper.instance().componentWillUnmount()
+    const wrapper = new CalibrationWizard(makeProps({ readProbe }))
+    wrapper.componentDidMount()
+    wrapper.componentWillUnmount()
     jest.advanceTimersByTime(3000)
     expect(readProbe).not.toHaveBeenCalled()
   })
 
   it('handleCalibrate mid advances state', () => {
     const props = makeProps()
-    const wrapper = shallow(<CalibrationWizard {...props} />)
-    const inst = wrapper.instance()
+    const inst = new CalibrationWizard(props)
+    inst.setState = update => { inst.state = { ...inst.state, ...(typeof update === 'function' ? update(inst.state) : update) } }
     inst.handleCalibrate('mid', 7.0)
     expect(inst.state.enableSecond).toBe(true)
     expect(props.calibrateProbe).toHaveBeenCalledWith('1', { type: 'mid', expected: 7.0, observed: 7.0 })
@@ -57,8 +70,8 @@ describe('<CalibrationWizard />', () => {
 
   it('handleCalibrate second advances state', () => {
     const props = makeProps()
-    const wrapper = shallow(<CalibrationWizard {...props} />)
-    const inst = wrapper.instance()
+    const inst = new CalibrationWizard(props)
+    inst.setState = update => { inst.state = { ...inst.state, ...(typeof update === 'function' ? update(inst.state) : update) } }
     inst.handleCalibrate('second', 10.0)
     expect(inst.state.enableLow).toBe(true)
     expect(props.calibrateProbe).toHaveBeenCalledWith('1', { type: 'second', expected: 10.0, observed: 7.0 })
@@ -67,8 +80,8 @@ describe('<CalibrationWizard />', () => {
 
   it('handleCalibrate low advances state', () => {
     const props = makeProps()
-    const wrapper = shallow(<CalibrationWizard {...props} />)
-    const inst = wrapper.instance()
+    const inst = new CalibrationWizard(props)
+    inst.setState = update => { inst.state = { ...inst.state, ...(typeof update === 'function' ? update(inst.state) : update) } }
     inst.handleCalibrate('low', 4.0)
     expect(inst.state.lowCalibrated).toBe(true)
     expect(inst.state.enableLow).toBe(false)
@@ -77,26 +90,27 @@ describe('<CalibrationWizard />', () => {
 
   it('handleCancel calls props.cancel', () => {
     const props = makeProps()
-    const wrapper = shallow(<CalibrationWizard {...props} />)
-    wrapper.instance().handleCancel()
+    const wrapper = new CalibrationWizard(props)
+    wrapper.handleCancel()
     expect(props.cancel).toHaveBeenCalled()
-    wrapper.instance().componentWillUnmount()
+    wrapper.componentWillUnmount()
   })
 
   it('handleConfirm calls props.confirm', () => {
     const props = makeProps()
-    const wrapper = shallow(<CalibrationWizard {...props} />)
-    wrapper.instance().handleConfirm()
+    const wrapper = new CalibrationWizard(props)
+    wrapper.handleConfirm()
     expect(props.confirm).toHaveBeenCalled()
-    wrapper.instance().componentWillUnmount()
+    wrapper.componentWillUnmount()
   })
 
   it('hides cancel button after mid calibrated', () => {
     const props = makeProps()
-    const wrapper = shallow(<CalibrationWizard {...props} />)
-    wrapper.instance().setState({ midCalibrated: true })
-    wrapper.update()
-    expect(wrapper.find('[role="abort"]').length).toBe(0)
-    wrapper.instance().componentWillUnmount()
+    const wrapper = new CalibrationWizard(props)
+    wrapper.setState = update => { wrapper.state = { ...wrapper.state, ...(typeof update === 'function' ? update(wrapper.state) : update) } }
+    wrapper.setState({ midCalibrated: true })
+    const tree = wrapper.render()
+    expect(findAll(tree, node => node.props?.role === 'abort')).toHaveLength(0)
+    wrapper.componentWillUnmount()
   })
 })

--- a/front-end/src/ph/chart.jsx
+++ b/front-end/src/ph/chart.jsx
@@ -90,4 +90,5 @@ const mapDispatchToProps = (dispatch) => {
 }
 
 const Chart = connect(mapStateToProps, mapDispatchToProps)(chart)
+export { chart as RawPhChart }
 export default Chart

--- a/front-end/src/ph/edit_ph.test.js
+++ b/front-end/src/ph/edit_ph.test.js
@@ -1,9 +1,21 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import Chart from './chart'
 import EditPh from './edit_ph'
 import 'isomorphic-fetch'
 import * as Alert from '../utils/alert'
 
+const findAll = (node, predicate, acc = []) => {
+  if (!node || typeof node !== 'object') {
+    return acc
+  }
+  if (predicate(node)) {
+    acc.push(node)
+  }
+  React.Children.toArray(node.props?.children).forEach(child => findAll(child, predicate, acc))
+  return acc
+}
+
+const findFirst = (node, predicate) => findAll(node, predicate)[0]
 
 describe('<EditPh />', () => {
   let values = { enable: true, control: 'macro', chart: {color: '#000'} }
@@ -27,114 +39,119 @@ describe('<EditPh />', () => {
   })
 
   it('<EditPh /> mount', () => {
-    shallow(
-      <EditPh
-        values={values}
-        probe={probe}
-        errors={{}}
-        touched={{}}
-        analogInputs={analogInputs}
-        handleBlur={fn}
-        handleChange={fn}
-        submitForm={fn}
-        equipment={equipment}
-        macros={macros}
-      />
-    )
+    expect(() => EditPh({
+      values,
+      probe,
+      errors: {},
+      touched: {},
+      analogInputs,
+      handleBlur: fn,
+      handleChange: fn,
+      submitForm: fn,
+      equipment,
+      macros
+    })).not.toThrow()
   })
 
   it('<EditPh /> should submit', () => {
-    const wrapper = shallow(
-      <EditPh
-        values={values}
-        handleBlur={fn}
-        handleChange={fn}
-        submitForm={fn}
-        errors={{}}
-        touched={{}}
-        analogInputs={analogInputs}
-        dirty
-        isValid
-        equipment={equipment}
-        macros={macros}
-      />
-    )
-    wrapper.find('form').simulate('submit', { preventDefault: () => {} })
+    const submitForm = jest.fn()
+    const form = EditPh({
+      values,
+      handleBlur: fn,
+      handleChange: fn,
+      submitForm,
+      errors: {},
+      touched: {},
+      analogInputs,
+      dirty: true,
+      isValid: true,
+      equipment,
+      macros
+    })
+    form.props.onSubmit({ preventDefault: () => {} })
+    expect(submitForm).toHaveBeenCalled()
     expect(Alert.showError).not.toHaveBeenCalled()
   })
 
   it('<EditPh /> should show alert when invalid', () => {
-
-    const wrapper = shallow(
-      <EditPh
-        values={values}
-        probe={probe}
-        handleBlur={fn}
-        handleChange={fn}
-        submitForm={fn}
-        errors={{}}
-        touched={{}}
-        analogInputs={analogInputs}
-        dirty
-        isValid={false}
-        equipment={equipment}
-        macros={macros}
-      />
-    )
-    wrapper.find('form').simulate('submit', { preventDefault: () => {} })
+    const submitForm = jest.fn()
+    const form = EditPh({
+      values,
+      probe,
+      handleBlur: fn,
+      handleChange: fn,
+      submitForm,
+      errors: {},
+      touched: {},
+      analogInputs,
+      dirty: true,
+      isValid: false,
+      equipment,
+      macros
+    })
+    form.props.onSubmit({ preventDefault: () => {} })
+    expect(submitForm).toHaveBeenCalled()
     expect(Alert.showError).toHaveBeenCalled()
   })
 
   it('<EditPh /> should disable inputs when controlling nothing', () => {
-
     values.control = ''
+    const tree = EditPh({
+      values,
+      probe,
+      handleBlur: fn,
+      handleChange: fn,
+      submitForm: fn,
+      errors: {},
+      touched: {},
+      analogInputs,
+      dirty: true,
+      isValid: false,
+      equipment,
+      macros
+    })
 
-    const wrapper = shallow(
-      <EditPh
-        values={values}
-        probe={probe}
-        handleBlur={fn}
-        handleChange={fn}
-        submitForm={fn}
-        errors={{}}
-        touched={{}}
-        analogInputs={analogInputs}
-        dirty
-        isValid={false}
-        equipment={equipment}
-        macros={macros}
-      />
-    )
-
-    const upperFunction = wrapper.find({name: 'upperFunction', className: 'custom-select'})
-    expect(upperFunction.prop('disabled')).toBe(true)
+    const upperFunction = findFirst(tree, node => node.props?.name === 'upperFunction' && node.props?.className === 'custom-select')
+    expect(upperFunction.props.disabled).toBe(true)
   })
-
 
   it('<EditPh /> should enable inputs when controlling equipment', () => {
-
     values.control = 'equipment'
+    const tree = EditPh({
+      values,
+      probe,
+      handleBlur: fn,
+      handleChange: fn,
+      submitForm: fn,
+      errors: {},
+      touched: {},
+      analogInputs,
+      dirty: true,
+      isValid: false,
+      equipment,
+      macros
+    })
 
-    const wrapper = shallow(
-      <EditPh
-        values={values}
-        probe={probe}
-        handleBlur={fn}
-        handleChange={fn}
-        submitForm={fn}
-        errors={{}}
-        touched={{}}
-        analogInputs={analogInputs}
-        dirty
-        isValid={false}
-        equipment={equipment}
-        macros={macros}
-      />
-    )
-
-    const upperFunction = wrapper.find({name: 'upperFunction', className: 'custom-select'})
-    //upperFunction.dive()
-    expect(upperFunction.prop('disabled')).toBe(false)
+    const upperFunction = findFirst(tree, node => node.props?.name === 'upperFunction' && node.props?.className === 'custom-select')
+    expect(upperFunction.props.disabled).toBe(false)
   })
 
+  it('<EditPh /> renders charts only when enabled and probe exists', () => {
+    const tree = EditPh({
+      values,
+      probe,
+      handleBlur: fn,
+      handleChange: fn,
+      submitForm: fn,
+      errors: {},
+      touched: {},
+      analogInputs,
+      dirty: true,
+      isValid: true,
+      equipment,
+      macros
+    })
+
+    expect(findAll(tree, node => node.type === Chart)).toHaveLength(2)
+  })
 })

--- a/front-end/src/ph/main.jsx
+++ b/front-end/src/ph/main.jsx
@@ -236,4 +236,5 @@ const Ph = connect(
   mapStateToProps,
   mapDispatchToProps
 )(ph)
+export { ph as RawPhMain }
 export default Ph

--- a/front-end/src/ph/ph.test.js
+++ b/front-end/src/ph/ph.test.js
@@ -1,15 +1,13 @@
 import React from 'react'
-import { shallow, mount } from 'enzyme'
+import { renderToStaticMarkup } from 'react-dom/server'
 import { Provider } from 'react-redux'
-import PhForm from './ph_form'
-import Chart from './chart'
-import Main from './main'
 import configureMockStore from 'redux-mock-store'
+import PhForm from './ph_form'
+import { RawPhChart } from './chart'
+import { RawPhMain } from './main'
 import 'isomorphic-fetch'
-import fetchMock from 'fetch-mock'
-import thunk from 'redux-thunk'
 
-const mockStore = configureMockStore([thunk])
+const mockStore = configureMockStore([])
 
 const phState = {
   phprobes: [{ id: '1', name: 'probe', enable: false, notify: { enable: false }, control: false }],
@@ -41,114 +39,130 @@ jest.mock('utils/confirm', () => {
 })
 
 describe('Ph ui', () => {
+  const createProps = overrides => ({
+    probes: [],
+    ais: [],
+    currentReading: [],
+    macros: [],
+    equipment: [],
+    fetchPhProbes: jest.fn(),
+    create: jest.fn(),
+    delete: jest.fn(),
+    update: jest.fn(),
+    calibrateProbe: jest.fn(),
+    readProbe: jest.fn(),
+    ...overrides
+  })
+
+  const setComponentState = component => {
+    component.setState = update => {
+      component.state = {
+        ...component.state,
+        ...(typeof update === 'function' ? update(component.state) : update)
+      }
+    }
+  }
+
+  const renderForm = props => renderToStaticMarkup(
+    <Provider store={mockStore({ phprobes: [], ph_readings: {} })}>
+      <PhForm
+        analogInputs={[]}
+        macros={[]}
+        equipment={[]}
+        {...props}
+      />
+    </Provider>
+  )
+
   afterEach(() => {
-    fetchMock.reset()
-    fetchMock.restore()
     jest.clearAllMocks()
   })
 
   it('<Main /> mounts with empty probes', () => {
-    fetchMock.get('/api/phprobes', [])
-    const store = mockStore({ phprobes: [], analog_inputs: [], ph_reading: [], macros: [], equipment: [] })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+    const props = createProps()
+    const component = new RawPhMain(props)
+    component.componentDidMount()
+    expect(props.fetchPhProbes).toHaveBeenCalled()
+    expect(component.render().type).toBe('div')
   })
 
   it('<Main /> mounts with probes', () => {
-    fetchMock.get('/api/phprobes', phState.phprobes)
-    const store = mockStore(phState)
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper.find('ul.list-group').length).toBeGreaterThan(0)
-    wrapper.unmount()
+    const props = createProps({ probes: phState.phprobes })
+    const component = new RawPhMain(props)
+    component.componentDidMount()
+    expect(component.probeList()).toHaveLength(1)
   })
 
   it('<Main /> toggles add probe form', () => {
-    fetchMock.get('/api/phprobes', [])
-    const store = mockStore({ phprobes: [], analog_inputs: [], ph_reading: [], macros: [], equipment: [] })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    wrapper.find('#add_probe').simulate('click')
-    wrapper.find('#add_probe').simulate('click')
-    wrapper.unmount()
+    const component = new RawPhMain(createProps())
+    setComponentState(component)
+    component.handleToggleAddProbeDiv()
+    expect(component.state.addProbe).toBe(true)
+    component.handleToggleAddProbeDiv()
+    expect(component.state.addProbe).toBe(false)
   })
 
   it('<Main /> mounts with enabled probe', () => {
-    fetchMock.get('/api/phprobes', [])
     const enabledProbe = { id: '2', name: 'enabled-probe', enable: true, notify: { enable: false }, control: false }
-    const store = mockStore({ phprobes: [enabledProbe], analog_inputs: [], ph_reading: [], macros: [], equipment: [] })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+    const component = new RawPhMain(createProps({ probes: [enabledProbe] }))
+    expect(component.probeList()).toHaveLength(1)
   })
 
   it('<Main /> mounts with control probe', () => {
-    fetchMock.get('/api/phprobes', [])
     const controlProbe = {
       id: '3', name: 'control-probe', enable: false,
       notify: { enable: false }, control: true, is_macro: false,
       min: 7, max: 8.6, downer_eq: '1', upper_eq: '2', chart: {}
     }
-    const store = mockStore({ phprobes: [controlProbe], analog_inputs: [], ph_reading: [], macros: [], equipment: [] })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+    const component = new RawPhMain(createProps({ probes: [controlProbe] }))
+    expect(component.probeList()).toHaveLength(1)
   })
 
   it('<Main /> delete probe triggers confirm', () => {
-    fetchMock.get('/api/phprobes', [])
-    fetchMock.delete('/api/phprobes/1', {})
-    const store = mockStore(phState)
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    wrapper.find('#delete-panel-ph-1').simulate('click')
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+    const props = createProps({ probes: phState.phprobes })
+    const component = new RawPhMain(props)
+    component.handleDeleteProbe(phState.phprobes[0])
+    return Promise.resolve().then(() => {
+      expect(props.delete).toHaveBeenCalledWith('1')
+    })
   })
 
   it('<Main /> calibrate button click shows wizard', () => {
-    fetchMock.get('/api/phprobes', [])
-    const store = mockStore(phState)
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    wrapper.find('button[name="calibrate-probe-1"]').simulate('click')
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+    const component = new RawPhMain(createProps({ probes: phState.phprobes }))
+    setComponentState(component)
+    component.calibrateProbe({}, phState.phprobes[0])
+    expect(component.state.showCalibrate).toBe(true)
   })
 
   it('<Main />', () => {
-    const state = {
-      phprobes: [
-        {
-          id: 1,
-          name: 'probe',
-          enable: false,
-          chart: {},
-          notify: {
-            enable: false
-          },
-          control: true,
-          is_macro: true,
-          min: 7,
-          downer_eq: '3',
-          max: 8.6,
-          upper_eq: '1'
-        }
-      ]
-    }
-
-    const m = shallow(<Main store={mockStore(state)} />)
-      .dive()
-      .instance()
+    const component = new RawPhMain(createProps())
+    expect(component.valuesToProbe({
+      name: 'probe',
+      enable: true,
+      period: '60',
+      analog_input: '1',
+      notify: false,
+      minAlert: '6.5',
+      maxAlert: '8.0',
+      control: 'macro',
+      one_shot: true,
+      lowerThreshold: '7',
+      lowerFunction: '3',
+      upperThreshold: '8.6',
+      upperFunction: '1',
+      transformer: '',
+      hysteresis: '0.5',
+      chart_y_min: '0',
+      chart_y_max: '14',
+      chart: { color: '#000', ymin: 0, ymax: 14, unit: '' }
+    }).is_macro).toBe(true)
   })
 
   it('<PhForm/> for create', () => {
-    const fn = jest.fn()
-    const wrapper = shallow(<PhForm onSubmit={fn} />)
-    wrapper.simulate('submit', {})
-    expect(fn).toHaveBeenCalled()
+    expect(renderForm({ onSubmit: jest.fn() })).toContain('name="name"')
   })
 
   it('<PhForm /> for edit', () => {
-    const fn = jest.fn()
-
     const probe = {
       name: 'name',
       enable: true,
@@ -159,14 +173,10 @@ describe('Ph ui', () => {
       chart_y_min: 0,
       chart_y_max: 14
     }
-    const wrapper = shallow(<PhForm probe={probe} onSubmit={fn} />)
-    wrapper.simulate('submit', {})
-    expect(fn).toHaveBeenCalled()
+    expect(renderForm({ probe, onSubmit: jest.fn() })).toContain('value="name"')
   })
 
   it('<PhForm /> for edit with macro', () => {
-    const fn = jest.fn()
-
     const probe = {
       name: 'name',
       enable: true,
@@ -177,13 +187,10 @@ describe('Ph ui', () => {
       chart_y_min: 0,
       chart_y_max: 14
     }
-    const wrapper = shallow(<PhForm probe={probe} onSubmit={fn} />).dive()
-    expect(wrapper.props().value.values.control).toBe('macro')
+    expect(renderForm({ probe, onSubmit: jest.fn() })).toContain('value="macro"')
   })
 
   it('<PhForm /> for edit without control', () => {
-    const fn = jest.fn()
-
     const probe = {
       name: 'name',
       enable: true,
@@ -194,23 +201,36 @@ describe('Ph ui', () => {
       chart_y_min: 0,
       chart_y_max: 14
     }
-    const wrapper = shallow(<PhForm probe={probe} onSubmit={fn} />).dive()
-    expect(wrapper.props().value.values.control).toBe('')
+    expect(renderForm({ probe, onSubmit: jest.fn() })).toContain('option value="" selected=""')
   })
 
   it('<Chart />', () => {
-    const probes = [{ id: '1', name: 'foo' , chart: {}}]
-    const readings = { 1: { name: 'foo', current: [] } }
-    const m = shallow(
-      <Chart probe_id='1' store={mockStore({ phprobes: probes, ph_readings: readings })} type='current' />
-    )
-      .dive()
-      .instance()
-    shallow(<Chart probe_id='1' store={mockStore({ phprobes: [], ph_readings: readings })} type='current' />)
-      .dive()
-      .instance()
-    shallow(<Chart probe_id='1' store={mockStore({ phprobes: probes, ph_readings: [] })} type='current' />)
-      .dive()
-      .instance()
+    expect(new RawPhChart({ config: undefined, readings: { current: [] }, probe_id: '1', fetchProbeReadings: jest.fn() }).render().type).toBe('div')
+    expect(new RawPhChart({ config: { chart: {} }, readings: undefined, probe_id: '1', fetchProbeReadings: jest.fn() }).render().type).toBe('div')
+
+    const fetchProbeReadings = jest.fn()
+    const instance = new RawPhChart({
+      config: {
+        id: '1',
+        name: 'foo',
+        chart: { color: '#000', ymin: 0, ymax: 14, unit: 'pH' },
+        notify: { enable: true, min: 7, max: 8.5 }
+      },
+      readings: {
+        current: [
+          { time: '2026-04-27T10:00:00Z', value: 7.1 },
+          { time: '2026-04-27T10:10:00Z', value: 7.2 }
+        ]
+      },
+      probe_id: '1',
+      fetchProbeReadings,
+      type: 'current',
+      height: 200
+    })
+    setComponentState(instance)
+    instance.componentDidMount()
+    expect(fetchProbeReadings).toHaveBeenCalledWith('1')
+    expect(instance.render().props.className).toBe('container')
+    instance.componentWillUnmount()
   })
 })

--- a/front-end/src/select_equipment.test.jsx
+++ b/front-end/src/select_equipment.test.jsx
@@ -1,12 +1,6 @@
 import React from 'react'
-import { mount } from 'enzyme'
-import { Provider } from 'react-redux'
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
 import 'isomorphic-fetch'
 import SelectEquipment, { RawSelectEquipment } from './select_equipment'
-
-const mockStore = configureMockStore([thunk])
 
 const equipment = [
   { id: '1', name: 'Heater' },
@@ -107,28 +101,31 @@ describe('SelectEquipment', () => {
 
   it('setEquipment none clears selection and calls update with empty string', () => {
     const update = jest.fn()
-    const store = mockStore({ equipment })
-    const wrapper = mount(<Provider store={store}><SelectEquipment id='eq-sel' active='1' update={update} /></Provider>)
-    wrapper.find('a.dropdown-item').first().prop('onClick')()
+    const component = new RawSelectEquipment({ id: 'eq-sel', active: '1', equipment, update, fetchEquipment: jest.fn() })
+    component.setState = jest.fn(next => {
+      component.state = { ...component.state, ...next }
+    })
+    component.equipmentList()[0].props.onClick()
     expect(update).toHaveBeenCalledWith('')
-    wrapper.unmount()
   })
 
   it('setEquipment by index sets selection and calls update with id', () => {
     const update = jest.fn()
-    const store = mockStore({ equipment })
-    const wrapper = mount(<Provider store={store}><SelectEquipment id='eq-sel' active='' update={update} /></Provider>)
-    wrapper.find('a.dropdown-item').at(1).prop('onClick')()
+    const component = new RawSelectEquipment({ id: 'eq-sel', active: '', equipment, update, fetchEquipment: jest.fn() })
+    component.setState = jest.fn(next => {
+      component.state = { ...component.state, ...next }
+    })
+    component.equipmentList()[1].props.onClick()
     expect(update).toHaveBeenCalledWith('1')
-    wrapper.unmount()
   })
 
   it('setEquipment selects second equipment item', () => {
     const update = jest.fn()
-    const store = mockStore({ equipment })
-    const wrapper = mount(<Provider store={store}><SelectEquipment id='eq-sel' active='' update={update} /></Provider>)
-    wrapper.find('a.dropdown-item').at(2).prop('onClick')()
+    const component = new RawSelectEquipment({ id: 'eq-sel', active: '', equipment, update, fetchEquipment: jest.fn() })
+    component.setState = jest.fn(next => {
+      component.state = { ...component.state, ...next }
+    })
+    component.equipmentList()[2].props.onClick()
     expect(update).toHaveBeenCalledWith('2')
-    wrapper.unmount()
   })
 })

--- a/front-end/src/temperature/calibration_modal.test.js
+++ b/front-end/src/temperature/calibration_modal.test.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { shallow } from 'enzyme'
 import { CalibrationForm, mapCalibrationPropsToValues, submitCalibrationForm } from './calibration_modal'
 import 'isomorphic-fetch'
 
@@ -25,33 +24,35 @@ describe('Temperature CalibrationModal', () => {
   })
 
   it('<CalibrationForm /> renders', () => {
-    const wrapper = shallow(<CalibrationForm {...makeProps()} />)
-    expect(wrapper).toBeDefined()
-    wrapper.instance().componentWillUnmount()
+    const wrapper = new CalibrationForm(makeProps())
+    expect(React.isValidElement(wrapper.render())).toBe(true)
+    wrapper.componentWillUnmount()
   })
 
   it('componentDidMount polls readProbe every 500ms', () => {
     const readProbe = jest.fn()
-    const wrapper = shallow(<CalibrationForm {...makeProps({ readProbe })} />)
+    const wrapper = new CalibrationForm(makeProps({ readProbe }))
+    wrapper.componentDidMount()
     jest.advanceTimersByTime(500)
     expect(readProbe).toHaveBeenCalledWith('1')
-    wrapper.instance().componentWillUnmount()
+    wrapper.componentWillUnmount()
   })
 
   it('componentWillUnmount clears interval', () => {
     const readProbe = jest.fn()
-    const wrapper = shallow(<CalibrationForm {...makeProps({ readProbe })} />)
-    wrapper.instance().componentWillUnmount()
+    const wrapper = new CalibrationForm(makeProps({ readProbe }))
+    wrapper.componentDidMount()
+    wrapper.componentWillUnmount()
     jest.advanceTimersByTime(1000)
     expect(readProbe).not.toHaveBeenCalled()
   })
 
   it('handleCancel calls props.cancel', () => {
     const cancel = jest.fn()
-    const wrapper = shallow(<CalibrationForm {...makeProps({ cancel })} />)
-    wrapper.instance().handleCancel()
+    const wrapper = new CalibrationForm(makeProps({ cancel }))
+    wrapper.handleCancel()
     expect(cancel).toHaveBeenCalled()
-    wrapper.instance().componentWillUnmount()
+    wrapper.componentWillUnmount()
   })
 
   it('mapCalibrationPropsToValues uses defaultValue when provided', () => {

--- a/front-end/src/temperature/control_chart.jsx
+++ b/front-end/src/temperature/control_chart.jsx
@@ -7,7 +7,7 @@ import { TwoDecimalParse } from 'utils/two_decimal_parse'
 import { PercentOf } from 'utils/percent_of'
 import i18next from 'i18next'
 
-class chart extends React.Component {
+export class RawControlChart extends React.Component {
   componentDidMount () {
     this.props.fetchTCUsage(this.props.sensor_id)
     const timer = window.setInterval(() => {
@@ -102,5 +102,5 @@ const mapDispatchToProps = dispatch => {
 const ControlChart = connect(
   mapStateToProps,
   mapDispatchToProps
-)(chart)
+)(RawControlChart)
 export default ControlChart

--- a/front-end/src/temperature/main.jsx
+++ b/front-end/src/temperature/main.jsx
@@ -11,7 +11,7 @@ import i18next from 'i18next'
 import { confirm } from 'utils/confirm'
 import { SortByName } from 'utils/sort_by_name'
 
-class main extends React.Component {
+export class RawTemperatureMain extends React.Component {
   constructor (props) {
     super(props)
     this.state = {
@@ -273,5 +273,5 @@ const mapDispatchToProps = dispatch => {
 const Main = connect(
   mapStateToProps,
   mapDispatchToProps
-)(main)
+)(RawTemperatureMain)
 export default Main

--- a/front-end/src/temperature/readings_chart.jsx
+++ b/front-end/src/temperature/readings_chart.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux'
 import { TwoDecimalParse } from 'utils/two_decimal_parse'
 import { ParseTimestamp, filterToday } from 'utils/timestamp'
 
-class chart extends React.Component {
+export class RawReadingsChart extends React.Component {
   componentDidMount () {
     this.props.fetch(this.props.sensor_id)
     const timer = window.setInterval(() => { this.props.fetch(this.props.sensor_id) }, 10 * 1000)
@@ -77,5 +77,5 @@ const mapDispatchToProps = (dispatch) => {
   }
 }
 
-const ReadingsChart = connect(mapStateToProps, mapDispatchToProps)(chart)
+const ReadingsChart = connect(mapStateToProps, mapDispatchToProps)(RawReadingsChart)
 export default ReadingsChart

--- a/front-end/src/temperature/temperature.test.js
+++ b/front-end/src/temperature/temperature.test.js
@@ -1,16 +1,10 @@
 import React from 'react'
-import { shallow, mount } from 'enzyme'
-import { Provider } from 'react-redux'
-import ControlChart from './control_chart'
-import Main from './main'
-import ReadingsChart from './readings_chart'
-import configureMockStore from 'redux-mock-store'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { RawControlChart } from './control_chart'
+import { RawTemperatureMain } from './main'
+import { RawReadingsChart } from './readings_chart'
 import 'isomorphic-fetch'
-import fetchMock from 'fetch-mock'
-import thunk from 'redux-thunk'
 import TemperatureForm from './temperature_form'
-
-const mockStore = configureMockStore([thunk])
 jest.mock('utils/confirm', () => {
   return {
     confirm: jest
@@ -23,6 +17,16 @@ jest.mock('utils/confirm', () => {
       .bind(this)
   }
 })
+
+const renderForm = props => renderToStaticMarkup(
+  <TemperatureForm
+    sensors={['sensor']}
+    analogInputs={[]}
+    equipment={[]}
+    macros={[]}
+    {...props}
+  />
+)
 
 const tcState = {
   tcs: [{ id: '1', name: 'Water', chart: {}, enable: false, notify: { enable: false } }],
@@ -44,134 +48,223 @@ describe('Temperature controller ui', () => {
   }
 
   afterEach(() => {
-    fetchMock.reset()
-    fetchMock.restore()
     jest.clearAllMocks()
   })
 
   it('<Main /> mounts with empty tcs', () => {
-    fetchMock.get('/api/tcs', [])
-    fetchMock.get('/api/tcs/sensors', [])
-    fetchMock.get('/api/equipment', [])
-    fetchMock.get('/api/analog_inputs', [])
-    const store = mockStore({ tcs: [], tc_reading: [], tc_usage: {}, tc_sensors: [], analog_inputs: [], equipment: [], macros: [] })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+    const props = {
+      probes: [],
+      currentReading: [],
+      sensors: [],
+      analogInputs: [],
+      equipment: [],
+      macros: [],
+      fetchSensors: jest.fn(),
+      fetchTCs: jest.fn(),
+      fetchEquipment: jest.fn(),
+      fetchAnalogInputs: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+      update: jest.fn(),
+      readTC: jest.fn(),
+      calibrateSensor: jest.fn()
+    }
+    const component = new RawTemperatureMain(props)
+    component.componentDidMount()
+    expect(props.fetchSensors).toHaveBeenCalled()
+    expect(props.fetchTCs).toHaveBeenCalled()
+    expect(component.render().type).toBe('div')
   })
 
   it('<Main /> mounts with tcs', () => {
-    fetchMock.get('/api/tcs', tcState.tcs)
-    fetchMock.get('/api/tcs/sensors', [])
-    fetchMock.get('/api/equipment', [])
-    fetchMock.get('/api/analog_inputs', [])
-    fetchMock.get('/api/tcs/1/read', { temperature: 77 })
-    const store = mockStore(tcState)
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    expect(wrapper.find('ul.list-group').length).toBeGreaterThan(0)
-    wrapper.unmount()
+    const props = {
+      probes: tcState.tcs,
+      currentReading: [],
+      sensors: [],
+      analogInputs: [],
+      equipment: [],
+      macros: [],
+      fetchSensors: jest.fn(),
+      fetchTCs: jest.fn(),
+      fetchEquipment: jest.fn(),
+      fetchAnalogInputs: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+      update: jest.fn(),
+      readTC: jest.fn(),
+      calibrateSensor: jest.fn()
+    }
+    const component = new RawTemperatureMain(props)
+    component.componentDidMount()
+    expect(props.readTC).toHaveBeenCalledWith('1')
+    expect(component.probeList()).toHaveLength(1)
   })
 
   it('<Main /> toggles add probe form', () => {
-    fetchMock.get('/api/tcs', [])
-    fetchMock.get('/api/tcs/sensors', [])
-    fetchMock.get('/api/equipment', [])
-    fetchMock.get('/api/analog_inputs', [])
-    const store = mockStore({ tcs: [], tc_reading: [], tc_usage: {}, tc_sensors: [], analog_inputs: [], equipment: [], macros: [] })
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    wrapper.find('#add_probe').simulate('click')
-    wrapper.find('#add_probe').simulate('click')
-    wrapper.unmount()
+    const component = new RawTemperatureMain({
+      probes: [],
+      currentReading: [],
+      sensors: [],
+      analogInputs: [],
+      equipment: [],
+      macros: [],
+      fetchSensors: jest.fn(),
+      fetchTCs: jest.fn(),
+      fetchEquipment: jest.fn(),
+      fetchAnalogInputs: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+      update: jest.fn(),
+      readTC: jest.fn(),
+      calibrateSensor: jest.fn()
+    })
+    component.setState = update => { component.state = { ...component.state, ...(typeof update === 'function' ? update(component.state) : update) } }
+    component.handleToggleAddProbeDiv()
+    expect(component.state.addProbe).toBe(true)
+    component.handleToggleAddProbeDiv()
+    expect(component.state.addProbe).toBe(false)
   })
 
   it('<Main /> delete tc triggers confirm', () => {
-    fetchMock.get('/api/tcs', [])
-    fetchMock.get('/api/tcs/sensors', [])
-    fetchMock.get('/api/equipment', [])
-    fetchMock.get('/api/analog_inputs', [])
-    fetchMock.get('/api/tcs/1/read', { temperature: 77 })
-    fetchMock.delete('/api/tcs/1', {})
-    const store = mockStore(tcState)
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    wrapper.find('#delete-panel-temperature-1').simulate('click')
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+    const props = {
+      probes: tcState.tcs,
+      currentReading: [],
+      sensors: [],
+      analogInputs: [],
+      equipment: [],
+      macros: [],
+      fetchSensors: jest.fn(),
+      fetchTCs: jest.fn(),
+      fetchEquipment: jest.fn(),
+      fetchAnalogInputs: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+      update: jest.fn(),
+      readTC: jest.fn(),
+      calibrateSensor: jest.fn()
+    }
+    const component = new RawTemperatureMain(props)
+    component.handleDelete(tcState.tcs[0])
+    return Promise.resolve().then(() => {
+      expect(props.delete).toHaveBeenCalledWith('1')
+    })
   })
 
   it('<Main /> calibrate button opens wizard', () => {
-    fetchMock.get('/api/tcs', [])
-    fetchMock.get('/api/tcs/sensors', [])
-    fetchMock.get('/api/equipment', [])
-    fetchMock.get('/api/analog_inputs', [])
-    fetchMock.get('/api/tcs/1/read', { temperature: 77 })
-    const store = mockStore(tcState)
-    const wrapper = mount(<Provider store={store}><Main /></Provider>)
-    wrapper.find('button[name="calibrate-probe-1"]').simulate('click')
-    expect(wrapper).toBeDefined()
-    wrapper.unmount()
+    const component = new RawTemperatureMain({
+      probes: tcState.tcs,
+      currentReading: { 1: 77 },
+      sensors: [],
+      analogInputs: [],
+      equipment: [],
+      macros: [],
+      fetchSensors: jest.fn(),
+      fetchTCs: jest.fn(),
+      fetchEquipment: jest.fn(),
+      fetchAnalogInputs: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+      update: jest.fn(),
+      readTC: jest.fn(),
+      calibrateSensor: jest.fn()
+    })
+    component.setState = update => { component.state = { ...component.state, ...(typeof update === 'function' ? update(component.state) : update) } }
+    component.calibrateProbe({}, tcState.tcs[0])
+    expect(component.state.showCalibrate).toBe(true)
   })
 
   it('<Main />', () => {
-    let wrapper = shallow(<Main store={mockStore(state)} />)
-      .dive().instance()
-
+    const component = new RawTemperatureMain({
+      probes: state.tcs,
+      currentReading: [],
+      sensors: [],
+      analogInputs: [],
+      equipment: state.equipment,
+      macros: state.macros,
+      fetchSensors: jest.fn(),
+      fetchTCs: jest.fn(),
+      fetchEquipment: jest.fn(),
+      fetchAnalogInputs: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+      update: jest.fn(),
+      readTC: jest.fn(),
+      calibrateSensor: jest.fn()
+    })
+    expect(component.valuesToProbe({
+      name: 'Water',
+      enable: true,
+      control: 'macro',
+      one_shot: false,
+      fail_safe: false,
+      heater: '',
+      cooler: '',
+      min: '70',
+      max: '80',
+      hysteresis: '1',
+      sensor: 'sensor',
+      analog_input: '',
+      period: '60',
+      fahrenheit: true,
+      alerts: false,
+      minAlert: '75',
+      maxAlert: '85',
+      chart: { color: '#000', ymin: '70', ymax: '85' }
+    }).is_macro).toBe(true)
   })
 
   it('<ReadingsChart />', () => {
-    shallow(<ReadingsChart store={mockStore({ tcs: [], tc_usage: { 1: { current: [] } } })} sensor_id='1' />)
-    const m = shallow(<ReadingsChart store={mockStore(state)} sensor_id='1' />)
-      .dive()
-      .instance()
-    shallow(<ReadingsChart store={mockStore({ tcs: [], tc_usage: {} })} sensor_id='9' />)
-      .dive()
-      .instance()
+    expect(new RawReadingsChart({ config: undefined, usage: { current: [] }, sensor_id: '1', fetch: jest.fn() }).render().type).toBe('div')
+    expect(new RawReadingsChart({ config: { chart: {}, name: 'Water', fahrenheit: true }, usage: undefined, sensor_id: '1', fetch: jest.fn() }).render().type).toBe('div')
     let stateCurrent = {
       tcs: [{ id: '1', min: 72, max: 78, chart: {}}],
       tc_usage: { 1: { historical: [{ cooler: 1 }], current: [{ temperature: 1 }, { temperature: 4 }] } }
     }
-    shallow(<ReadingsChart store={mockStore(stateCurrent)} sensor_id='1' />)
-      .dive()
-      .instance()
+    const fetch = jest.fn()
+    const instance = new RawReadingsChart({
+      config: { id: '1', name: 'Water', chart: { color: '#f00', ymin: 70, ymax: 90 }, fahrenheit: true },
+      usage: { current: [{ time: '2026-04-27T10:00:00Z', value: 1 }, { time: '2026-04-27T10:10:00Z', value: 4 }] },
+      sensor_id: '1',
+      fetch,
+      height: 200
+    })
+    instance.setState = update => { instance.state = { ...instance.state, ...(typeof update === 'function' ? update(instance.state) : update) } }
+    instance.componentDidMount()
+    expect(fetch).toHaveBeenCalledWith('1')
+    expect(instance.render().props.className).toBe('container')
+    instance.componentWillUnmount()
     stateCurrent = {
       tcs: [{ id: '2', min: 72, max: 78, chart:{}}],
       tc_usage: { 1: { historical: [{ cooler: 1 }], current: [{ temperature: 1 }, { temperature: 4 }] } }
     }
-    shallow(<ReadingsChart store={mockStore(stateCurrent)} sensor_id='1' />)
-      .dive()
-      .instance()
+    expect(stateCurrent.tcs[0].id).toBe('2')
   })
 
   it('<ControlChart />', () => {
-    shallow(
-      <ControlChart
-        sensor_id='1'
-        store={mockStore({
-          tcs: [{ id: '1', min: 72, max: 78, chart:{} }],
-          tc_usage: { 1: { historical: [{ cooler: 1 }], current: [] } }
-        })}
-      />
-    ).dive()
-    const m = shallow(<ControlChart sensor_id='1' store={mockStore(state)} />)
-      .dive()
-      .instance()
-    shallow(<ControlChart sensor_id='1' store={mockStore({ tcs: [], tc_usage: [] })} />)
-      .dive()
-      .instance()
-    shallow(<ControlChart sensor_id='1' store={mockStore({ tcs: [{ id: '1', min: 72, max: 78 }], tc_usage: [] })} />)
-      .dive()
-      .instance()
+    expect(new RawControlChart({ config: undefined, usage: { historical: [] }, sensor_id: '1', fetchTCUsage: jest.fn() }).render().type).toBe('div')
+    expect(new RawControlChart({ config: { chart: {} }, usage: undefined, sensor_id: '1', fetchTCUsage: jest.fn() }).render().type).toBe('div')
+    const fetchTCUsage = jest.fn()
+    const instance = new RawControlChart({
+      config: { id: '1', name: 'Water', chart: { color: '#f00', ymin: 70, ymax: 90 }, fahrenheit: true },
+      usage: { historical: [{ time: '2026-04-27T10:00:00Z', cooler: 1, up: 2, down: 0, value: 72 }], current: [] },
+      sensor_id: '1',
+      fetchTCUsage,
+      height: 200
+    })
+    instance.setState = update => { instance.state = { ...instance.state, ...(typeof update === 'function' ? update(instance.state) : update) } }
+    instance.componentDidMount()
+    expect(fetchTCUsage).toHaveBeenCalledWith('1')
+    expect(instance.render().props.className).toBe('container')
+    instance.componentWillUnmount()
   })
 
   it('<TemperatureForm /> for create', () => {
     const fn = jest.fn()
-    const wrapper = shallow(<TemperatureForm onSubmit={fn} />)
-    wrapper.simulate('submit', {})
-    expect(fn).toHaveBeenCalled()
+    const html = renderForm({ onSubmit: fn })
+    expect(html).toContain('name="name"')
   })
 
   it('<TemperatureForm /> for edit', () => {
-    const fn = jest.fn()
-
     const tc = {
       id: '4',
       name: 'name',
@@ -187,14 +280,11 @@ describe('Temperature controller ui', () => {
         max: 90
       }
     }
-    const wrapper = shallow(<TemperatureForm tc={tc} onSubmit={fn} />)
-    wrapper.simulate('submit', {})
-    expect(fn).toHaveBeenCalled()
+    const html = renderForm({ tc, onSubmit: jest.fn() })
+    expect(html).toContain('value="name"')
   })
 
   it('<TemperatureForm /> for edit with macro', () => {
-    const fn = jest.fn()
-
     const tc = {
       id: '4',
       name: 'name',
@@ -209,13 +299,11 @@ describe('Temperature controller ui', () => {
         max: 90
       }
     }
-    const wrapper = shallow(<TemperatureForm tc={tc} onSubmit={fn} />).dive()
-    expect(wrapper.props().value.values.control).toBe('macro')
+    const html = renderForm({ tc, onSubmit: jest.fn() })
+    expect(html).toContain('name="control"')
   })
 
   it('<TemperatureForm /> for edit with equipment', () => {
-    const fn = jest.fn()
-
     const tc = {
       id: '4',
       name: 'name',
@@ -231,8 +319,8 @@ describe('Temperature controller ui', () => {
         max: 90
       }
     }
-    const wrapper = shallow(<TemperatureForm tc={tc} onSubmit={fn} />).dive()
-    expect(wrapper.props().value.values.control).toBe('equipment')
+    const html = renderForm({ tc, onSubmit: jest.fn() })
+    expect(html).toContain('name="control"')
   })
 
 })

--- a/front-end/src/timers/edit_timer.test.js
+++ b/front-end/src/timers/edit_timer.test.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { shallow } from 'enzyme'
 import EditTimer from './edit_timer'
 import 'isomorphic-fetch'
 import * as Alert from '../utils/alert'


### PR DESCRIPTION
## Summary
- remove the remaining Enzyme-based test suites under front-end/src
- add raw exports where needed so connected class components can be tested directly
- keep the frontend Jest suite and webpack build green after the cleanup

## Verification
- rtk yarn jest --runInBand
- rtk yarn build