### PR TITLE
[codex] Add coverage hygiene targets

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ Closes #
 List the exact commands you ran locally.
 
 ```text
-go test ./...
+make test
 ```
 
 ## Risk review

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           go-version: '1.26.2'
       - name: Run coverage
-        run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+        run: make coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5.5.1
       - run: go install golang.org/x/tools/cmd/goimports@v0.31.0

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SOURCES = $(shell find $(SOURCEDIR) -name '*.go')
 VERSION:=$(shell git describe --always --tags)
 BINARY=bin/reef-pi
 DETECT_RACE='-race'
+GO_TEST_PACKAGES=$(shell go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./commands ./controller/...)
 
 .PHONY:bin
 bin:
@@ -31,7 +32,11 @@ x86:
 
 .PHONY: test
 test:
-	go test -count=1 -cover $(DETECT_RACE) ./...
+	go test -count=1 -cover $(DETECT_RACE) $(GO_TEST_PACKAGES)
+
+.PHONY: coverage
+coverage:
+	go test -race -coverprofile=coverage.txt -covermode=atomic $(GO_TEST_PACKAGES)
 
 .PHONY: js-lint
 js-lint:

--- a/package.json
+++ b/package.json
@@ -130,6 +130,10 @@
     "testPathIgnorePatterns": [
       "<rootDir>/front-end/e2e/"
     ],
+    "coveragePathIgnorePatterns": [
+      "<rootDir>/build/translations/",
+      "<rootDir>/front-end/test/"
+    ],
     "transform": {
       "^.+\\.[jt]sx?$": "babel-jest"
     },


### PR DESCRIPTION
## Summary

Make coverage collection use explicit reef-pi project package discovery instead of raw `./...`, and keep generated/test-helper frontend files out of Jest coverage accounting.

Closes part of #2631.

## Scope

- [x] Behavior-preserving refactor only
- [x] No API schema changes
- [x] No UI/UX changes
- [x] No hardware behavior changes

## Verification

```text
rtk make coverage
rtk make test
rtk yarn jest --coverage --all --runInBand
```

## Risk review

- Main regression risks: CI could miss a future Go package if it has production code but no tests. This matches the intent of the current coverage target, which is coverage hygiene rather than no-test package enforcement.
- Areas reviewers should scrutinize: `GO_TEST_PACKAGES` package selection and the Jest coverage ignore paths.
- Rollback approach: revert this commit and restore direct `go test ... ./...` usage.

## Tracking

Tracking issue: #2631
