### PR TITLE
docs: close out react migration track

### DIFF
--- a/docs/github-issues/slice-23-react-ecosystem-cleanup.md
+++ b/docs/github-issues/slice-23-react-ecosystem-cleanup.md
@@ -74,6 +74,13 @@ This section reflects the current `main` branch rather than the older pre-React-
    - `docs/library-migration-plan.md` still describes old blockers such as React 16 Enzyme adapter usage and legacy render APIs
    - Slice 23 should leave the migration notes matching current repo reality
 
+### Closeout status
+
+- the last React-core peer-range warning from `yarn install` has been cleared
+- the remaining React-adjacent package audit is complete
+- no further code change is required to satisfy Slice 23 goals
+- any remaining work is documentation cleanup or unrelated product follow-up, not React 19 compatibility blocking work
+
 ### Recommended execution order
 
 1. Audit dependency compatibility one package at a time and record only evidence-backed changes.

--- a/docs/library-migration-plan.md
+++ b/docs/library-migration-plan.md
@@ -30,12 +30,12 @@ This document extends the refactor program with a version modernization track fo
 - `ReactDOM.render` and `unmountComponentAtNode` have been removed from:
   - `front-end/src/entry.js`
   - `front-end/src/utils/confirm.js`
-- function-component `defaultProps` still exist in several lighting profile components.
 - Redux bindings are aligned with the React 19 runtime:
   - `react-redux` is on `9.x`
   - `redux` is on `5.x`
   - `redux-thunk` is on `3.x`
 - app-local `redux/store` and `redux/actions/...` imports now require explicit resolver aliases in Jest and webpack to avoid colliding with the published `redux` package name.
+- no remaining function-component `defaultProps` blocker is present in `front-end/src`; current `defaultProps` matches are test fixture variables only.
 
 ### Jest
 
@@ -62,6 +62,12 @@ This document extends the refactor program with a version modernization track fo
 - React 19 was previously blocked by legacy render APIs and Enzyme.
 - Jest 30 is safer after some test decoupling work.
 - ecosystem cleanup should follow the core React move, not precede it.
+
+## Current status
+
+- Slices 18 through 23 have landed on `main`.
+- The core migration track is complete.
+- Remaining follow-up work, if any, should be tracked as standalone cleanup items rather than new slices in this program.
 
 ## Validation expectations
 


### PR DESCRIPTION
## Summary
- update the migration docs to reflect the current post-React-19 repo state
- remove the stale function-component defaultProps blocker note
- mark slices 18 through 23 as complete and note that remaining work is no longer part of the core migration track

## Verification
- repo inspection only; docs-only change