### PR TITLE
Clean up daemon constructor lifecycle

### DIFF
--- a/controller/daemon/reef_pi.go
+++ b/controller/daemon/reef_pi.go
@@ -33,6 +33,17 @@ func New(version, database string) (*ReefPi, error) {
 		log.Println("ERROR: Failed to create store. DB:", database)
 		return nil, fmt.Errorf("create store %q: %w", database, err)
 	}
+
+	return newReefPi(version, store)
+}
+
+func newReefPi(version string, store storage.Store) (r *ReefPi, err error) {
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, store.Close())
+		}
+	}()
+
 	s, err := loadOrInitializeSettings(store)
 	if err != nil {
 		return nil, err
@@ -45,7 +56,7 @@ func New(version, database string) (*ReefPi, error) {
 		return nil, fmt.Errorf("initialize auth: %w", err)
 	}
 
-	r := &ReefPi{
+	r = &ReefPi{
 		store:      store,
 		settings:   s,
 		telemetry:  tele,

--- a/controller/daemon/reef_pi_test.go
+++ b/controller/daemon/reef_pi_test.go
@@ -1,12 +1,90 @@
 package daemon
 
 import (
+	"errors"
+	"strings"
+
 	"github.com/reef-pi/reef-pi/controller/settings"
 	"github.com/reef-pi/reef-pi/controller/storage"
 
 	"net/http"
 	"testing"
 )
+
+type failingStore struct {
+	closed bool
+}
+
+func (s *failingStore) Close() error {
+	s.closed = true
+	return nil
+}
+
+func (s *failingStore) Buckets() ([]string, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *failingStore) CreateBucket(string) error {
+	return errors.New("create bucket failed")
+}
+
+func (s *failingStore) DeleteBucket(string) error {
+	return errors.New("not implemented")
+}
+
+func (s *failingStore) Path() string {
+	return ""
+}
+
+func (s *failingStore) SubBucket(string, string) storage.ObjectStore {
+	return s
+}
+
+func (s *failingStore) RawGet(string, string) ([]byte, error) {
+	return nil, errors.New("get failed")
+}
+
+func (s *failingStore) Get(string, string, interface{}) error {
+	return errors.New("get failed")
+}
+
+func (s *failingStore) List(string, func(string, []byte) error) error {
+	return errors.New("not implemented")
+}
+
+func (s *failingStore) Create(string, func(string) interface{}) error {
+	return errors.New("not implemented")
+}
+
+func (s *failingStore) CreateWithID(string, string, interface{}) error {
+	return errors.New("not implemented")
+}
+
+func (s *failingStore) Update(string, string, interface{}) error {
+	return errors.New("not implemented")
+}
+
+func (s *failingStore) RawUpdate(string, string, []byte) error {
+	return errors.New("not implemented")
+}
+
+func (s *failingStore) Delete(string, string) error {
+	return errors.New("not implemented")
+}
+
+func TestNewReefPiClosesStoreOnInitializationFailure(t *testing.T) {
+	store := &failingStore{}
+	_, err := newReefPi("0.1", store)
+	if err == nil {
+		t.Fatal("expected initialization error")
+	}
+	if !strings.Contains(err.Error(), "initialize default settings") {
+		t.Fatalf("expected settings initialization error, got %v", err)
+	}
+	if !store.closed {
+		t.Fatal("expected store to be closed after initialization failure")
+	}
+}
 
 func TestReefPi(t *testing.T) {
 	http.DefaultServeMux = new(http.ServeMux)


### PR DESCRIPTION
## Summary
- split daemon construction after store creation into a helper that can clean up on later initialization failure
- close the opened store when post-store initialization fails
- add regression coverage for constructor cleanup

## Scope
- Slice 04: backend error, config, and shutdown flow
- No settings schema, startup option, subsystem order, health behavior, or shutdown semantic changes intended

## Tests
- `rtk go test ./controller/daemon`
- `rtk go test ./controller/...`

## Notes
- Local test execution modified `front-end/test/images/thumbnail-01.png` in the worktree; it is unstaged and not part of this PR.
