### PR TITLE
Add lighting storage repository seam

### DIFF
--- a/controller/modules/lighting/controller.go
+++ b/controller/modules/lighting/controller.go
@@ -31,6 +31,7 @@ type Controller struct {
 	jacks    *connectors.Jacks
 	config   Config
 	c        controller.Controller
+	repo     repository
 	quitters map[string]chan struct{}
 	statsMgr telemetry.StatsManager
 }
@@ -39,6 +40,7 @@ func New(conf Config, c controller.Controller) (*Controller, error) {
 	return &Controller{
 		Mutex:    sync.Mutex{},
 		c:        c,
+		repo:     newRepository(c.Store()),
 		jacks:    c.DM().Jacks(),
 		config:   conf,
 		quitters: make(map[string]chan struct{}),
@@ -89,10 +91,7 @@ func (c *Controller) Stop() {
 func (c *Controller) Setup() error {
 	c.Lock()
 	defer c.Unlock()
-	if err := c.c.Store().CreateBucket(Bucket); err != nil {
-		return err
-	}
-	return c.c.Store().CreateBucket(UsageBucket)
+	return c.repo.Setup()
 }
 
 func (c *Controller) On(id string, on bool) error {

--- a/controller/modules/lighting/light.go
+++ b/controller/modules/lighting/light.go
@@ -1,7 +1,6 @@
 package lighting
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"time"
@@ -43,21 +42,11 @@ func (l *Light) LoadChannels() error {
 }
 
 func (c *Controller) Get(id string) (Light, error) {
-	var l Light
-	return l, c.c.Store().Get(Bucket, id, &l)
+	return c.repo.Get(id)
 }
 
 func (c *Controller) List() ([]Light, error) {
-	ls := []Light{}
-	fn := func(_ string, v []byte) error {
-		var l Light
-		if err := json.Unmarshal(v, &l); err != nil {
-			return err
-		}
-		ls = append(ls, l)
-		return nil
-	}
-	return ls, c.c.Store().List(Bucket, fn)
+	return c.repo.List()
 }
 
 func (c *Controller) validate(l *Light) error {
@@ -110,11 +99,9 @@ func (c *Controller) Create(l Light) error {
 	if err := c.validate(&l); err != nil {
 		return err
 	}
-	fn := func(id string) interface{} {
-		l.ID = id
-		return &l
-	}
-	if err := c.c.Store().Create(Bucket, fn); err != nil {
+	var err error
+	l, err = c.repo.Create(l)
+	if err != nil {
 		return nil
 	}
 	c.statsMgr.Initialize(l.ID)
@@ -133,7 +120,7 @@ func (c *Controller) Update(id string, l Light) error {
 	if err := c.validate(&l); err != nil {
 		return err
 	}
-	if err := c.c.Store().Update(Bucket, id, l); err != nil {
+	if err := c.repo.Update(id, l); err != nil {
 		return err
 	}
 	quit, ok := c.quitters[l.ID]
@@ -154,7 +141,7 @@ func (c *Controller) Delete(id string) error {
 	if err != nil {
 		return err
 	}
-	if err := c.c.Store().Delete(Bucket, id); err != nil {
+	if err := c.repo.Delete(id); err != nil {
 		return err
 	}
 	quit, ok := c.quitters[id]

--- a/controller/modules/lighting/repository.go
+++ b/controller/modules/lighting/repository.go
@@ -1,0 +1,67 @@
+package lighting
+
+import (
+	"encoding/json"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+type repository interface {
+	Setup() error
+	Get(string) (Light, error)
+	List() ([]Light, error)
+	Create(Light) (Light, error)
+	Update(string, Light) error
+	Delete(string) error
+}
+
+type storeRepository struct {
+	store storage.Store
+}
+
+func newRepository(store storage.Store) repository {
+	return storeRepository{store: store}
+}
+
+func (r storeRepository) Setup() error {
+	if err := r.store.CreateBucket(Bucket); err != nil {
+		return err
+	}
+	return r.store.CreateBucket(UsageBucket)
+}
+
+func (r storeRepository) Get(id string) (Light, error) {
+	var l Light
+	return l, r.store.Get(Bucket, id, &l)
+}
+
+func (r storeRepository) List() ([]Light, error) {
+	ls := []Light{}
+	fn := func(_ string, v []byte) error {
+		var l Light
+		if err := json.Unmarshal(v, &l); err != nil {
+			return err
+		}
+		ls = append(ls, l)
+		return nil
+	}
+	return ls, r.store.List(Bucket, fn)
+}
+
+func (r storeRepository) Create(l Light) (Light, error) {
+	created := l
+	fn := func(id string) interface{} {
+		created.ID = id
+		return &created
+	}
+	return created, r.store.Create(Bucket, fn)
+}
+
+func (r storeRepository) Update(id string, l Light) error {
+	l.ID = id
+	return r.store.Update(Bucket, id, l)
+}
+
+func (r storeRepository) Delete(id string) error {
+	return r.store.Delete(Bucket, id)
+}

--- a/controller/modules/lighting/repository_test.go
+++ b/controller/modules/lighting/repository_test.go
@@ -1,0 +1,64 @@
+package lighting
+
+import (
+	"testing"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+func TestStoreRepositoryCRUD(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	repo := newRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	light := Light{
+		Name:   "Main Light",
+		Jack:   "jack-1",
+		Enable: true,
+		Channels: map[int]*Channel{
+			1: {Name: "white", Manual: true, Value: 55},
+		},
+	}
+	created, err := repo.Create(light)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.ID != "1" {
+		t.Fatalf("expected created ID 1, got %q", created.ID)
+	}
+
+	got, err := repo.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "Main Light" || got.Jack != "jack-1" {
+		t.Fatalf("unexpected light: %#v", got)
+	}
+
+	got.Name = "Frag Tank"
+	if err := repo.Update(got.ID, got); err != nil {
+		t.Fatal(err)
+	}
+
+	lights, err := repo.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lights) != 1 || lights[0].Name != "Frag Tank" {
+		t.Fatalf("unexpected lights: %#v", lights)
+	}
+
+	if err := repo.Delete(got.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.Get(got.ID); err == nil {
+		t.Fatal("expected deleted light lookup to fail")
+	}
+}


### PR DESCRIPTION
## Summary
- add a narrow repository seam for lighting storage operations
- route lighting setup and CRUD methods through the repository
- add repository CRUD coverage to preserve bucket, payload, and created-ID behavior

## Scope
- Slice 05: backend storage and service seams
- focused on `controller/modules/lighting`
- no API path, bucket name, payload, schedule, telemetry, or hardware behavior changes intended

## Tests
- `rtk go test ./controller/modules/lighting`
- `rtk go test ./controller/...`
- `rtk git diff --check`

## Notes
- Local test execution modified `front-end/test/images/thumbnail-01.png`; it is unstaged and not part of this PR.
