### PR TITLE
Refactor daemon HTTP API composition

### DIFF
--- a/controller/daemon/api.go
+++ b/controller/daemon/api.go
@@ -26,14 +26,22 @@ func (r *ReefPi) UnAuthenticatedAPI(router *mux.Router) {
 
 // Authenticated API using the BasicAuth middleware
 func (r *ReefPi) AuthenticatedAPI(router *mux.Router) {
+	r.registerCoreAPI(router)
+	r.registerTelemetryAPI(router)
+	r.registerErrorAPI(router)
+	r.registerRuntimeAPI(router)
+	r.dm.LoadAPI(router)
+	r.subsystems.LoadAPI(router)
+	r.registerDashboardAPI(router)
+}
+
+func (r *ReefPi) registerCoreAPI(router *mux.Router) {
 	// swagger:route GET /api/capabilities Capabilities capabilitiesList
 	// List all capabilities.
 	// List all capabilities in reef-pi.
 	// responses:
 	// 	200: body:capabilities
 	router.HandleFunc("/api/capabilities", r.GetCapabilities).Methods("GET")
-
-	r.subsystems.LoadAPI(router)
 
 	// swagger:route GET /api/settings Settings settingsList
 	// List all settings.
@@ -73,7 +81,9 @@ func (r *ReefPi) AuthenticatedAPI(router *mux.Router) {
 	// 200:
 	//  description: OK
 	router.HandleFunc("/api/credentials", r.a.UpdateCredentials).Methods("POST")
+}
 
+func (r *ReefPi) registerTelemetryAPI(router *mux.Router) {
 	// swagger:route GET /api/telemetry Telemetry telemetryGet
 	// List telemetry configuration.
 	// List telemetry configuration.
@@ -103,7 +113,9 @@ func (r *ReefPi) AuthenticatedAPI(router *mux.Router) {
 	// responses:
 	//  200:
 	router.HandleFunc("/api/telemetry/test_message", r.telemetry.SendTestMessage).Methods("POST")
+}
 
+func (r *ReefPi) registerErrorAPI(router *mux.Router) {
 	// swagger:route DELETE /api/errors/clear Errors errorsClear
 	// Clear errors.
 	// Clear errors.
@@ -153,7 +165,9 @@ func (r *ReefPi) AuthenticatedAPI(router *mux.Router) {
 	// responses:
 	// 	200: body:[]error
 	router.HandleFunc("/api/errors", r.listErrors).Methods("GET")
+}
 
+func (r *ReefPi) registerRuntimeAPI(router *mux.Router) {
 	// swagger:route GET /api/me Me meGet
 	// Ping API.
 	// Ping API to determine if server is running.
@@ -168,33 +182,35 @@ func (r *ReefPi) AuthenticatedAPI(router *mux.Router) {
 	if r.h != nil {
 		router.HandleFunc("/api/health_stats", r.h.GetStats).Methods("GET")
 	}
-	r.dm.LoadAPI(router)
-	r.subsystems.LoadAPI(router)
-	if r.settings.Capabilities.Dashboard {
+}
 
-		// swagger:route GET /api/dashboard Dashboard dashboardGet
-		// Get dashboard.
-		// Get dashboard.
-		// responses:
-		// 	200: body:dashboard
-		router.HandleFunc("/api/dashboard", r.GetDashboard).Methods("GET")
-
-		// swagger:operation POST /api/dashboard Dashboard dashboardUpdate
-		// Update dasboard configuration.
-		// Update dasboard configuration.
-		//---
-		//parameters:
-		// - in: body
-		//   name: dashboardConfiguration
-		//   description: The dashboard configuration
-		//   required: true
-		//   schema:
-		//    $ref: '#/definitions/dashboard'
-		//responses:
-		// 200:
-		//  description: OK
-		router.HandleFunc("/api/dashboard", r.UpdateDashboard).Methods("POST")
+func (r *ReefPi) registerDashboardAPI(router *mux.Router) {
+	if !r.settings.Capabilities.Dashboard {
+		return
 	}
+
+	// swagger:route GET /api/dashboard Dashboard dashboardGet
+	// Get dashboard.
+	// Get dashboard.
+	// responses:
+	// 	200: body:dashboard
+	router.HandleFunc("/api/dashboard", r.GetDashboard).Methods("GET")
+
+	// swagger:operation POST /api/dashboard Dashboard dashboardUpdate
+	// Update dasboard configuration.
+	// Update dasboard configuration.
+	//---
+	//parameters:
+	// - in: body
+	//   name: dashboardConfiguration
+	//   description: The dashboard configuration
+	//   required: true
+	//   schema:
+	//    $ref: '#/definitions/dashboard'
+	//responses:
+	// 200:
+	//  description: OK
+	router.HandleFunc("/api/dashboard", r.UpdateDashboard).Methods("POST")
 }
 
 func (r *ReefPi) serverHandler() http.Handler {
@@ -220,9 +236,6 @@ func (r *ReefPi) serverHandler() http.Handler {
 	r.AuthenticatedAPI(apiRouter)
 	root.PathPrefix("/api/").Handler(r.a.Authenticate(apiRouter.ServeHTTP))
 
-	if r.h != nil {
-		apiRouter.HandleFunc("/api/health_stats", r.h.GetStats).Methods("GET")
-	}
 	if r.settings.Prometheus {
 		r.prometheus(root)
 	}

--- a/controller/daemon/api_test.go
+++ b/controller/daemon/api_test.go
@@ -3,14 +3,160 @@ package daemon
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/gorilla/mux"
+
+	"github.com/reef-pi/reef-pi/controller"
+	"github.com/reef-pi/reef-pi/controller/device_manager"
 	"github.com/reef-pi/reef-pi/controller/settings"
 	"github.com/reef-pi/reef-pi/controller/storage"
 	"github.com/reef-pi/reef-pi/controller/telemetry"
 	"github.com/reef-pi/reef-pi/controller/utils"
 )
+
+type apiLoadCountingSubsystem struct {
+	loadCount int
+}
+
+func (s *apiLoadCountingSubsystem) Setup() error          { return nil }
+func (s *apiLoadCountingSubsystem) LoadAPI(r *mux.Router) { s.loadCount++ }
+func (s *apiLoadCountingSubsystem) Start()                {}
+func (s *apiLoadCountingSubsystem) Stop()                 {}
+func (s *apiLoadCountingSubsystem) On(string, bool) error { return nil }
+func (s *apiLoadCountingSubsystem) InUse(string, string) ([]string, error) {
+	return nil, nil
+}
+func (s *apiLoadCountingSubsystem) GetEntity(string) (controller.Entity, error) {
+	return nil, nil
+}
+
+func newHTTPCompositionTestReefPi(t *testing.T) *ReefPi {
+	t.Helper()
+
+	store, err := storage.NewStore(filepath.Join(t.TempDir(), "reef-pi.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	if err := store.CreateBucket(Bucket); err != nil {
+		t.Fatal(err)
+	}
+
+	tele := telemetry.TestTelemetry(store)
+	auth, err := utils.NewAuth(Bucket, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := settings.DefaultSettings
+	return &ReefPi{
+		a:          auth,
+		store:      store,
+		settings:   s,
+		telemetry:  tele,
+		dm:         device_manager.New(s, store, tele),
+		subsystems: controller.NewSubsystemComposite(),
+	}
+}
+
+func TestAuthenticatedAPILoadsSubsystemRoutesOnce(t *testing.T) {
+	r := newHTTPCompositionTestReefPi(t)
+	subsystem := &apiLoadCountingSubsystem{}
+	r.subsystems.Load("test-subsystem", subsystem)
+
+	r.AuthenticatedAPI(mux.NewRouter())
+
+	if subsystem.loadCount != 1 {
+		t.Fatalf("expected subsystem API to load once, got %d", subsystem.loadCount)
+	}
+}
+
+func TestServerHandlerComposesStaticAuthCORSAndPrometheus(t *testing.T) {
+	r := newHTTPCompositionTestReefPi(t)
+	r.settings.CORS = true
+	r.settings.Prometheus = true
+
+	root := t.TempDir()
+	for _, dir := range []string{"ui/assets", "images"} {
+		if err := os.MkdirAll(filepath.Join(root, dir), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	files := map[string]string{
+		"ui/home.html":     "home",
+		"ui/favicon.ico":   "icon",
+		"ui/assets/app.js": "asset",
+		"images/test.txt":  "image",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Error(err)
+		}
+	})
+
+	handler := r.serverHandler()
+	assertHTTPStatus(t, handler, "GET", "/", nil, http.StatusOK)
+	assertHTTPStatus(t, handler, "GET", "/assets/app.js", nil, http.StatusOK)
+	assertHTTPStatus(t, handler, "GET", "/images/test.txt", nil, http.StatusOK)
+	assertHTTPStatus(t, handler, "GET", "/api/me", nil, http.StatusUnauthorized)
+	assertHTTPStatus(t, handler, "GET", "/x/metrics", nil, http.StatusOK)
+
+	signInBody := bytes.NewBufferString(`{"user":"reef-pi","password":"reef-pi"}`)
+	signIn := httptest.NewRecorder()
+	handler.ServeHTTP(signIn, httptest.NewRequest("POST", "/auth/signin", signInBody))
+	if signIn.Code != http.StatusOK {
+		t.Fatalf("expected signin status %d, got %d: %s", http.StatusOK, signIn.Code, signIn.Body.String())
+	}
+
+	meRequest := httptest.NewRequest("GET", "/api/me", nil)
+	for _, cookie := range signIn.Result().Cookies() {
+		meRequest.AddCookie(cookie)
+	}
+	me := httptest.NewRecorder()
+	handler.ServeHTTP(me, meRequest)
+	if me.Code != http.StatusOK {
+		t.Fatalf("expected authenticated API status %d, got %d: %s", http.StatusOK, me.Code, me.Body.String())
+	}
+	if got := me.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Fatalf("expected CORS origin header '*', got %q", got)
+	}
+}
+
+func assertHTTPStatus(t *testing.T, handler http.Handler, method, path string, body *bytes.Buffer, expected int) {
+	t.Helper()
+
+	var requestBody *bytes.Buffer
+	if body == nil {
+		requestBody = new(bytes.Buffer)
+	} else {
+		requestBody = body
+	}
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(method, path, requestBody))
+	if response.Code != expected {
+		t.Fatalf("expected %s %s status %d, got %d: %s", method, path, expected, response.Code, response.Body.String())
+	}
+}
 
 func TestAPI(t *testing.T) {
 	const dbFile = "api-test.db"


### PR DESCRIPTION
## Summary
- split daemon HTTP composition into smaller route registration helpers
- remove duplicate subsystem API registration and redundant health route registration
- add coverage for static files, unauthenticated auth routes, authenticated API access, CORS, Prometheus, and single subsystem API loading

## Scope
- Slice 03: backend startup and HTTP composition
- No API path, auth, static asset, CORS, or Prometheus behavior changes intended

## Tests
- `rtk go test ./controller/daemon`
- `rtk go test ./controller/...`
- `rtk git diff --check`

## Notes
- Local test execution modified `front-end/test/images/thumbnail-01.png` in the worktree; it is unstaged and not part of this PR.
