### PR TITLE
Clarify frontend API error flow

### DIFF
--- a/front-end/src/utils/ajax.js
+++ b/front-end/src/utils/ajax.js
@@ -1,5 +1,7 @@
 import { showError } from 'utils/alert'
 
+const handledError = Symbol('handledError')
+
 function makeHeaders () {
   const headers = new Headers()
   headers.append('Content-Type', 'application/json')
@@ -30,31 +32,34 @@ function buildRequestOptions (params) {
 function handleErrorResponse (response, params) {
   if (response.status === 401) {
     showError('Authentication failure')
-    return
+    return Promise.resolve(handledError)
   }
   if (params.suppressError) {
-    return response
+    return Promise.resolve(handledError)
   }
 
-  response.text().then(err => {
+  return response.text().then(err => {
     if (params.failure) {
       params.failure(response)
-      return
+      return handledError
     }
     showError(err + ' | HTTP ' + response.status)
+    return handledError
   })
-
-  return response
 }
 
 function parseResponse (response, params) {
-  if (response === undefined) {
-    return Promise.resolve(undefined)
-  }
   if (!params.parseJSON) {
     return Promise.resolve(response)
   }
   return response.json()
+}
+
+function dispatchSuccess (data, params, dispatch) {
+  if (data === handledError) {
+    return undefined
+  }
+  return dispatch(params.success(data))
 }
 
 function request (params, dispatch) {
@@ -63,10 +68,9 @@ function request (params, dispatch) {
       if (!response.ok) {
         return handleErrorResponse(response, params)
       }
-      return response
+      return parseResponse(response, params)
     })
-    .then(response => parseResponse(response, params))
-    .then(data => dispatch(params.success(data)))
+    .then(data => dispatchSuccess(data, params, dispatch))
     .catch(() => {
       dispatch({ type: 'API_FAILURE', params })
     })

--- a/front-end/src/utils/ajax.test.js
+++ b/front-end/src/utils/ajax.test.js
@@ -1,104 +1,141 @@
 import { reduxGet, reduxDelete, reduxPut, reduxPost } from './ajax'
+import { showError } from 'utils/alert'
 import 'isomorphic-fetch'
 
-const fecthOK = jest.fn().mockImplementation(() => {
-  let p = new Promise(resolve => {
-    resolve({
-      ok: true,
-      status: 200,
-      text: () => {
-        return new Promise(resolve => {
-          resolve(true)
-        })
-      },
-      json: () => {
-        return new Promise(resolve => {
-          resolve(true)
-        })
-      }
-    })
-  })
-  return p
+jest.mock('utils/alert', () => ({
+  showError: jest.fn()
+}))
+
+const response = ({ ok = true, status = 200, body = { ok: true }, text = 'boom' } = {}) => ({
+  ok,
+  status,
+  text: jest.fn(() => Promise.resolve(text)),
+  json: jest.fn(() => Promise.resolve(body))
 })
-const fetch401 = jest.fn().mockImplementation(() => {
-  let p = new Promise(resolve => {
-    resolve({
-      ok: false,
-      status: 401,
-      text: () => {
-        return new Promise(resolve => {
-          resolve(true)
-        })
-      },
-      json: () => {
-        return new Promise(resolve => {
-          resolve(true)
-        })
-      }
-    })
-  })
-  return p
+
+const success = data => ({
+  type: 'API_SUCCESS',
+  payload: data
 })
-const fetch500 = jest.fn().mockImplementation(() => {
-  let p = new Promise(resolve => {
-    resolve({
-      ok: false,
-      status: 500,
-      text: () => {
-        return new Promise(resolve => {
-          resolve(true)
-        })
-      },
-      json: () => {
-        return new Promise(resolve => {
-          resolve(true)
-        })
-      }
-    })
-  })
-  return p
-})
-const dispatch = () => {
-  return true
-}
+
 describe('Ajax', () => {
+  let dispatch
+
   beforeEach(() => {
-    global.fetch = fecthOK
+    dispatch = jest.fn(action => action)
+    global.fetch = jest.fn()
+    showError.mockClear()
   })
-  it('reduxGet', () => {
-    reduxGet({ url: '/foo', data: {} })(dispatch)
-    global.fetch = fetch401
-    reduxGet({ url: '/foo', data: {} })(dispatch)
-    global.fetch = fetch500
-    reduxGet({ url: '/foo', data: {} })(dispatch)
-    reduxGet({ url: '/foo', data: {}, suppressError: true })(dispatch)
-    reduxGet({ url: '/foo', data: {}, suppressError: false })(dispatch)
+
+  it('reduxGet parses JSON responses before dispatching success', () => {
+    global.fetch.mockResolvedValue(response({ body: { name: 'reef-pi' } }))
+
+    return reduxGet({ url: '/foo', success })(dispatch).then(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/foo', {
+        method: 'GET',
+        credentials: 'same-origin',
+        headers: expect.any(Headers)
+      })
+      expect(dispatch).toHaveBeenCalledWith(success({ name: 'reef-pi' }))
+    })
   })
-  it('reduxDelete', () => {
-    reduxDelete({ url: '/foo', data: {} })(dispatch)
-    global.fetch = fetch401
-    reduxDelete({ url: '/foo', data: {} })(dispatch)
-    global.fetch = fetch500
-    reduxDelete({ url: '/foo', data: {} })(dispatch)
-    reduxDelete({ url: '/foo', data: {}, suppressError: true })(dispatch)
-    reduxDelete({ url: '/foo', data: {}, suppressError: false })(dispatch)
+
+  it('reduxDelete dispatches the raw response by default', () => {
+    const res = response()
+    global.fetch.mockResolvedValue(res)
+
+    return reduxDelete({ url: '/foo', success })(dispatch).then(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/foo', {
+        method: 'DELETE',
+        credentials: 'same-origin',
+        headers: expect.any(Headers)
+      })
+      expect(dispatch).toHaveBeenCalledWith(success(res))
+    })
   })
-  it('reduxPut ', () => {
-    reduxPut({ url: '/foo', data: {} })(dispatch)
-    global.fetch = fetch401
-    reduxPut({ url: '/foo', data: {} })(dispatch)
-    global.fetch = fetch500
-    reduxPut({ url: '/foo', data: {} })(dispatch)
-    reduxPut({ url: '/foo', data: {}, suppressError: true })(dispatch)
-    reduxPut({ url: '/foo', data: {}, suppressError: false })(dispatch)
+
+  it('reduxPut serializes data and dispatches the raw response by default', () => {
+    const res = response()
+    global.fetch.mockResolvedValue(res)
+
+    return reduxPut({ url: '/foo', data: { name: 'reef-pi' }, success })(dispatch).then(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/foo', {
+        method: 'PUT',
+        credentials: 'same-origin',
+        headers: expect.any(Headers),
+        body: JSON.stringify({ name: 'reef-pi' })
+      })
+      expect(dispatch).toHaveBeenCalledWith(success(res))
+    })
   })
-  it('reduxPost ', () => {
-    reduxPost({ url: '/foo', data: {} })(dispatch)
-    global.fetch = fetch401
-    reduxPost({ url: '/foo', data: {} })(dispatch)
-    global.fetch = fetch500
-    reduxPost({ url: '/foo', data: {} })(dispatch)
-    reduxPost({ url: '/foo', data: {}, suppressError: true })(dispatch)
-    reduxPost({ url: '/foo', data: {}, suppressError: false })(dispatch)
+
+  it('reduxPost sends raw bodies without JSON headers', () => {
+    const res = response()
+    const raw = new FormData()
+    global.fetch.mockResolvedValue(res)
+
+    return reduxPost({ url: '/foo', raw, success })(dispatch).then(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/foo', {
+        method: 'POST',
+        credentials: 'same-origin',
+        body: raw
+      })
+      expect(dispatch).toHaveBeenCalledWith(success(res))
+    })
+  })
+
+  it('shows authentication failures and skips success dispatch', () => {
+    global.fetch.mockResolvedValue(response({ ok: false, status: 401 }))
+
+    return reduxGet({ url: '/foo', success })(dispatch).then(() => {
+      expect(showError).toHaveBeenCalledWith('Authentication failure')
+      expect(dispatch).not.toHaveBeenCalled()
+    })
+  })
+
+  it('shows HTTP errors and skips success dispatch', () => {
+    global.fetch.mockResolvedValue(response({ ok: false, status: 500, text: 'failed' }))
+
+    return reduxPost({ url: '/foo', data: {}, success })(dispatch).then(() => {
+      expect(showError).toHaveBeenCalledWith('failed | HTTP 500')
+      expect(dispatch).not.toHaveBeenCalled()
+    })
+  })
+
+  it('calls failure callbacks for HTTP errors instead of showing an alert', () => {
+    const failure = jest.fn()
+    const res = response({ ok: false, status: 500 })
+    global.fetch.mockResolvedValue(res)
+
+    return reduxPost({ url: '/foo', data: {}, success, failure })(dispatch).then(() => {
+      expect(failure).toHaveBeenCalledWith(res)
+      expect(showError).not.toHaveBeenCalled()
+      expect(dispatch).not.toHaveBeenCalled()
+    })
+  })
+
+  it('suppresses HTTP error alerts and skips success dispatch', () => {
+    global.fetch.mockResolvedValue(response({ ok: false, status: 500 }))
+
+    return reduxGet({ url: '/foo', success, suppressError: true })(dispatch).then(() => {
+      expect(showError).not.toHaveBeenCalled()
+      expect(dispatch).not.toHaveBeenCalled()
+    })
+  })
+
+  it('dispatches API_FAILURE when fetch rejects', () => {
+    global.fetch.mockRejectedValue(new Error('offline'))
+
+    return reduxGet({ url: '/foo', success })(dispatch).then(() => {
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'API_FAILURE',
+        params: {
+          url: '/foo',
+          success,
+          method: 'GET',
+          parseJSON: true
+        }
+      })
+    })
   })
 })


### PR DESCRIPTION
## Summary
- make frontend API error handling use an explicit handled-error sentinel
- prevent non-OK responses from falling through to success dispatch
- preserve auth failure alert text, suppressError behavior, failure callbacks, JSON parsing, and network rejection handling

## Scope
- Slice 08: unified frontend API request behavior
- Public redux request helper APIs are preserved

## Tests
- `rtk yarn jest front-end/src/utils/ajax.test.js --runInBand`
- `rtk yarn jest front-end/src/redux/actions --runInBand`
- `rtk yarn standard`
