### PR TITLE
Refactor app shell routes

### DIFF
--- a/front-end/src/main_panel.jsx
+++ b/front-end/src/main_panel.jsx
@@ -1,58 +1,22 @@
 import React from 'react'
-import { BrowserRouter, Route, Routes, NavLink, useLocation } from 'react-router-dom'
-import Ato from 'ato/main'
-import Camera from 'camera/main'
-import Equipment from 'equipment/main'
+import { BrowserRouter, Routes, NavLink, useLocation } from 'react-router-dom'
 import NotificationAlert from 'notifications/alert'
-import Lighting from 'lighting/main'
-import Configuration from 'configuration/main'
-import Temperature from 'temperature/main'
-import Timers from 'timers/main'
-import Doser from 'doser/main'
-import Ph from 'ph/main'
-import Macro from 'macro/main'
-import Dashboard from 'dashboard/main'
 import { fetchUIData } from 'redux/actions/ui'
 import { fetchInfo } from 'redux/actions/info'
 import { connect } from 'react-redux'
 import Summary from 'summary'
 import FatalError from './fatal_error'
 import ErrorBoundary from './ui_components/error_boundary'
-import i18n from 'utils/i18n'
-import Instances from 'instances/main'
-import Journal from 'journal/main'
-
-const routes = [
-  { key: 'dashboard', index: true, path: '', element: <Dashboard />, label: i18n.t('capabilities:dashboard') },
-  { key: 'equipment', path: '/equipment', element: <Equipment />, label: i18n.t('capabilities:equipment') },
-  { key: 'timers', path: '/timers', element: <Timers />, label: i18n.t('capabilities:timers') },
-  { key: 'lighting', path: '/lighting', element: <Lighting />, label: i18n.t('capabilities:lights') },
-  { key: 'temperature', path: '/temperature', element: <Temperature />, label: i18n.t('capabilities:temperature') },
-  { key: 'ato', path: '/ato', element: <Ato />, label: i18n.t('capabilities:ato') },
-  { key: 'ph', path: '/ph', element: <Ph />, label: i18n.t('capabilities:ph') },
-  { key: 'doser', path: '/doser', element: <Doser />, label: i18n.t('capabilities:dosing_pumps') },
-  { key: 'macro', path: '/macro', element: <Macro />, label: i18n.t('capabilities:macros') },
-  { key: 'camera', path: '/camera', element: <Camera />, label: i18n.t('capabilities:camera') },
-  { key: 'manager', path: '/manager', element: <Instances />, label: i18n.t('capabilities:manager') },
-  { key: 'journal', path: '/journal', element: <Journal />, label: i18n.t('capabilities:journal') },
-  { key: 'configuration', path: '/configuration/*', element: <Configuration />, label: i18n.t('capabilities:configuration') }
-]
-
-const routeElements = routes.map(route => (
-  <Route key={route.key} index={route.index} path={route.path} element={route.element} />
-))
-
-const routeMatchesLocation = (route, pathname) => {
-  if (route.index) {
-    return pathname === '/'
-  }
-  const basePath = route.path.replace('/*', '')
-  return pathname === basePath || pathname.startsWith(basePath + '/')
-}
+import {
+  currentRouteForPath,
+  mainPanelRouteElements,
+  navigationRoutes,
+  routeNavigationPath
+} from './main_panel_routes'
 
 function CurrentPageHeader () {
   const location = useLocation()
-  const route = routes.find(r => routeMatchesLocation(r, location.pathname))
+  const route = currentRouteForPath(location.pathname)
   const label = route ? route.label : location.pathname.slice(1)
   return <span>{label}</span>
 }
@@ -68,15 +32,13 @@ export class RawMainPanel extends React.Component {
   }
 
   navs (currentCaps) {
-    const panels = routes
-      .filter(route => currentCaps[route.key] !== undefined && currentCaps[route.key])
-      .map(route => (
-        <li className='nav-item' key={'li-tab-' + route.key}>
-          <NavLink to={route.path || ''} id={'tab-' + route.key} data-testid={'smoke-tab-' + route.key} className='nav-link'>
-            {route.label}
-          </NavLink>
-        </li>
-      ))
+    const panels = navigationRoutes(currentCaps).map(route => (
+      <li className='nav-item' key={'li-tab-' + route.key}>
+        <NavLink to={routeNavigationPath(route)} id={'tab-' + route.key} data-testid={'smoke-tab-' + route.key} className='nav-link'>
+          {route.label}
+        </NavLink>
+      </li>
+    ))
     return (
       <ul className='navbar-nav'>{panels}</ul>
     )
@@ -119,7 +81,7 @@ export class RawMainPanel extends React.Component {
               <div className='col'>
                 <ErrorBoundary>
                   <Routes>
-                    {routeElements}
+                    {mainPanelRouteElements}
                   </Routes>
                 </ErrorBoundary>
               </div>

--- a/front-end/src/main_panel.test.js
+++ b/front-end/src/main_panel.test.js
@@ -1,5 +1,12 @@
 import React from 'react'
 import MainPanel, { RawMainPanel } from './main_panel'
+import {
+  currentRouteForPath,
+  mainPanelRoutes,
+  navigationRoutes,
+  routeMatchesLocation,
+  routeNavigationPath
+} from './main_panel_routes'
 import 'isomorphic-fetch'
 
 const countByType = (node, predicate) => {
@@ -11,6 +18,17 @@ const countByType = (node, predicate) => {
     count += countByType(child, predicate)
   })
   return count
+}
+
+const findAll = (node, predicate) => {
+  if (!node || typeof node !== 'object') {
+    return []
+  }
+  const matches = predicate(node) ? [node] : []
+  React.Children.toArray(node.props?.children).forEach(child => {
+    matches.push(...findAll(child, predicate))
+  })
+  return matches
 }
 
 describe('MainPanel', () => {
@@ -37,5 +55,78 @@ describe('MainPanel', () => {
     expect(() => panel.render()).not.toThrow()
     expect(MainPanel).toBeDefined()
     expect(countByType(panel.render(), node => node.type === 'nav')).toBeGreaterThan(0)
+  })
+
+  it('keeps route metadata order and paths stable', () => {
+    expect(mainPanelRoutes.map(route => [route.key, route.path])).toEqual([
+      ['dashboard', ''],
+      ['equipment', '/equipment'],
+      ['timers', '/timers'],
+      ['lighting', '/lighting'],
+      ['temperature', '/temperature'],
+      ['ato', '/ato'],
+      ['ph', '/ph'],
+      ['doser', '/doser'],
+      ['macro', '/macro'],
+      ['camera', '/camera'],
+      ['manager', '/manager'],
+      ['journal', '/journal'],
+      ['configuration', '/configuration/*']
+    ])
+  })
+
+  it('filters navigation routes with the existing capability gate', () => {
+    const routes = navigationRoutes({
+      dashboard: true,
+      equipment: false,
+      timers: 1,
+      lighting: 0,
+      temperature: undefined,
+      configuration: true,
+      dev_mode: true
+    })
+
+    expect(routes.map(route => route.key)).toEqual(['dashboard', 'timers', 'configuration'])
+  })
+
+  it('renders nav links with preserved ids, test ids, and paths', () => {
+    const panel = new RawMainPanel({
+      info: { name: 'reef-pi' },
+      errors: [],
+      capabilities: {},
+      fetchUIData: jest.fn(),
+      fetchInfo: jest.fn()
+    })
+
+    const nav = panel.navs({
+      dashboard: true,
+      timers: true,
+      configuration: true
+    })
+    const links = findAll(nav, node => node.props?.className === 'nav-link')
+
+    expect(links.map(link => link.props.id)).toEqual(['tab-dashboard', 'tab-timers', 'tab-configuration'])
+    expect(links.map(link => link.props['data-testid'])).toEqual(['smoke-tab-dashboard', 'smoke-tab-timers', 'smoke-tab-configuration'])
+    expect(links.map(link => link.props.to)).toEqual(['', '/timers', '/configuration/*'])
+  })
+
+  it('matches current page routes including nested configuration pages', () => {
+    const dashboard = mainPanelRoutes.find(route => route.key === 'dashboard')
+    const configuration = mainPanelRoutes.find(route => route.key === 'configuration')
+    const equipment = mainPanelRoutes.find(route => route.key === 'equipment')
+
+    expect(routeMatchesLocation(dashboard, '/')).toBe(true)
+    expect(routeMatchesLocation(dashboard, '/dashboard')).toBe(false)
+    expect(routeMatchesLocation(configuration, '/configuration')).toBe(true)
+    expect(routeMatchesLocation(configuration, '/configuration/errors')).toBe(true)
+    expect(routeMatchesLocation(equipment, '/equipment/1')).toBe(true)
+    expect(routeMatchesLocation(equipment, '/equipmentish')).toBe(false)
+    expect(currentRouteForPath('/configuration/errors').key).toBe('configuration')
+    expect(currentRouteForPath('/missing')).toBeUndefined()
+  })
+
+  it('normalizes only dashboard navigation to the empty path', () => {
+    expect(routeNavigationPath(mainPanelRoutes[0])).toBe('')
+    expect(routeNavigationPath(mainPanelRoutes[12])).toBe('/configuration/*')
   })
 })

--- a/front-end/src/main_panel_routes.jsx
+++ b/front-end/src/main_panel_routes.jsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { Route } from 'react-router-dom'
+import Ato from 'ato/main'
+import Camera from 'camera/main'
+import Equipment from 'equipment/main'
+import Lighting from 'lighting/main'
+import Configuration from 'configuration/main'
+import Temperature from 'temperature/main'
+import Timers from 'timers/main'
+import Doser from 'doser/main'
+import Ph from 'ph/main'
+import Macro from 'macro/main'
+import Dashboard from 'dashboard/main'
+import i18n from 'utils/i18n'
+import Instances from 'instances/main'
+import Journal from 'journal/main'
+
+export const mainPanelRoutes = [
+  { key: 'dashboard', index: true, path: '', element: <Dashboard />, label: i18n.t('capabilities:dashboard') },
+  { key: 'equipment', path: '/equipment', element: <Equipment />, label: i18n.t('capabilities:equipment') },
+  { key: 'timers', path: '/timers', element: <Timers />, label: i18n.t('capabilities:timers') },
+  { key: 'lighting', path: '/lighting', element: <Lighting />, label: i18n.t('capabilities:lights') },
+  { key: 'temperature', path: '/temperature', element: <Temperature />, label: i18n.t('capabilities:temperature') },
+  { key: 'ato', path: '/ato', element: <Ato />, label: i18n.t('capabilities:ato') },
+  { key: 'ph', path: '/ph', element: <Ph />, label: i18n.t('capabilities:ph') },
+  { key: 'doser', path: '/doser', element: <Doser />, label: i18n.t('capabilities:dosing_pumps') },
+  { key: 'macro', path: '/macro', element: <Macro />, label: i18n.t('capabilities:macros') },
+  { key: 'camera', path: '/camera', element: <Camera />, label: i18n.t('capabilities:camera') },
+  { key: 'manager', path: '/manager', element: <Instances />, label: i18n.t('capabilities:manager') },
+  { key: 'journal', path: '/journal', element: <Journal />, label: i18n.t('capabilities:journal') },
+  { key: 'configuration', path: '/configuration/*', element: <Configuration />, label: i18n.t('capabilities:configuration') }
+]
+
+export const mainPanelRouteElements = mainPanelRoutes.map(route => (
+  <Route key={route.key} index={route.index} path={route.path} element={route.element} />
+))
+
+export const routeNavigationPath = route => route.path || ''
+
+export const routeEnabled = (route, capabilities) => (
+  capabilities[route.key] !== undefined && capabilities[route.key]
+)
+
+export const navigationRoutes = capabilities => (
+  mainPanelRoutes.filter(route => routeEnabled(route, capabilities))
+)
+
+export const routeMatchesLocation = (route, pathname) => {
+  if (route.index) {
+    return pathname === '/'
+  }
+  const basePath = route.path.replace('/*', '')
+  return pathname === basePath || pathname.startsWith(basePath + '/')
+}
+
+export const currentRouteForPath = pathname => (
+  mainPanelRoutes.find(route => routeMatchesLocation(route, pathname))
+)


### PR DESCRIPTION
## Summary
- extract app shell route metadata and helpers from `main_panel.jsx`
- keep route keys, paths, labels, order, nav IDs, smoke test IDs, capability gating, nested matching, shell layout, and summary rendering stable
- add app shell route regression coverage

## Scope
- Slice 09: app shell, routing, and shared UI boundaries
- No route or UX behavior changes intended

## Tests
- `rtk yarn jest front-end/src/main_panel.test.js front-end/src/configuration/configuration.test.js front-end/src/configuration/capabilities.test.js --runInBand`
- `rtk yarn standard`
- `rtk make go`

## Notes
- `rtk yarn pw-smoke` was attempted after building `bin/reef-pi`, but Playwright timed out waiting for `config.webServer` after 120s even though the server logged startup on `0.0.0.0:8080`.
