### PR TITLE
Improve telemetry coverage

### DIFF
--- a/controller/telemetry/api_test.go
+++ b/controller/telemetry/api_test.go
@@ -3,6 +3,8 @@ package telemetry
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/reef-pi/reef-pi/controller/storage"
@@ -47,4 +49,63 @@ func TestDeleteFeedIfExist(t *testing.T) {
 	tele := TestTelemetry(store)
 	// AdafruitIO disabled (default) — should be a no-op
 	tele.DeleteFeedIfExist("test-feed")
+}
+
+func TestConfigAPIRedactsAndPreservesSecrets(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	store.CreateBucket("telemetry")
+
+	original := DefaultTelemetryConfig
+	original.AdafruitIO.Token = "aio-token"
+	original.Mailer.Password = "mail-password"
+	if err := store.Update("telemetry", DBKey, original); err != nil {
+		t.Fatal(err)
+	}
+
+	tele := TestTelemetry(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/telemetry", nil)
+	w := httptest.NewRecorder()
+	tele.GetConfig(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected get config status 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var redacted TelemetryConfig
+	if err := json.NewDecoder(w.Body).Decode(&redacted); err != nil {
+		t.Fatal(err)
+	}
+	if redacted.AdafruitIO.Token != AdafruitIOTokenStoredPlaceholder {
+		t.Fatalf("expected redacted AIO token, got %q", redacted.AdafruitIO.Token)
+	}
+	if redacted.Mailer.Password != PasswordStoredPlaceholder {
+		t.Fatalf("expected redacted mail password, got %q", redacted.Mailer.Password)
+	}
+
+	body := new(bytes.Buffer)
+	body.Reset()
+	redacted.Notify = false
+	if err := json.NewEncoder(body).Encode(redacted); err != nil {
+		t.Fatal(err)
+	}
+	req = httptest.NewRequest(http.MethodPost, "/api/telemetry", body)
+	w = httptest.NewRecorder()
+	tele.UpdateConfig(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected update config status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var saved TelemetryConfig
+	if err := store.Get("telemetry", DBKey, &saved); err != nil {
+		t.Fatal(err)
+	}
+	if saved.AdafruitIO.Token != original.AdafruitIO.Token {
+		t.Fatalf("expected stored AIO token to be preserved, got %q", saved.AdafruitIO.Token)
+	}
+	if saved.Mailer.Password != original.Mailer.Password {
+		t.Fatalf("expected stored mail password to be preserved, got %q", saved.Mailer.Password)
+	}
 }

--- a/controller/telemetry/health_test.go
+++ b/controller/telemetry/health_test.go
@@ -1,12 +1,20 @@
 package telemetry
 
 import (
+	"errors"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/reef-pi/reef-pi/controller/settings"
 	"github.com/reef-pi/reef-pi/controller/storage"
 )
+
+type failingMailer struct{}
+
+func (f failingMailer) Email(string, string) error {
+	return errors.New("mail failed")
+}
 
 func TestHealthChecker(t *testing.T) {
 	store, err := storage.TestDB()
@@ -68,4 +76,77 @@ func TestNotifyIfNeeded(t *testing.T) {
 	// Notify disabled — should be no-op even if over threshold
 	checker.Notify.Enable = false
 	checker.NotifyIfNeeded(90, 90, 0)
+}
+
+func TestNotifyIfNeededCPUTemp(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	alerts := 0
+	tele := TestTelemetry(store)
+	tele.logError = func(_, _ string) error {
+		alerts++
+		return nil
+	}
+	checker := NewHealthChecker("reef-pi", time.Second, settings.HealthCheckNotify{
+		Enable:     true,
+		MaxMemory:  100,
+		MaxCPU:     100,
+		MaxCPUTemp: 70,
+	}, tele, store).(*hc)
+
+	checker.NotifyIfNeeded(10, 10, 71)
+	if alerts != 1 {
+		t.Fatalf("expected one CPU temperature alert, got %d", alerts)
+	}
+}
+
+func TestSendReportSuccessAndFailure(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	tele := TestTelemetry(store)
+	checker := &hc{
+		t: tele,
+		lastMetric: HealthMetric{
+			Load5:        1.2,
+			UsedMemory:   45.6,
+			CPUTemp:      67.8,
+			UnderVoltage: 1,
+		},
+	}
+	checker.sendReport()
+
+	tele.dispatcher = failingMailer{}
+	checker.sendReport()
+}
+
+func TestHealthMetricRollupNewHourCarriesNewMetric(t *testing.T) {
+	oldMetric := HealthMetric{
+		Time:       TeleTime(time.Date(2026, 4, 28, 1, 0, 0, 0, time.UTC)),
+		Load5:      1,
+		UsedMemory: 10,
+		len:        1,
+		loadSum:    1,
+		memorySum:  10,
+	}
+	newMetric := HealthMetric{
+		Time:       TeleTime(time.Date(2026, 4, 28, 2, 0, 0, 0, time.UTC)),
+		Load5:      2,
+		UsedMemory: 20,
+	}
+
+	rolled, moved := oldMetric.Rollup(newMetric)
+	if !moved {
+		t.Fatal("expected rollup to move on a new hour")
+	}
+	if rolled.(HealthMetric).Load5 != 2 {
+		t.Fatalf("expected new metric to be returned, got %#v", rolled)
+	}
 }

--- a/controller/telemetry/stats_manager_test.go
+++ b/controller/telemetry/stats_manager_test.go
@@ -210,3 +210,16 @@ func TestStatsManagerUpdateRollupSameHour(t *testing.T) {
 		t.Error("Expected at least one current reading after rollup")
 	}
 }
+
+func TestStatsManagerSaveMissingStats(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	m := newTestMgr(store)
+	if err := m.Save("missing"); err == nil {
+		t.Fatal("expected saving missing stats to fail")
+	}
+}

--- a/controller/telemetry/telemetry_test.go
+++ b/controller/telemetry/telemetry_test.go
@@ -1,9 +1,16 @@
 package telemetry
 
 import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
+	"time"
 
+	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/reef-pi/adafruitio"
 	"github.com/reef-pi/reef-pi/controller/storage"
 )
 
@@ -154,7 +161,6 @@ func TestApplyConfig(t *testing.T) {
 	tele.applyConfig(c)
 }
 
-
 func TestSanitizePrometheusMetricName(t *testing.T) {
 	checks := []struct {
 		input  string
@@ -186,5 +192,184 @@ func TestSanitizePrometheusMetricName(t *testing.T) {
 		if out != c.output {
 			t.Errorf("metric name not sanitized: input '%s', output '%s', expected '%s'", c.input, out, c.output)
 		}
+	}
+}
+
+type fakeMQTTToken struct {
+	err error
+}
+
+func (t fakeMQTTToken) Wait() bool                     { return true }
+func (t fakeMQTTToken) WaitTimeout(time.Duration) bool { return true }
+func (t fakeMQTTToken) Done() <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+func (t fakeMQTTToken) Error() error { return t.err }
+
+type fakeMQTTClient struct {
+	topic    string
+	qos      byte
+	retained bool
+	payload  interface{}
+	err      error
+}
+
+func (c *fakeMQTTClient) IsConnected() bool      { return true }
+func (c *fakeMQTTClient) IsConnectionOpen() bool { return true }
+func (c *fakeMQTTClient) Connect() mqtt.Token    { return fakeMQTTToken{} }
+func (c *fakeMQTTClient) Disconnect(uint)        {}
+func (c *fakeMQTTClient) Subscribe(string, byte, mqtt.MessageHandler) mqtt.Token {
+	return fakeMQTTToken{}
+}
+func (c *fakeMQTTClient) SubscribeMultiple(map[string]byte, mqtt.MessageHandler) mqtt.Token {
+	return fakeMQTTToken{}
+}
+func (c *fakeMQTTClient) Unsubscribe(...string) mqtt.Token        { return fakeMQTTToken{} }
+func (c *fakeMQTTClient) AddRoute(string, mqtt.MessageHandler)    {}
+func (c *fakeMQTTClient) OptionsReader() mqtt.ClientOptionsReader { return mqtt.ClientOptionsReader{} }
+func (c *fakeMQTTClient) Publish(topic string, qos byte, retained bool, payload interface{}) mqtt.Token {
+	c.topic = topic
+	c.qos = qos
+	c.retained = retained
+	c.payload = payload
+	return fakeMQTTToken{err: c.err}
+}
+
+func TestEmitMQTTPublishesWithConfiguredPrefix(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	client := &fakeMQTTClient{}
+	tele := TestTelemetry(store)
+	tele.mClient = &MQTTClient{
+		config: MQTTConfig{
+			Prefix:   "reef",
+			QoS:      1,
+			Retained: true,
+		},
+		client: client,
+	}
+
+	if err := tele.EmitMQTT("system_load5", 2.5); err != nil {
+		t.Fatal(err)
+	}
+	if client.topic != "reef/system_load5" {
+		t.Fatalf("expected prefixed topic, got %q", client.topic)
+	}
+	if client.qos != 1 || !client.retained {
+		t.Fatalf("unexpected publish options: qos=%d retained=%t", client.qos, client.retained)
+	}
+	if client.payload != "2.500000" {
+		t.Fatalf("expected formatted payload, got %#v", client.payload)
+	}
+}
+
+func TestEmitMetricMQTTErrorLogs(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	var logged bool
+	tele := TestTelemetry(store)
+	tele.config.MQTT.Enable = true
+	tele.logError = func(subject, body string) error {
+		logged = subject == "telemtry-mqtt" && strings.Contains(body, "publish failed")
+		return nil
+	}
+	tele.mClient = &MQTTClient{
+		client: &fakeMQTTClient{err: errors.New("publish failed")},
+	}
+
+	tele.EmitMetric("system", "load", 1.2)
+	if !logged {
+		t.Fatal("expected MQTT publish error to be logged")
+	}
+}
+
+type aioRoundTripper struct {
+	statusByMethod map[string]int
+	requests       []*http.Request
+}
+
+func (rt *aioRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.requests = append(rt.requests, req)
+	status := rt.statusByMethod[req.Method]
+	if status == 0 {
+		status = http.StatusOK
+	}
+	body := `{}`
+	if status >= 400 {
+		body = `aio error`
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}, nil
+}
+
+func withAIORoundTripper(t *testing.T, rt http.RoundTripper) {
+	t.Helper()
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = rt
+	t.Cleanup(func() {
+		http.DefaultTransport = oldTransport
+	})
+}
+
+func TestEmitAIO(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	rt := &aioRoundTripper{statusByMethod: map[string]int{http.MethodPost: http.StatusCreated}}
+	withAIORoundTripper(t, rt)
+	tele := TestTelemetry(store)
+	tele.aClient = adafruitio.NewClient("token")
+
+	if err := tele.EmitAIO("reef", "system-load5", 12.3); err != nil {
+		t.Fatal(err)
+	}
+	if len(rt.requests) != 1 || rt.requests[0].URL.Path != "/api/v2/reef/feeds/system-load5/data" {
+		t.Fatalf("unexpected AIO request path: %#v", rt.requests)
+	}
+}
+
+func TestCreateAndDeleteFeedFailurePaths(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	rt := &aioRoundTripper{statusByMethod: map[string]int{
+		http.MethodGet:    http.StatusNotFound,
+		http.MethodPost:   http.StatusInternalServerError,
+		http.MethodDelete: http.StatusInternalServerError,
+	}}
+	withAIORoundTripper(t, rt)
+
+	tele := TestTelemetry(store)
+	tele.config.AdafruitIO = AdafruitIO{Enable: true, User: "reef", Token: "token", Prefix: "tank-"}
+	tele.aClient = adafruitio.NewClient("token")
+
+	tele.CreateFeedIfNotExist("System Load")
+	tele.DeleteFeedIfExist("System Load")
+
+	if len(rt.requests) != 3 {
+		t.Fatalf("expected get, create, and delete requests, got %d", len(rt.requests))
+	}
+	if rt.requests[0].Method != http.MethodGet || rt.requests[1].Method != http.MethodPost || rt.requests[2].Method != http.MethodDelete {
+		t.Fatalf("unexpected request methods: %s %s %s", rt.requests[0].Method, rt.requests[1].Method, rt.requests[2].Method)
 	}
 }

--- a/controller/telemetry/teletime_test.go
+++ b/controller/telemetry/teletime_test.go
@@ -23,4 +23,7 @@ func TestTeleTime(t *testing.T) {
 	if d := t1.Day(); d < 1 || d > 31 {
 		t.Error("Expected valid day, got:", d)
 	}
+	if err := t1.UnmarshalJSON([]byte("\"not-a-time\"")); err == nil {
+		t.Error("expected invalid time to fail")
+	}
 }

--- a/controller/telemetry/vcgencmd_test.go
+++ b/controller/telemetry/vcgencmd_test.go
@@ -2,6 +2,9 @@ package telemetry
 
 import (
 	"context"
+	"errors"
+	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -26,5 +29,89 @@ func TestGetThrottles(t *testing.T) {
 	}
 	if issues[0] != UnderVoltage {
 		t.Errorf("Expected arm frequency capped, found: '%s'", issues[0].String())
+	}
+}
+
+func TestThrottleTypeStringUnknown(t *testing.T) {
+	known := UnderVoltage
+	if known.String() != "under voltage" {
+		t.Fatalf("unexpected known throttle string: %q", known.String())
+	}
+	unknown := ThrottleType(99)
+	if unknown.String() != _unknown {
+		t.Fatalf("expected unknown throttle string, got %q", unknown.String())
+	}
+}
+
+func TestGetThrottledErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  []byte
+		runErr  error
+		wantErr string
+	}{
+		{
+			name:    "runner error",
+			runErr:  errors.New("vcgencmd failed"),
+			wantErr: "vcgencmd failed",
+		},
+		{
+			name:    "bad format",
+			output:  []byte("throttled"),
+			wantErr: "failed to parse output",
+		},
+		{
+			name:    "bad integer",
+			output:  []byte("throttled=nope"),
+			wantErr: "invalid syntax",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory := func(context.Context, string, ...string) Runner {
+				return func() ([]byte, error) {
+					return tt.output, tt.runErr
+				}
+			}
+			_, err := GetThrottled(context.Background(), factory)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestGetThrottledMultipleBits(t *testing.T) {
+	factory := func(context.Context, string, ...string) Runner {
+		return func() ([]byte, error) {
+			return []byte("throttled=0x50005"), nil
+		}
+	}
+	issues, err := GetThrottled(context.Background(), factory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := map[ThrottleType]bool{}
+	for _, issue := range issues {
+		found[issue] = true
+	}
+	for _, expected := range []ThrottleType{UnderVoltage, CurrentlyThrottled, UnderVoltageHasOccurred, ThrottlingHasOccurred} {
+		if !found[expected] {
+			t.Fatalf("expected throttle %s in %#v", expected.String(), issues)
+		}
+	}
+}
+
+func TestExecFactory(t *testing.T) {
+	out, err := ExecFactory(context.Background(), "printf", "ok")()
+	if err != nil {
+		if _, missing := err.(*exec.Error); missing {
+			t.Skip("printf executable not available")
+		}
+		t.Fatal(err)
+	}
+	if string(out) != "ok" {
+		t.Fatalf("expected command output, got %q", string(out))
 	}
 }


### PR DESCRIPTION
## Summary
- add focused telemetry API, health, stats, teletime, vcgencmd, AIO, and MQTT tests
- cover telemetry sanitization, publish/error paths, feed creation/deletion failures, and command parsing behavior

## Coverage
- `./controller/telemetry`: 70.1% -> 74.1% statements with `go test -coverprofile`

## Tests
- `rtk go test ./controller/telemetry`
- `rtk proxy go test -coverprofile=/tmp/telemetry-cover-after.out ./controller/telemetry`
