### PR TITLE
[codex] Improve WLED driver coverage

### DIFF
--- a/controller/device_manager/drivers/wled/driver_test.go
+++ b/controller/device_manager/drivers/wled/driver_test.go
@@ -32,6 +32,13 @@ func TestFactory_metadata(t *testing.T) {
 	if !hasPWM {
 		t.Error("expected PWM capability")
 	}
+	params := f.GetParameters()
+	if len(params) != 1 {
+		t.Fatalf("expected one config parameter, got %d", len(params))
+	}
+	if params[0].Name != paramAddress {
+		t.Fatalf("expected parameter %q, got %q", paramAddress, params[0].Name)
+	}
 }
 
 func TestFactory_validateParameters(t *testing.T) {
@@ -54,17 +61,60 @@ func TestFactory_validateParameters(t *testing.T) {
 
 func TestFactory_newDriver(t *testing.T) {
 	f := Factory()
-	d, err := f.NewDriver(map[string]interface{}{paramAddress: "192.168.1.1"}, nil)
+	halDriver, err := f.NewDriver(map[string]interface{}{paramAddress: "192.168.1.1"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	pins := d.(hal.DigitalOutputDriver).DigitalOutputPins()
-	if len(pins) != 1 {
-		t.Fatalf("expected 1 digital output pin, got %d", len(pins))
+	d := halDriver.(*driver)
+	if d.Metadata().Name != "WLED" {
+		t.Fatalf("unexpected metadata name: %s", d.Metadata().Name)
 	}
-	channels := d.(hal.PWMDriver).PWMChannels()
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close() error: %v", err)
+	}
+	pins, err := d.Pins(hal.DigitalOutput)
+	if err != nil {
+		t.Fatalf("Pins(DigitalOutput) error: %v", err)
+	}
+	if len(pins) != 1 {
+		t.Fatalf("expected one digital output pin, got %d", len(pins))
+	}
+	pins, err = d.Pins(hal.PWM)
+	if err != nil {
+		t.Fatalf("Pins(PWM) error: %v", err)
+	}
+	if len(pins) != 1 {
+		t.Fatalf("expected one PWM pin, got %d", len(pins))
+	}
+	if _, err := d.Pins(hal.AnalogInput); err == nil {
+		t.Fatal("expected unsupported capability error")
+	}
+	outputPins := halDriver.(hal.DigitalOutputDriver).DigitalOutputPins()
+	if len(outputPins) != 1 {
+		t.Fatalf("expected 1 digital output pin, got %d", len(outputPins))
+	}
+	if _, err := d.DigitalOutputPin(0); err != nil {
+		t.Fatalf("DigitalOutputPin(0) error: %v", err)
+	}
+	if _, err := d.DigitalOutputPin(1); err == nil {
+		t.Fatal("expected invalid digital pin error")
+	}
+	channels := halDriver.(hal.PWMDriver).PWMChannels()
 	if len(channels) != 1 {
 		t.Fatalf("expected 1 PWM channel, got %d", len(channels))
+	}
+	if _, err := d.PWMChannel(0); err != nil {
+		t.Fatalf("PWMChannel(0) error: %v", err)
+	}
+	if _, err := d.PWMChannel(1); err == nil {
+		t.Fatal("expected invalid PWM channel error")
+	}
+}
+
+func TestFactory_newDriverInvalidParams(t *testing.T) {
+	f := Factory()
+	if _, err := f.NewDriver(map[string]interface{}{}, nil); err == nil {
+		t.Fatal("expected invalid params to fail")
 	}
 }
 
@@ -93,6 +143,15 @@ func TestWledChannel_Write_on(t *testing.T) {
 	defer srv.Close()
 
 	ch := &wledChannel{address: addr}
+	if ch.Name() != "wled" {
+		t.Fatalf("unexpected channel name: %s", ch.Name())
+	}
+	if ch.Number() != 0 {
+		t.Fatalf("unexpected channel number: %d", ch.Number())
+	}
+	if err := ch.Close(); err != nil {
+		t.Fatalf("Close() error: %v", err)
+	}
 	if err := ch.Write(true); err != nil {
 		t.Fatal(err)
 	}
@@ -126,6 +185,30 @@ func TestWledChannel_LastState(t *testing.T) {
 	}
 }
 
+func TestWledChannel_LastStateErrorsReturnFalse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`not-json`))
+	}))
+	defer srv.Close()
+
+	ch := &wledChannel{address: strings.TrimPrefix(srv.URL, "http://")}
+	if ch.LastState() {
+		t.Fatal("expected LastState false for invalid state response")
+	}
+}
+
+func TestWledChannel_setStateHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad state", http.StatusTeapot)
+	}))
+	defer srv.Close()
+
+	ch := &wledChannel{address: strings.TrimPrefix(srv.URL, "http://")}
+	if err := ch.Write(true); err == nil {
+		t.Fatal("expected non-200 setState response to fail")
+	}
+}
+
 func TestWledChannel_Set_brightness(t *testing.T) {
 	state := &wledState{On: false, Bri: 0}
 	srv, addr := newTestServer(t, state)
@@ -155,5 +238,34 @@ func TestWledChannel_Set_zero_turns_off(t *testing.T) {
 	}
 	if state.On {
 		t.Error("expected device off after Set(0)")
+	}
+}
+
+func TestWledChannel_Set_clampsBrightness(t *testing.T) {
+	state := &wledState{On: false, Bri: 0}
+	srv, addr := newTestServer(t, state)
+	defer srv.Close()
+
+	ch := &wledChannel{address: addr}
+	if err := ch.Set(-10); err != nil {
+		t.Fatal(err)
+	}
+	if state.On {
+		t.Fatal("expected negative brightness to turn off")
+	}
+	if err := ch.Set(200); err != nil {
+		t.Fatal(err)
+	}
+	if !state.On {
+		t.Fatal("expected clamped high brightness to turn on")
+	}
+	if state.Bri != 255 {
+		t.Fatalf("expected brightness 255, got %d", state.Bri)
+	}
+	if err := ch.Set(0.1); err != nil {
+		t.Fatal(err)
+	}
+	if state.Bri != 1 {
+		t.Fatalf("expected low positive brightness to clamp to 1, got %d", state.Bri)
 	}
 }


### PR DESCRIPTION
## Summary

Improve coverage for the WLED device driver package, completing the backend device-driver coverage group from #2631.

Closes part of #2631.

## Details

- Covers factory parameters and invalid-driver construction.
- Covers driver metadata, close, supported and unsupported capability paths, digital output helpers, and PWM helpers.
- Covers channel identity and close methods.
- Covers HTTP error handling, invalid state responses, and brightness clamp behavior for low, zero, high, and nominal values.

Coverage impact:

- `controller/device_manager/drivers/wled`: 61.4% -> 94.3%

## Verification

```text
rtk go test ./controller/device_manager/drivers/wled
rtk proxy go test -coverprofile=/tmp/wled-cover-after.out ./controller/device_manager/drivers/wled
rtk go tool cover -func=/tmp/wled-cover-after.out
```

## Risk review

- Main regression risks: low; this is test-only.
- Areas reviewers should scrutinize: HTTP test server behavior for state reads/writes and brightness clamp expectations.
- Rollback approach: revert this test-only commit.

## Tracking

Tracking issue: #2631
