### PR TITLE
Add macro storage repository seam

### DIFF
--- a/controller/modules/macro/macro.go
+++ b/controller/modules/macro/macro.go
@@ -1,7 +1,6 @@
 package macro
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 )
@@ -15,43 +14,22 @@ type Macro struct {
 }
 
 func (s *Subsystem) Get(id string) (Macro, error) {
-	var m Macro
-	return m, s.controller.Store().Get(Bucket, id, &m)
+	return s.repo.Get(id)
 }
 func (s *Subsystem) List() ([]Macro, error) {
-	ms := []Macro{}
-	fn := func(_ string, v []byte) error {
-		var m Macro
-		if err := json.Unmarshal(v, &m); err != nil {
-			return err
-		}
-		ms = append(ms, m)
-		return nil
-	}
-	return ms, s.controller.Store().List(Bucket, fn)
+	return s.repo.List()
 }
 
 func (s *Subsystem) Create(m Macro) error {
-	fn := func(id string) interface{} {
-		m.ID = id
-		return &m
-	}
-	return s.controller.Store().Create(Bucket, fn)
+	return s.repo.Create(m)
 }
 
 func (s *Subsystem) Update(id string, m Macro) error {
-	m.ID = id
-	return s.controller.Store().Update(Bucket, id, m)
+	return s.repo.Update(id, m)
 }
 
 func (s *Subsystem) Delete(id string) error {
-	if err := s.controller.Store().Delete(Bucket, id); err != nil {
-		return err
-	}
-	if err := s.controller.Store().Delete(UsageBucket, id); err != nil {
-		log.Println("ERROR:  macro-subsystem: Failed to deleted usage details for macro:", id)
-	}
-	return nil
+	return s.repo.Delete(id)
 }
 
 func (s *Subsystem) Run(m Macro, reverse bool) error {

--- a/controller/modules/macro/repository.go
+++ b/controller/modules/macro/repository.go
@@ -1,0 +1,70 @@
+package macro
+
+import (
+	"encoding/json"
+	"log"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+type repository interface {
+	Setup() error
+	Get(string) (Macro, error)
+	List() ([]Macro, error)
+	Create(Macro) error
+	Update(string, Macro) error
+	Delete(string) error
+}
+
+type storeRepository struct {
+	store storage.Store
+}
+
+func newRepository(store storage.Store) repository {
+	return storeRepository{store: store}
+}
+
+func (r storeRepository) Setup() error {
+	return r.store.CreateBucket(Bucket)
+}
+
+func (r storeRepository) Get(id string) (Macro, error) {
+	var m Macro
+	return m, r.store.Get(Bucket, id, &m)
+}
+
+func (r storeRepository) List() ([]Macro, error) {
+	ms := []Macro{}
+	fn := func(_ string, v []byte) error {
+		var m Macro
+		if err := json.Unmarshal(v, &m); err != nil {
+			return err
+		}
+		ms = append(ms, m)
+		return nil
+	}
+	return ms, r.store.List(Bucket, fn)
+}
+
+func (r storeRepository) Create(m Macro) error {
+	fn := func(id string) interface{} {
+		m.ID = id
+		return &m
+	}
+	return r.store.Create(Bucket, fn)
+}
+
+func (r storeRepository) Update(id string, m Macro) error {
+	m.ID = id
+	return r.store.Update(Bucket, id, m)
+}
+
+func (r storeRepository) Delete(id string) error {
+	if err := r.store.Delete(Bucket, id); err != nil {
+		return err
+	}
+	if err := r.store.Delete(UsageBucket, id); err != nil {
+		log.Println("ERROR:  macro-subsystem: Failed to deleted usage details for macro:", id)
+	}
+	return nil
+}

--- a/controller/modules/macro/repository_test.go
+++ b/controller/modules/macro/repository_test.go
@@ -1,0 +1,56 @@
+package macro
+
+import (
+	"testing"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+func TestStoreRepositoryCRUD(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	repo := newRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	macro := Macro{
+		Name:  "Feed Mode",
+		Steps: []Step{{Type: "equipment", Config: []byte(`{"id":"1","on":false}`)}},
+	}
+	if err := repo.Create(macro); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := repo.Get("1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "1" || got.Name != "Feed Mode" {
+		t.Fatalf("unexpected macro: %#v", got)
+	}
+
+	got.Name = "Maintenance Mode"
+	if err := repo.Update(got.ID, got); err != nil {
+		t.Fatal(err)
+	}
+
+	macros, err := repo.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(macros) != 1 || macros[0].Name != "Maintenance Mode" {
+		t.Fatalf("unexpected macros: %#v", macros)
+	}
+
+	if err := repo.Delete(got.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.Get(got.ID); err == nil {
+		t.Fatal("expected deleted macro lookup to fail")
+	}
+}

--- a/controller/modules/macro/subsystem.go
+++ b/controller/modules/macro/subsystem.go
@@ -19,18 +19,20 @@ type Subsystem struct {
 	devMode    bool
 	running    map[string]struct{}
 	controller controller.Controller
+	repo       repository
 }
 
 func New(devMode bool, c controller.Controller) (*Subsystem, error) {
 	return &Subsystem{
 		devMode:    devMode,
 		controller: c,
+		repo:       newRepository(c.Store()),
 		running:    make(map[string]struct{}),
 	}, nil
 }
 
 func (s *Subsystem) Setup() error {
-	return s.controller.Store().CreateBucket(Bucket)
+	return s.repo.Setup()
 }
 
 func (s *Subsystem) Start() {


### PR DESCRIPTION
## Summary
- add a narrow repository seam for macro storage operations
- route macro setup and CRUD methods through the repository
- add repository CRUD coverage to preserve bucket and payload behavior

## Scope
- Slice 05: backend storage and service seams
- focused on `controller/modules/macro`
- no API path, bucket name, payload, or macro execution behavior changes intended

## Tests
- `rtk go test ./controller/modules/macro`
- `rtk go test ./controller/...`
- `rtk git diff --check`

## Notes
- Local test execution modified `front-end/test/images/thumbnail-01.png`; it is unstaged and not part of this PR.
