### PR TITLE
[codex] Improve ESPHome driver coverage

### DIFF
--- a/controller/device_manager/drivers/esphome/driver_test.go
+++ b/controller/device_manager/drivers/esphome/driver_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/reef-pi/hal"
 )
 
 func TestFactory_Metadata(t *testing.T) {
@@ -16,6 +18,9 @@ func TestFactory_Metadata(t *testing.T) {
 	}
 	if len(m.Capabilities) == 0 {
 		t.Error("expected at least one capability")
+	}
+	if params := f.GetParameters(); len(params) != 3 {
+		t.Fatalf("expected three config parameters, got %d", len(params))
 	}
 }
 
@@ -53,6 +58,7 @@ func TestFactory_ValidateParameters(t *testing.T) {
 }
 
 func TestSwitchPin_Write(t *testing.T) {
+	var paths []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
@@ -60,6 +66,7 @@ func TestSwitchPin_Write(t *testing.T) {
 		if !strings.Contains(r.URL.Path, "/switch/light/") {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
+		paths = append(paths, r.URL.Path)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
@@ -74,6 +81,29 @@ func TestSwitchPin_Write(t *testing.T) {
 	if err := p.Write(false); err != nil {
 		t.Errorf("Write(false) unexpected error: %v", err)
 	}
+	if strings.Join(paths, "\n") != "/switch/light/turn_on\n/switch/light/turn_off" {
+		t.Fatalf("unexpected switch paths: %v", paths)
+	}
+	if p.Name() != "light" || p.Number() != 0 {
+		t.Fatalf("unexpected switch pin identity: %s %d", p.Name(), p.Number())
+	}
+	if err := p.Close(); err != nil {
+		t.Fatalf("switch Close() error: %v", err)
+	}
+}
+
+func TestSwitchPin_WriteHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusTeapot)
+	}))
+	defer srv.Close()
+
+	address := strings.TrimPrefix(srv.URL, "http://")
+	p := &switchPin{address: address, entityID: "light"}
+
+	if err := p.Write(true); err == nil {
+		t.Fatal("expected non-200 response to fail")
+	}
 }
 
 func TestSwitchPin_LastState(t *testing.T) {
@@ -87,6 +117,19 @@ func TestSwitchPin_LastState(t *testing.T) {
 	p := &switchPin{address: address, entityID: "light"}
 	if !p.LastState() {
 		t.Error("expected LastState to be true")
+	}
+}
+
+func TestSwitchPin_LastStateErrorsReturnFalse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`not-json`))
+	}))
+	defer srv.Close()
+
+	address := strings.TrimPrefix(srv.URL, "http://")
+	p := &switchPin{address: address, entityID: "light"}
+	if p.LastState() {
+		t.Fatal("expected invalid response to return false")
 	}
 }
 
@@ -106,11 +149,64 @@ func TestSensorPin_Value(t *testing.T) {
 	if v != 23.5 {
 		t.Errorf("expected 23.5, got %f", v)
 	}
+	if s.Name() != "temp" || s.Number() != 0 {
+		t.Fatalf("unexpected sensor pin identity: %s %d", s.Name(), s.Number())
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("sensor Close() error: %v", err)
+	}
+}
+
+func TestSensorPin_Measure(t *testing.T) {
+	entities := []entityState{{ID: "temp", State: "", Value: 23.5}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(entities)
+	}))
+	defer srv.Close()
+
+	address := strings.TrimPrefix(srv.URL, "http://")
+	s := &sensorPin{address: address, entityID: "temp"}
+
+	raw, err := s.Measure()
+	if err != nil {
+		t.Fatalf("Measure() raw error: %v", err)
+	}
+	if raw != 23.5 {
+		t.Fatalf("expected raw measure 23.5, got %f", raw)
+	}
+	if err := s.Calibrate([]hal.Measurement{{Expected: 25, Observed: 23.5}}); err != nil {
+		t.Fatalf("Calibrate() error: %v", err)
+	}
+	calibrated, err := s.Measure()
+	if err != nil {
+		t.Fatalf("Measure() calibrated error: %v", err)
+	}
+	if calibrated != 25 {
+		t.Fatalf("expected calibrated measure 25, got %f", calibrated)
+	}
+	if err := s.Calibrate([]hal.Measurement{{}, {}, {}}); err != nil {
+		t.Fatalf("Calibrate() stores invalid calibration for Measure: %v", err)
+	}
+	if _, err := s.Measure(); err == nil {
+		t.Fatal("expected invalid calibration to fail during Measure")
+	}
+}
+
+func TestFetchEntityStateErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]entityState{{ID: "other", Value: 1}})
+	}))
+	defer srv.Close()
+
+	address := strings.TrimPrefix(srv.URL, "http://")
+	if _, err := fetchEntityState(address, "missing"); err == nil {
+		t.Fatal("expected missing entity to fail")
+	}
 }
 
 func TestNewDriver_Switch(t *testing.T) {
 	f := Factory()
-	d, err := f.NewDriver(map[string]interface{}{
+	halDriver, err := f.NewDriver(map[string]interface{}{
 		paramAddress:    "192.168.1.50",
 		paramEntityID:   "light",
 		paramEntityType: entityTypeSwitch,
@@ -118,9 +214,35 @@ func TestNewDriver_Switch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewDriver error: %v", err)
 	}
-	pins, err := d.Pins(0) // hal.DigitalOutput == 2; use Pins directly
-	_ = pins
-	_ = err
+	d := halDriver.(*driver)
+	if d.Metadata().Name != "ESPHome" {
+		t.Fatalf("unexpected metadata name: %s", d.Metadata().Name)
+	}
+	pins, err := d.Pins(hal.DigitalOutput)
+	if err != nil {
+		t.Fatalf("DigitalOutput Pins() error: %v", err)
+	}
+	if len(pins) != 1 {
+		t.Fatalf("expected one digital output pin, got %d", len(pins))
+	}
+	if _, err := d.Pins(hal.AnalogInput); err == nil {
+		t.Fatal("expected analog pins on switch driver to fail")
+	}
+	if _, err := d.Pins(hal.PWM); err == nil {
+		t.Fatal("expected unsupported capability to fail")
+	}
+	if len(d.DigitalOutputPins()) != 1 {
+		t.Fatal("expected one digital output pin")
+	}
+	if _, err := d.DigitalOutputPin(0); err != nil {
+		t.Fatalf("DigitalOutputPin(0) error: %v", err)
+	}
+	if _, err := d.DigitalOutputPin(1); err == nil {
+		t.Fatal("expected invalid digital pin to fail")
+	}
+	if d.AnalogInputPins() != nil {
+		t.Fatal("expected no analog pins on switch driver")
+	}
 	if err := d.Close(); err != nil {
 		t.Errorf("Close() error: %v", err)
 	}
@@ -128,13 +250,36 @@ func TestNewDriver_Switch(t *testing.T) {
 
 func TestNewDriver_Sensor(t *testing.T) {
 	f := Factory()
-	d, err := f.NewDriver(map[string]interface{}{
+	halDriver, err := f.NewDriver(map[string]interface{}{
 		paramAddress:    "192.168.1.50",
 		paramEntityID:   "temperature",
 		paramEntityType: entityTypeSensor,
 	}, nil)
 	if err != nil {
 		t.Fatalf("NewDriver error: %v", err)
+	}
+	d := halDriver.(*driver)
+	pins, err := d.Pins(hal.AnalogInput)
+	if err != nil {
+		t.Fatalf("AnalogInput Pins() error: %v", err)
+	}
+	if len(pins) != 1 {
+		t.Fatalf("expected one analog input pin, got %d", len(pins))
+	}
+	if _, err := d.Pins(hal.DigitalOutput); err == nil {
+		t.Fatal("expected digital output pins on sensor driver to fail")
+	}
+	if len(d.AnalogInputPins()) != 1 {
+		t.Fatal("expected one analog input pin")
+	}
+	if _, err := d.AnalogInputPin(0); err != nil {
+		t.Fatalf("AnalogInputPin(0) error: %v", err)
+	}
+	if _, err := d.AnalogInputPin(1); err == nil {
+		t.Fatal("expected invalid analog pin to fail")
+	}
+	if d.DigitalOutputPins() != nil {
+		t.Fatal("expected no digital output pins on sensor driver")
 	}
 	if err := d.Close(); err != nil {
 		t.Errorf("Close() error: %v", err)


### PR DESCRIPTION
## Summary

Improve coverage for the ESPHome device driver package as the first backend device-driver coverage slice from #2631.

Closes part of #2631.

## Details

- Covers factory parameter metadata.
- Covers driver metadata, capability routing, pin helper success/error paths, and unsupported capabilities.
- Covers switch pin identity, close, on/off write paths, non-200 HTTP errors, and `LastState` error behavior.
- Covers sensor pin identity, close, raw measurement, one-point calibration, invalid calibration, and missing entity errors.

Coverage impact:

- `controller/device_manager/drivers/esphome`: 53.5% -> 94.9%

## Verification

```text
rtk go test ./controller/device_manager/drivers/esphome
rtk proxy go test -coverprofile=/tmp/esphome-cover-after.out ./controller/device_manager/drivers/esphome
rtk go tool cover -func=/tmp/esphome-cover-after.out
```

## Risk review

- Main regression risks: low; this is test-only.
- Areas reviewers should scrutinize: HTTP test server coverage for switch and sensor entity IDs, and calibration expectations.
- Rollback approach: revert this test-only commit.

## Tracking

Tracking issue: #2631
