### PR TITLE
Add system and lighting coverage tests

### DIFF
--- a/controller/modules/lighting/channel_test.go
+++ b/controller/modules/lighting/channel_test.go
@@ -1,0 +1,91 @@
+package lighting
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/reef-pi/reef-pi/controller/pwm_profile"
+)
+
+func TestChannelValueAtManual(t *testing.T) {
+	t.Parallel()
+
+	ch := Channel{
+		Name:   "manual",
+		Manual: true,
+		Value:  42,
+	}
+
+	v, err := ch.ValueAt(time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != 42 {
+		t.Fatalf("expected manual value 42, got %f", v)
+	}
+}
+
+func TestChannelValueAtLoadsProfileAndAppliesBounds(t *testing.T) {
+	t.Parallel()
+
+	ch := Channel{
+		Name: "auto",
+		Min:  10,
+		Max:  100,
+		ProfileSpec: pwm_profile.ProfileSpec{
+			Type:   "loop",
+			Config: []byte(`{"values":[5,120,60]}`),
+		},
+	}
+
+	tests := []float64{0, 100, 60}
+	for i, expected := range tests {
+		v, err := ch.ValueAt(time.Now())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v != expected {
+			t.Fatalf("iteration %d: expected %f, got %f", i, expected, v)
+		}
+	}
+}
+
+func TestChannelValueAtProfileError(t *testing.T) {
+	t.Parallel()
+
+	ch := Channel{
+		Name: "bad-profile",
+		ProfileSpec: pwm_profile.ProfileSpec{
+			Type: "bogus",
+		},
+	}
+
+	if _, err := ch.ValueAt(time.Now()); err == nil {
+		t.Fatal("expected invalid profile to return an error")
+	}
+}
+
+func TestLightLoadChannelsReturnsProfileError(t *testing.T) {
+	t.Parallel()
+
+	l := Light{
+		Name: "bad-light",
+		Channels: map[int]*Channel{
+			1: {
+				Name: "bad-channel",
+				ProfileSpec: pwm_profile.ProfileSpec{
+					Type: "bogus",
+				},
+			},
+		},
+	}
+
+	err := l.LoadChannels()
+	if err == nil {
+		t.Fatal("expected invalid channel profile to fail")
+	}
+	if !strings.Contains(err.Error(), "bad-light") || !strings.Contains(err.Error(), "bad-channel") {
+		t.Fatalf("expected light and channel names in error, got %q", err.Error())
+	}
+}

--- a/controller/modules/system/display_info_test.go
+++ b/controller/modules/system/display_info_test.go
@@ -1,0 +1,76 @@
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDisplayStateReadsFilesAndReportsBrightnessErrors(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	powerFile := filepath.Join(dir, "power")
+	brightnessFile := filepath.Join(dir, "brightness")
+	if err := os.WriteFile(powerFile, []byte("0"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(brightnessFile, []byte("77\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &Controller{
+		PowerFile:      powerFile,
+		BrightnessFile: brightnessFile,
+	}
+	state, err := c.currentDisplayState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !state.On || state.Brightness != 77 {
+		t.Fatalf("unexpected display state: %+v", state)
+	}
+
+	if err := os.WriteFile(brightnessFile, []byte("bad"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.currentDisplayState(); err == nil {
+		t.Fatal("expected invalid brightness file to return an error")
+	}
+}
+
+func TestDisplayFileOperationErrors(t *testing.T) {
+	t.Parallel()
+
+	missingFile := filepath.Join(t.TempDir(), "missing")
+	c := &Controller{
+		PowerFile:      missingFile,
+		BrightnessFile: missingFile,
+	}
+
+	if _, err := c.currentDisplayState(); err == nil {
+		t.Fatal("expected missing power file to return an error")
+	}
+	if _, err := c.getBrightness(); err == nil {
+		t.Fatal("expected missing brightness file to return an error")
+	}
+	c.BrightnessFile = t.TempDir()
+	if err := c.setBrightness(12); err == nil {
+		t.Fatal("expected directory brightness path to return an error")
+	}
+}
+
+func TestCPUTemperatureDevMode(t *testing.T) {
+	t.Parallel()
+
+	c := &Controller{
+		config: Config{DevMode: true},
+	}
+	temp, err := c.CPUTemperature()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if temp != "23.23 " {
+		t.Fatalf("expected dev-mode temperature, got %q", temp)
+	}
+}


### PR DESCRIPTION
## Summary
- add focused tests for lighting channel profile loading, bounds, and error handling
- cover system display info file success/error paths and dev-mode CPU temperature behavior

## Coverage
- `./controller/modules/system ./controller/modules/lighting`: 66.4% -> 73.8% statements

## Tests
- `rtk go test ./controller/modules/system ./controller/modules/lighting -coverprofile=/tmp/reef-pi-system-lighting-after.out`
