### PR TITLE
[codex] Improve DS18B20 driver coverage

### DIFF
--- a/controller/device_manager/drivers/ds18b20/driver_test.go
+++ b/controller/device_manager/drivers/ds18b20/driver_test.go
@@ -16,6 +16,13 @@ func TestFactory(t *testing.T) {
 	if !meta.HasCapability(hal.AnalogInput) {
 		t.Error("expected AnalogInput capability")
 	}
+	params := f.GetParameters()
+	if len(params) != 1 {
+		t.Fatalf("expected one config parameter, got %d", len(params))
+	}
+	if params[0].Name != deviceParam {
+		t.Fatalf("expected parameter %q, got %q", deviceParam, params[0].Name)
+	}
 }
 
 func TestValidateParameters(t *testing.T) {
@@ -32,6 +39,22 @@ func TestValidateParameters(t *testing.T) {
 	}
 	if len(errs) == 0 {
 		t.Error("expected validation errors")
+	}
+
+	ok, errs = f.ValidateParameters(map[string]interface{}{deviceParam: ""})
+	if ok {
+		t.Error("expected empty device to be invalid")
+	}
+	if len(errs[deviceParam]) == 0 {
+		t.Error("expected device validation error for empty string")
+	}
+
+	ok, errs = f.ValidateParameters(map[string]interface{}{deviceParam: 28})
+	if ok {
+		t.Error("expected non-string device to be invalid")
+	}
+	if len(errs[deviceParam]) == 0 {
+		t.Error("expected device validation error for non-string")
 	}
 }
 
@@ -54,6 +77,42 @@ func TestReadTempCRCFail(t *testing.T) {
 	}
 }
 
+func TestReadTempErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "missing second line",
+			input: "61 01 4b 46 7f ff 0c 10 e7 : crc=e7 YES\n",
+		},
+		{
+			name:  "second line missing equals",
+			input: "61 01 4b 46 7f ff 0c 10 e7 : crc=e7 YES\n61 01 4b 46 7f ff 0c 10 e7\n",
+		},
+		{
+			name:  "bad number",
+			input: "61 01 4b 46 7f ff 0c 10 e7 : crc=e7 YES\n61 01 4b 46 7f ff 0c 10 e7 t=nope\n",
+		},
+		{
+			name:  "out of range high",
+			input: "61 01 4b 46 7f ff 0c 10 e7 : crc=e7 YES\n61 01 4b 46 7f ff 0c 10 e7 t=126000\n",
+		},
+		{
+			name:  "out of range low",
+			input: "61 01 4b 46 7f ff 0c 10 e7 : crc=e7 YES\n61 01 4b 46 7f ff 0c 10 e7 t=-56000\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := readTemp(strings.NewReader(tc.input)); err == nil {
+				t.Fatal("expected readTemp error")
+			}
+		})
+	}
+}
+
 func TestNewDriver(t *testing.T) {
 	f := Factory()
 	d, err := f.NewDriver(map[string]interface{}{deviceParam: "28-abc123"}, nil)
@@ -66,6 +125,15 @@ func TestNewDriver(t *testing.T) {
 	}
 	if len(pins) != 1 {
 		t.Errorf("expected 1 pin, got %d", len(pins))
+	}
+	if d.Metadata().Name != "ds18b20" {
+		t.Fatalf("unexpected metadata name: %s", d.Metadata().Name)
+	}
+	if _, err := d.Pins(hal.DigitalOutput); err == nil {
+		t.Fatal("expected unsupported capability error")
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close() error: %v", err)
 	}
 
 	ad, ok := d.(hal.AnalogInputDriver)
@@ -82,9 +150,48 @@ func TestNewDriver(t *testing.T) {
 	if pin.Number() != 0 {
 		t.Errorf("expected pin number 0, got %d", pin.Number())
 	}
+	if len(ad.AnalogInputPins()) != 1 {
+		t.Fatal("expected one analog input pin")
+	}
 
 	_, err = ad.AnalogInputPin(1)
 	if err == nil {
 		t.Error("expected error for invalid pin number")
+	}
+}
+
+func TestNewDriverInvalidParams(t *testing.T) {
+	f := Factory()
+	if _, err := f.NewDriver(map[string]interface{}{}, nil); err == nil {
+		t.Fatal("expected invalid params to fail")
+	}
+}
+
+func TestChannel(t *testing.T) {
+	pin := newChannel("28-missing")
+	ch, ok := pin.(*channel)
+	if !ok {
+		t.Fatal("expected *channel")
+	}
+	if ch.Name() != "temperature" {
+		t.Fatalf("unexpected channel name: %s", ch.Name())
+	}
+	if ch.Number() != 0 {
+		t.Fatalf("unexpected channel number: %d", ch.Number())
+	}
+	if err := ch.Close(); err != nil {
+		t.Fatalf("Close() error: %v", err)
+	}
+	if err := ch.Calibrate([]hal.Measurement{{Expected: 25, Observed: 23}}); err != nil {
+		t.Fatalf("Calibrate() error: %v", err)
+	}
+	if err := ch.Calibrate([]hal.Measurement{{}, {}, {}}); err == nil {
+		t.Fatal("expected invalid calibration to fail")
+	}
+	if _, err := ch.Value(); err == nil {
+		t.Fatal("expected Value() to fail for missing sysfs device")
+	}
+	if _, err := ch.Measure(); err == nil {
+		t.Fatal("expected Measure() to fail for missing sysfs device")
 	}
 }


### PR DESCRIPTION
## Summary

Improve coverage for the DS18B20 device driver package as the next backend device-driver coverage slice from #2631.

Closes part of #2631.

## Details

- Covers factory parameters and validation failures for missing, empty, and non-string device IDs.
- Covers driver metadata, supported/unsupported capability paths, analog pin helpers, and close behavior.
- Covers channel identity, close, calibration success/failure, missing sysfs device errors, and measure error propagation.
- Covers additional parser errors for malformed, missing, non-numeric, and out-of-range sensor values.

Coverage impact:

- `controller/device_manager/drivers/ds18b20`: 55.1% -> 91.3%

## Verification

```text
rtk go test ./controller/device_manager/drivers/ds18b20
rtk proxy go test -coverprofile=/tmp/ds18b20-cover-after.out ./controller/device_manager/drivers/ds18b20
rtk go tool cover -func=/tmp/ds18b20-cover-after.out
```

## Risk review

- Main regression risks: low; this is test-only.
- Areas reviewers should scrutinize: parser error expectations and calibration edge coverage.
- Rollback approach: revert this test-only commit.

## Tracking

Tracking issue: #2631
