### PR TITLE
Refactor alert dispatch ownership

### DIFF
--- a/front-end/src/entry.js
+++ b/front-end/src/entry.js
@@ -2,9 +2,11 @@ import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { Provider } from 'react-redux'
 import { configureStore, setStore } from 'redux/store'
+import { setAlertDispatcher } from 'utils/alert'
 import App from 'app'
 
 const store = setStore(configureStore())
+setAlertDispatcher(store.dispatch)
 const root = createRoot(document.getElementById('main-panel'))
 
 root.render(

--- a/front-end/src/redux/store.js
+++ b/front-end/src/redux/store.js
@@ -15,8 +15,5 @@ export const setStore = (store) => {
 }
 
 export const getStore = () => {
-  if (!appStore) {
-    appStore = configureStore()
-  }
   return appStore
 }

--- a/front-end/src/redux/store.test.js
+++ b/front-end/src/redux/store.test.js
@@ -1,0 +1,19 @@
+describe('redux store ownership', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  it('does not create a store before one is registered', () => {
+    const { getStore } = require('./store')
+
+    expect(getStore()).toBeUndefined()
+  })
+
+  it('returns the registered store', () => {
+    const { getStore, setStore } = require('./store')
+    const store = { dispatch: jest.fn(), getState: jest.fn() }
+
+    expect(setStore(store)).toBe(store)
+    expect(getStore()).toBe(store)
+  })
+})

--- a/front-end/src/utils/alert.js
+++ b/front-end/src/utils/alert.js
@@ -1,8 +1,18 @@
-import { getStore } from 'redux/store'
 import { setAlert } from 'notifications/statics'
 import { addAlert, delAlert } from 'redux/actions/alert'
 import { MsgLevel } from 'utils/enums'
 import i18n from 'utils/i18n'
+
+let dispatchAlertAction
+
+export function setAlertDispatcher (dispatch) {
+  dispatchAlertAction = dispatch
+  return dispatchAlertAction
+}
+
+export function clearAlertDispatcher () {
+  dispatchAlertAction = undefined
+}
 
 export function showInfo (msg) {
   _showAlert(MsgLevel.info, msg)
@@ -20,13 +30,18 @@ export function showUpdateSuccessful () {
   const alert = _showAlert(MsgLevel.success, i18n.t('save_successful'))
   setTimeout(() => {
     // only show alert for a second to not block page content
-    getStore().dispatch(delAlert(alert))
+    _dispatchAlert(delAlert(alert))
   }, 1000)
 }
 function _showAlert (type, msg) {
   const alert = setAlert(type, msg)
-  getStore().dispatch(addAlert(alert))
+  _dispatchAlert(addAlert(alert))
   return alert
+}
+function _dispatchAlert (action) {
+  if (dispatchAlertAction) {
+    dispatchAlertAction(action)
+  }
 }
 export function showAlert (msg) {
   console.warn('showAlert is deprecated. Please Use showError')

--- a/front-end/src/utils/alert.test.js
+++ b/front-end/src/utils/alert.test.js
@@ -1,49 +1,60 @@
-import { showInfo, showError, showSuccess, showWarning, showUpdateSuccessful, showAlert, clearAlert } from './alert'
-import * as store from 'redux/store'
-
-jest.mock('redux/store', () => ({
-  getStore: jest.fn(() => ({
-    dispatch: jest.fn()
-  }))
-}))
+import {
+  showInfo,
+  showError,
+  showSuccess,
+  showWarning,
+  showUpdateSuccessful,
+  showAlert,
+  clearAlert,
+  setAlertDispatcher,
+  clearAlertDispatcher
+} from './alert'
 
 describe('alert utils', () => {
+  let dispatch
+
   beforeEach(() => {
-    store.getStore.mockReturnValue({ dispatch: jest.fn() })
+    dispatch = jest.fn()
+    setAlertDispatcher(dispatch)
     jest.useFakeTimers()
   })
 
   afterEach(() => {
+    clearAlertDispatcher()
     jest.useRealTimers()
   })
 
   it('showInfo dispatches an action', () => {
     expect(() => showInfo('test info')).not.toThrow()
-    expect(store.getStore).toHaveBeenCalled()
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'ALERT_ADDED' }))
   })
 
   it('showError dispatches an action', () => {
     expect(() => showError('test error')).not.toThrow()
-    expect(store.getStore).toHaveBeenCalled()
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'ALERT_ADDED' }))
   })
 
   it('showSuccess dispatches an action', () => {
     expect(() => showSuccess('test success')).not.toThrow()
-    expect(store.getStore).toHaveBeenCalled()
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'ALERT_ADDED' }))
   })
 
   it('showWarning dispatches an action', () => {
     expect(() => showWarning('test warning')).not.toThrow()
-    expect(store.getStore).toHaveBeenCalled()
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'ALERT_ADDED' }))
   })
 
   it('showUpdateSuccessful dispatches and auto-dismisses', () => {
-    const dispatch = jest.fn()
-    store.getStore.mockReturnValue({ dispatch })
     showUpdateSuccessful()
     expect(dispatch).toHaveBeenCalledTimes(1)
     jest.runAllTimers()
     expect(dispatch).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not create or require a store when no dispatcher is registered', () => {
+    clearAlertDispatcher()
+    expect(() => showError('test error')).not.toThrow()
+    expect(dispatch).not.toHaveBeenCalled()
   })
 
   it('showAlert logs deprecation warning and calls showError', () => {


### PR DESCRIPTION
## Summary
- remove lazy global store creation from alert utilities
- register the app Redux dispatch during entry setup
- keep existing alert utility caller APIs intact
- add store and alert regression tests

## Scope
- Slice 07: Redux store ownership
- No visible alert behavior changes intended

## Tests
- `rtk yarn jest front-end/src/utils/alert.test.js front-end/src/notifications/alert.test.js front-end/src/notifications/notifications.test.js front-end/src/redux/reducer.test.js front-end/src/redux/store.test.js`
- `rtk yarn standard`
