### PR TITLE
Add doser module coverage

### DIFF
--- a/controller/modules/doser/api_test.go
+++ b/controller/modules/doser/api_test.go
@@ -70,6 +70,14 @@ func TestDoserAPI(t *testing.T) {
 	if err := tr.Do("GET", "/api/doser/pumps/1", new(bytes.Buffer), nil); err != nil {
 		t.Fatal("Failed to delete get pump using api. Error:", err)
 	}
+	body.Reset()
+	json.NewEncoder(body).Encode(&CalibrationDetails{Duration: 10, Volume: 25})
+	if err := tr.Do("POST", "/api/doser/pumps/1/calibrate/save", body, nil); err != nil {
+		t.Fatal("Failed to save dosing pump calibration using api. Error:", err)
+	}
+	if err := tr.Do("GET", "/api/doser/pumps/1/usage", new(bytes.Buffer), nil); err != nil {
+		t.Fatal("Failed to get dosing pump usage using api. Error:", err)
+	}
 	c.Start()
 	body.Reset()
 	regiment := DosingRegiment{

--- a/controller/modules/doser/pump_test.go
+++ b/controller/modules/doser/pump_test.go
@@ -1,11 +1,13 @@
 package doser
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/reef-pi/reef-pi/controller"
 	"github.com/reef-pi/reef-pi/controller/device_manager/connectors"
 	"github.com/reef-pi/reef-pi/controller/device_manager/drivers"
+	"github.com/reef-pi/reef-pi/controller/storage"
 )
 
 func TestPumpIsValid(t *testing.T) {
@@ -58,6 +60,99 @@ func TestPumpIsValid(t *testing.T) {
 	p = Pump{Name: "P2", Type: "stepper", Regiment: DosingRegiment{Volume: 5}, Stepper: &DRV8825{}}
 	if err := p.IsValid(); err == nil {
 		t.Error("expected error for stepper with invalid stepper config")
+	}
+}
+
+func TestControllerCalibrationAndDependencyPaths(t *testing.T) {
+	con, err := controller.TestController()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer con.Store().Close()
+
+	ctrl, err := New(true, con)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ctrl.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ctrl.GetEntity("1"); err == nil {
+		t.Fatal("expected GetEntity to fail")
+	}
+	if _, err := ctrl.InUse("unknown", "1"); err == nil || !strings.Contains(err.Error(), "unknown deptype") {
+		t.Fatalf("expected unknown dependency type error, got %v", err)
+	}
+
+	p := Pump{
+		Name: "pump-1",
+		Pin:  1,
+		Jack: "jack-1",
+		Regiment: DosingRegiment{
+			Schedule: Schedule{Second: "0", Minute: "*", Hour: "*", Day: "*", Month: "*", Week: "*"},
+		},
+	}
+	if err := ctrl.Create(p); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, err := ctrl.InUse(storage.JackBucket, "jack-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(deps) != 1 || deps[0] != "jack-1" {
+		t.Fatalf("unexpected jack dependencies: %v", deps)
+	}
+
+	if err := ctrl.SaveCalibrationResult("1", CalibrationDetails{Duration: 0, Volume: 5}); err == nil {
+		t.Fatal("expected zero calibration duration to fail")
+	}
+	if err := ctrl.SaveCalibrationResult("1", CalibrationDetails{Duration: 10, Volume: 0}); err == nil {
+		t.Fatal("expected zero calibration volume to fail")
+	}
+	if err := ctrl.SaveCalibrationResult("1", CalibrationDetails{Duration: 10, Volume: 25}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ctrl.Get("1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Regiment.VolumePerSecond != 2.5 {
+		t.Fatalf("expected volume per second 2.5, got %f", got.Regiment.VolumePerSecond)
+	}
+}
+
+func TestControllerOnRejectsEnabledPumpBeforeControl(t *testing.T) {
+	con, err := controller.TestController()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer con.Store().Close()
+
+	ctrl, err := New(true, con)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ctrl.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	p := Pump{
+		Name: "pump-1",
+		Pin:  1,
+		Jack: "missing-jack",
+		Regiment: DosingRegiment{
+			Enable:   true,
+			Schedule: Schedule{Second: "0", Minute: "*", Hour: "*", Day: "*", Month: "*", Week: "*"},
+		},
+	}
+	if err := ctrl.Create(p); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ctrl.On("1", true); err == nil || !strings.Contains(err.Error(), "enabled doser") {
+		t.Fatalf("expected enabled doser On error, got %v", err)
 	}
 }
 

--- a/controller/modules/doser/runner_test.go
+++ b/controller/modules/doser/runner_test.go
@@ -1,10 +1,75 @@
 package doser
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/reef-pi/reef-pi/controller/telemetry"
 )
+
+type fakeDoserStatsManager struct {
+	updates []telemetry.Metric
+	saves   []string
+}
+
+func (f *fakeDoserStatsManager) Get(string) (telemetry.StatsResponse, error) {
+	return telemetry.StatsResponse{}, nil
+}
+
+func (f *fakeDoserStatsManager) IsLoaded(string) bool { return false }
+
+func (f *fakeDoserStatsManager) Initialize(string) error { return nil }
+
+func (f *fakeDoserStatsManager) Load(string, func(json.RawMessage) interface{}) error { return nil }
+
+func (f *fakeDoserStatsManager) Save(id string) error {
+	f.saves = append(f.saves, id)
+	return nil
+}
+
+func (f *fakeDoserStatsManager) Update(_ string, m telemetry.Metric) {
+	f.updates = append(f.updates, m)
+}
+
+func (f *fakeDoserStatsManager) Delete(string) error { return nil }
+
+type fakeDoserTelemetry struct {
+	metrics []struct {
+		module string
+		name   string
+		value  float64
+	}
+}
+
+func (f *fakeDoserTelemetry) Alert(string, string) (bool, error) { return false, nil }
+
+func (f *fakeDoserTelemetry) Mail(string, string) (bool, error) { return false, nil }
+
+func (f *fakeDoserTelemetry) EmitMetric(module, name string, value float64) {
+	f.metrics = append(f.metrics, struct {
+		module string
+		name   string
+		value  float64
+	}{module: module, name: name, value: value})
+}
+
+func (f *fakeDoserTelemetry) CreateFeedIfNotExist(string) {}
+
+func (f *fakeDoserTelemetry) DeleteFeedIfExist(string) {}
+
+func (f *fakeDoserTelemetry) NewStatsManager(string) telemetry.StatsManager { return nil }
+
+func (f *fakeDoserTelemetry) SendTestMessage(http.ResponseWriter, *http.Request) {}
+
+func (f *fakeDoserTelemetry) GetConfig(http.ResponseWriter, *http.Request) {}
+
+func (f *fakeDoserTelemetry) UpdateConfig(http.ResponseWriter, *http.Request) {}
+
+func (f *fakeDoserTelemetry) LogError(string, string) error { return nil }
 
 func TestPumpIsValidRejectsNegativeSoftStart(t *testing.T) {
 	t.Parallel()
@@ -80,5 +145,89 @@ func TestRunnerPWMDoseWithSoftStart(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected PWM ramp sequence: got %v want %v", got, want)
+	}
+}
+
+func TestRunnerRunUsesCalibratedVolumeForPWMDuration(t *testing.T) {
+	stats := &fakeDoserStatsManager{}
+	tel := &fakeDoserTelemetry{}
+	r := &Runner{
+		pump: &Pump{
+			ID:   "pump-1",
+			Name: "alk",
+			Jack: "jack-1",
+			Pin:  3,
+			Regiment: DosingRegiment{
+				Speed:           60,
+				Duration:        99,
+				Volume:          6,
+				VolumePerSecond: 2,
+			},
+		},
+		statsMgr: stats,
+		t:        tel,
+		sleep:    func(time.Duration) {},
+	}
+
+	var got []float64
+	r.control = func(_ string, values map[int]float64) error {
+		got = append(got, values[r.pump.Pin])
+		return nil
+	}
+
+	r.Run()
+
+	if want := []float64{60, 0}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected PWM sequence: got %v want %v", got, want)
+	}
+	if len(stats.updates) != 1 {
+		t.Fatalf("expected one stats update, got %d", len(stats.updates))
+	}
+	if got := stats.updates[0].(Usage).Pump; got != 3 {
+		t.Fatalf("expected calibrated usage duration 3, got %d", got)
+	}
+	if !reflect.DeepEqual(stats.saves, []string{"pump-1"}) {
+		t.Fatalf("unexpected stats saves: %v", stats.saves)
+	}
+	if len(tel.metrics) != 1 {
+		t.Fatalf("expected one emitted metric, got %d", len(tel.metrics))
+	}
+	if metric := tel.metrics[0]; metric.module != "doser" || metric.name != "alk-usage" || metric.value != 3 {
+		t.Fatalf("unexpected emitted metric: %+v", metric)
+	}
+}
+
+func TestRunnerRunSkipsStatsWhenPWMControlFails(t *testing.T) {
+	stats := &fakeDoserStatsManager{}
+	tel := &fakeDoserTelemetry{}
+	r := &Runner{
+		pump: &Pump{
+			ID:   "pump-1",
+			Name: "alk",
+			Jack: "jack-1",
+			Pin:  3,
+			Regiment: DosingRegiment{
+				Speed:    60,
+				Duration: 3,
+			},
+		},
+		statsMgr: stats,
+		t:        tel,
+		sleep:    func(time.Duration) {},
+		control: func(string, map[int]float64) error {
+			return fmt.Errorf("boom")
+		},
+	}
+
+	r.Run()
+
+	if len(stats.updates) != 0 {
+		t.Fatalf("expected no stats updates, got %d", len(stats.updates))
+	}
+	if len(stats.saves) != 0 {
+		t.Fatalf("expected no stats saves, got %d", len(stats.saves))
+	}
+	if len(tel.metrics) != 0 {
+		t.Fatalf("expected no metrics, got %d", len(tel.metrics))
 	}
 }


### PR DESCRIPTION
## Summary
- add doser API tests for calibration save and usage paths
- cover pump calibration persistence validation, entity lookup, in-use checks, and enabled `On` error behavior
- cover `Runner.Run` PWM success and error paths

## Coverage
- `./controller/modules/doser`: 57.5% -> 69.8% statements

## Tests
- `rtk go test ./controller/modules/doser`
- `rtk proxy go test -coverprofile=/tmp/doser-cover-after.out ./controller/modules/doser`

## Notes
- Stepper runtime paths remain a follow-up candidate because they depend on outlet/HAL pin behavior and timing.
