### PR TITLE
[codex] Improve lowest frontend coverage

### DIFF
--- a/front-end/src/confirm.test.jsx
+++ b/front-end/src/confirm.test.jsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import Confirm from './confirm'
+
+const findAll = (node, predicate, acc = []) => {
+  if (!node || typeof node !== 'object') {
+    return acc
+  }
+  if (predicate(node)) {
+    acc.push(node)
+  }
+  React.Children.toArray(node.props?.children).forEach(child => findAll(child, predicate, acc))
+  return acc
+}
+
+describe('<Confirm />', () => {
+  it('renders default labels and optional description', () => {
+    const component = new Confirm({
+      message: 'Delete item?',
+      description: <span id='description'>This cannot be undone.</span>
+    })
+
+    const tree = component.render()
+    expect(JSON.stringify(tree)).toContain('Delete item?')
+    expect(JSON.stringify(tree)).toContain('description')
+    expect(findAll(tree, node => node.type === 'button')).toHaveLength(2)
+  })
+
+  it('uses custom labels and omits body without description', () => {
+    const component = new Confirm({
+      message: 'Continue?',
+      confirmLabel: 'Yes',
+      abortLabel: 'No'
+    })
+
+    const tree = component.render()
+    expect(component.state.abortLabel).toBe('No')
+    expect(component.state.confirmLabel).toBe('Yes')
+    expect(findAll(tree, node => node.type === 'button')).toHaveLength(2)
+    expect(JSON.stringify(tree)).not.toContain('modal-body')
+  })
+
+  it('focuses confirm button on mount', () => {
+    const component = new Confirm({ message: 'Continue?' })
+    component.confirmRef.current = { focus: jest.fn() }
+
+    component.componentDidMount()
+
+    expect(component.confirmRef.current.focus).toHaveBeenCalled()
+    expect(component.promise).toBeDefined()
+  })
+
+  it('resolves or rejects its promise from button handlers', () => {
+    const component = new Confirm({ message: 'Continue?' })
+    component.promise = {
+      resolve: jest.fn(),
+      reject: jest.fn()
+    }
+
+    component.handleConfirm()
+    component.handleAbort()
+
+    expect(component.promise.resolve).toHaveBeenCalled()
+    expect(component.promise.reject).toHaveBeenCalled()
+  })
+})

--- a/front-end/src/dashboard/dashboard.test.js
+++ b/front-end/src/dashboard/dashboard.test.js
@@ -3,7 +3,13 @@ import ComponentSelector from './component_selector'
 import { RawDashboardConfig } from './config'
 import Grid from './grid'
 import { RawDashboardMain } from './main'
+import * as Alert from 'utils/alert'
 import 'isomorphic-fetch'
+
+jest.mock('utils/alert', () => ({
+  showError: jest.fn(),
+  showUpdateSuccessful: jest.fn()
+}))
 
 describe('Dashboard', () => {
   const click = (node, event = {}) => {
@@ -127,5 +133,88 @@ describe('Dashboard', () => {
     })
     m.state = RawDashboardConfig.getDerivedStateFromProps({ config }, m.state) || { updated: false, config }
     expect(m.render().props.className).toBe('col-12')
+  })
+
+  it('<Config /> fetches dashboard on mount and handles empty props', () => {
+    const fetchDashboard = jest.fn()
+    const m = new RawDashboardConfig({ fetchDashboard })
+
+    m.componentDidMount()
+
+    expect(fetchDashboard).toHaveBeenCalled()
+    expect(RawDashboardConfig.getDerivedStateFromProps({ config: undefined }, m.state)).toBeNull()
+    expect(RawDashboardConfig.getDerivedStateFromProps({ config: {} }, m.state)).toBeNull()
+    expect(RawDashboardConfig.getDerivedStateFromProps({ config: { row: 1 }, updated: true }, { updated: true })).toBeNull()
+  })
+
+  it('<Config /> edits numeric rows and saves valid config', () => {
+    const cells = [[{ type: 'ato', id: '1' }]]
+    const updateDashboard = jest.fn()
+    const m = new RawDashboardConfig({
+      config: { row: 1, column: 1, width: 100, height: 100, grid_details: cells },
+      fetchDashboard: jest.fn(),
+      updateDashboard,
+      atos: [],
+      phs: [],
+      tcs: [],
+      lights: [],
+      dosers: [],
+      equips: [],
+      journals: [],
+      blank: []
+    })
+    m.state = { updated: false, config: { row: 1, column: 1, width: 100, height: 100, grid_details: cells } }
+    m.setState = update => { m.state = { ...m.state, ...update } }
+
+    const row = m.toRow('row', 'Rows', 1, 12)
+    row.props.children[1].props.onChange({ target: { value: '' } })
+    expect(m.state.config.row).toBe('')
+    row.props.children[1].props.onChange({ target: { value: '2' } })
+    expect(m.state.config.row).toBe(2)
+    row.props.children[1].props.onChange({ target: { value: 'x' } })
+    expect(m.state.config.row).toBe(2)
+
+    m.handleSave()
+
+    expect(updateDashboard).toHaveBeenCalledWith({
+      row: 2,
+      column: 1,
+      width: 100,
+      height: 100,
+      grid_details: cells
+    })
+    expect(Alert.showUpdateSuccessful).toHaveBeenCalled()
+  })
+
+  it('<Config /> rejects invalid save values and rebuilds grid details', () => {
+    const cells = [[{ type: 'ato', id: '1' }]]
+    const updateDashboard = jest.fn()
+    const m = new RawDashboardConfig({
+      fetchDashboard: jest.fn(),
+      updateDashboard,
+      atos: [],
+      phs: [],
+      tcs: [],
+      lights: [],
+      dosers: [],
+      equips: [],
+      journals: [],
+      blank: []
+    })
+    m.state = { updated: false, config: { row: 2, column: 2, width: 0, height: 100, grid_details: cells } }
+    m.setState = update => { m.state = { ...m.state, ...update } }
+
+    m.handleSave()
+
+    expect(Alert.showError).toHaveBeenCalled()
+    expect(updateDashboard).not.toHaveBeenCalled()
+
+    m.state.config.width = 100
+    m.updateHook([[{ id: 'a', type: 'ato' }]])
+    expect(m.state.updated).toBe(true)
+    expect(m.state.config.grid_details).toEqual([
+      [{ id: 'a', type: 'ato' }, { id: 'none', type: 'blank_panel' }],
+      [{ id: 'none', type: 'blank_panel' }, { id: 'none', type: 'blank_panel' }]
+    ])
   })
 })

--- a/front-end/src/doser/doser_schema.test.js
+++ b/front-end/src/doser/doser_schema.test.js
@@ -84,4 +84,59 @@ describe('DoserValidation', () => {
     return DoserSchema.isValid(doser).then(valid => expect(valid).toBe(true))
   })
 
+  it('requires cron fields for scheduled dosers', () => {
+    expect.assertions(1)
+    const doser = {
+      ...basicDoser,
+      continuous: false,
+      month: '',
+      week: '',
+      day: '',
+      hour: '',
+      minute: '',
+      second: ''
+    }
+    return DoserSchema.validate(doser, { abortEarly: false })
+      .catch(err => expect(err.inner.map(e => e.path)).toEqual(expect.arrayContaining([
+        'month',
+        'week',
+        'day',
+        'hour',
+        'minute',
+        'second'
+      ])))
+  })
+
+  it('allows continuous dosers without cron fields', () => {
+    expect.assertions(1)
+    const doser = {
+      ...basicDoser,
+      continuous: true,
+      month: '',
+      week: '',
+      day: '',
+      hour: '',
+      minute: '',
+      second: ''
+    }
+    return DoserSchema.isValid(doser).then(valid => expect(valid).toBe(true))
+  })
+
+  it('rejects invalid numeric dosing limits', () => {
+    expect.assertions(1)
+    const doser = {
+      ...basicDoser,
+      continuous: false,
+      soft_start: -1,
+      duration: 0,
+      speed: 101
+    }
+    return DoserSchema.validate(doser, { abortEarly: false })
+      .catch(err => expect(err.inner.map(e => e.path)).toEqual(expect.arrayContaining([
+        'soft_start',
+        'duration',
+        'speed'
+      ])))
+  })
+
 })

--- a/front-end/src/drivers/driver.test.js
+++ b/front-end/src/drivers/driver.test.js
@@ -1,6 +1,16 @@
 import Driver from './driver'
 import 'isomorphic-fetch'
 import DriverForm, { mapDriverPropsToValues, submitDriverForm } from './driver_form'
+import { confirm } from 'utils/confirm'
+import { showUpdateSuccessful } from 'utils/alert'
+
+jest.mock('utils/confirm', () => ({
+  confirm: jest.fn(() => Promise.resolve())
+}))
+
+jest.mock('utils/alert', () => ({
+  showUpdateSuccessful: jest.fn()
+}))
 
 describe('driver UI', () => {
   let driver = {
@@ -30,6 +40,119 @@ describe('driver UI', () => {
     component.handleEdit()
     expect(component.state.edit).toBe(true)
     expect(component.state.lbl).toBe('save')
+  })
+
+  it('<Driver /> ignores edit when read only', () => {
+    const component = new Driver({
+      driver,
+      read_only: true,
+      remove: jest.fn(),
+      update: jest.fn(),
+      validate: jest.fn(() => Promise.resolve({ status: 200 })),
+      provision: jest.fn(),
+      driverOptions: {}
+    })
+    component.setState = jest.fn(update => {
+      component.state = { ...component.state, ...update }
+    })
+
+    component.handleEdit()
+
+    expect(component.state.edit).toBeUndefined()
+    expect(component.setState).not.toHaveBeenCalled()
+    expect(component.render().props.children[1].props.children).toEqual([null, null, null])
+  })
+
+  it('<Driver /> removes after confirmation', () => {
+    expect.assertions(2)
+    const remove = jest.fn()
+    const component = new Driver({
+      driver,
+      remove,
+      update: jest.fn(),
+      validate: jest.fn(() => Promise.resolve({ status: 200 })),
+      provision: jest.fn(),
+      driverOptions: {}
+    })
+
+    component.handleRemove(driver)
+
+    expect(confirm).toHaveBeenCalled()
+    return Promise.resolve().then(() => expect(remove).toHaveBeenCalledWith(driver.id))
+  })
+
+  it('<Driver /> saves valid edits and maps validation errors', () => {
+    expect.assertions(5)
+    const update = jest.fn()
+    const component = new Driver({
+      driver,
+      remove: jest.fn(),
+      update,
+      validate: jest.fn(() => Promise.resolve({ status: 200 })),
+      provision: jest.fn(),
+      driverOptions: {}
+    })
+    component.setState = jest.fn(update => {
+      component.state = { ...component.state, ...update }
+    })
+
+    component.handleSave({ name: 'new', type: 'pca9685', config: { address: 64 } }, { setErrors: jest.fn() })
+
+    return Promise.resolve()
+      .then(() => {
+        expect(update).toHaveBeenCalledWith(driver.id, {
+          id: driver.id,
+          name: 'new',
+          type: 'pca9685',
+          config: { address: 64 }
+        })
+        expect(component.state.edit).toBe(false)
+        const setErrors = jest.fn()
+        const invalid = new Driver({
+          driver,
+          remove: jest.fn(),
+          update: jest.fn(),
+          validate: jest.fn(() => Promise.resolve({
+            status: 400,
+            json: () => Promise.resolve({
+              name: 'bad name',
+              'config.address': 'bad address'
+            })
+          })),
+          provision: jest.fn(),
+          driverOptions: {}
+        })
+        invalid.handleSave({ name: 'bad', type: 'pca9685', config: {} }, { setErrors })
+        return Promise.resolve().then(() => Promise.resolve())
+          .then(() => {
+            expect(setErrors).toHaveBeenCalledWith({
+              name: 'bad name',
+              'config.address': 'bad address',
+              config: { address: 'bad address' }
+            })
+            expect(invalid.editUI().type).toBe(DriverForm)
+            expect(invalid.ui().props.children).toHaveLength(2)
+          })
+      })
+  })
+
+  it('<Driver /> provisions from render button', () => {
+    const provision = jest.fn()
+    const component = new Driver({
+      driver,
+      remove: jest.fn(),
+      update: jest.fn(),
+      validate: jest.fn(() => Promise.resolve({ status: 200 })),
+      provision,
+      driverOptions: {}
+    })
+
+    const tree = component.render()
+    const buttons = tree.props.children[1].props.children
+    buttons[2].props.onClick()
+
+    expect(provision).toHaveBeenCalledWith(driver.id)
+    expect(showUpdateSuccessful).toHaveBeenCalled()
   })
 
   it('<DriverForm /> maps and submits', () => {

--- a/front-end/src/lighting/lighting.test.js
+++ b/front-end/src/lighting/lighting.test.js
@@ -26,6 +26,22 @@ const wrapFormik = (component, initialValues = {}) => renderToStaticMarkup(
   </Formik>
 )
 
+const findNode = (node, predicate) => {
+  if (!node || typeof node !== 'object') {
+    return undefined
+  }
+  if (predicate(node)) {
+    return node
+  }
+  for (const child of React.Children.toArray(node.props?.children)) {
+    const found = findNode(child, predicate)
+    if (found) {
+      return found
+    }
+  }
+  return undefined
+}
+
 jest.mock('utils/confirm', () => {
   return {
     confirm: jest
@@ -288,6 +304,68 @@ describe('Lighting ui', () => {
       />,
       { config: light }
     )).toContain('channel_name')
+  })
+
+  it('<Channel /> resets profile config when profile type changes', () => {
+    const profileTypes = {
+      fixed: { start: '', end: '', value: 0 },
+      diurnal: { start: '', end: '' },
+      interval: {
+        start: '00:00:00',
+        end: '22:00:00',
+        interval: 120,
+        values: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+      },
+      lunar: { start: '', end: '', full_moon: null },
+      random: { start: '', end: '' },
+      sine: { start: '', end: '' },
+      circadian: { start: '', end: '', dawn_value: 10, noon_value: 100 },
+      cyclic: { period: 60, phase_shift: 0 },
+      lightning: { start: '', end: '', frequency: 2, flash_slot: 1, intensity: 100 },
+      solar: { latitude: 0, longitude: 0 },
+      unknown: {}
+    }
+
+    Object.entries(profileTypes).forEach(([type, config]) => {
+      const onChangeHandler = jest.fn()
+      const setTouched = jest.fn()
+      const touched = {
+        config: {
+          channels: {
+            1: {
+              profile: {
+                config: { start: true }
+              }
+            }
+          }
+        }
+      }
+      const tree = Channel({
+        name: 'config.channels.1',
+        channel: light.channels['1'],
+        channelNum: '1',
+        onChangeHandler,
+        onBlur: jest.fn(),
+        touched,
+        errors: {},
+        setTouched
+      })
+      const selector = findNode(tree, node => node.type === ProfileSelector)
+      selector.props.onChangeHandler({ target: { name: 'profile', value: type } })
+
+      expect(onChangeHandler).toHaveBeenCalledWith({
+        target: {
+          name: 'profile',
+          value: {
+            type,
+            config
+          }
+        }
+      }, '1')
+      if (type !== 'unknown') {
+        expect(setTouched).toHaveBeenCalledWith(touched)
+      }
+    })
   })
 
   it('<Profile /> fixed', () => {


### PR DESCRIPTION
## Summary

Improve coverage for the lowest-coverage frontend files identified in #2631.

Closes part of #2631.

## Details

- Added direct component coverage for `front-end/src/confirm.jsx`.
- Extended dashboard config tests for derived state, numeric edits, save validation, successful updates, and grid rebuild behavior.
- Extended doser schema tests for cron requirements, continuous dosers, and numeric limits.
- Extended driver row tests for read-only behavior, confirmation removal, validation error mapping, save success, and provisioning.
- Extended lighting channel tests for profile config reset behavior across all profile types.

Coverage impact from full Jest coverage:

- `front-end/src/confirm.jsx`: 0% -> 100%
- `front-end/src/lighting/channel.jsx`: 11.32% -> 98.11%
- `front-end/src/doser/doser_schema.jsx`: 22.22% -> 100%
- `front-end/src/dashboard/config.jsx`: 29.31% -> 91.37%
- `front-end/src/drivers/driver.jsx`: 30.0% -> 97.5%
- Overall frontend statement coverage: 76.66% -> 79.8%

## Verification

```text
rtk yarn jest front-end/src/confirm.test.jsx front-end/src/doser/doser_schema.test.js front-end/src/lighting/lighting.test.js front-end/src/dashboard/dashboard.test.js front-end/src/drivers/driver.test.js --runInBand
rtk yarn jest --coverage --all --runInBand
rtk ./node_modules/.bin/standard "front-end/src/**/*.{js,jsx}"
```

## Risk review

- Main regression risks: tests use direct component method calls in the same style as existing tests; mock interactions in dashboard/driver suites should be reviewed.
- Areas reviewers should scrutinize: async promise assertions in driver tests and direct Channel profile selector invocation.
- Rollback approach: revert this test-only commit.

## Tracking

Tracking issue: #2631
