### PR TITLE
Add temperature storage repository seam

### DIFF
--- a/controller/modules/temperature/controller.go
+++ b/controller/modules/temperature/controller.go
@@ -21,6 +21,7 @@ const CalibrationBucket = storage.TemperatureCalibrationBucket
 type Controller struct {
 	sync.Mutex
 	c           controller.Controller
+	repo        repository
 	devMode     bool
 	quitters    map[string]chan struct{}
 	wg          sync.WaitGroup
@@ -33,6 +34,7 @@ type Controller struct {
 func New(devMode bool, c controller.Controller) (*Controller, error) {
 	return &Controller{
 		c:           c,
+		repo:        newRepository(c.Store()),
 		devMode:     devMode,
 		quitters:    make(map[string]chan struct{}),
 		tcs:         make(map[string]*TC),
@@ -45,13 +47,7 @@ func New(devMode bool, c controller.Controller) (*Controller, error) {
 func (c *Controller) Setup() error {
 	c.Lock()
 	defer c.Unlock()
-	if err := c.c.Store().CreateBucket(Bucket); err != nil {
-		return err
-	}
-	if err := c.c.Store().CreateBucket(CalibrationBucket); err != nil {
-		return err
-	}
-	if err := c.c.Store().CreateBucket(UsageBucket); err != nil {
+	if err := c.repo.Setup(); err != nil {
 		return err
 	}
 	tcs, err := c.List()
@@ -62,19 +58,21 @@ func (c *Controller) Setup() error {
 		c.tcs[tc.ID] = tc
 	}
 
-	err = c.c.Store().List(CalibrationBucket, func(k string, v []byte) error {
-		var ms []hal.Measurement
-		if err := json.Unmarshal(v, &ms); err != nil {
-			return err
-		}
+	calibrations, err := c.repo.ListCalibrations()
+	if err != nil {
+		return err
+	}
+	for k, ms := range calibrations {
 		calibrator, err := hal.CalibratorFactory(ms)
 		if err == nil {
 			c.calibrators[k] = calibrator
 		}
-		return err
-	})
+		if err != nil {
+			return err
+		}
+	}
 
-	return err
+	return nil
 }
 
 func (c *Controller) Start() {

--- a/controller/modules/temperature/repository.go
+++ b/controller/modules/temperature/repository.go
@@ -1,0 +1,94 @@
+package temperature
+
+import (
+	"encoding/json"
+
+	"github.com/reef-pi/hal"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+type repository interface {
+	Setup() error
+	List() ([]*TC, error)
+	Create(*TC) error
+	Update(string, *TC) error
+	Delete(string) error
+	DeleteUsage(string) error
+	ListCalibrations() (map[string][]hal.Measurement, error)
+	UpdateCalibration(string, []hal.Measurement) error
+	DeleteCalibration(string) error
+}
+
+type storeRepository struct {
+	store storage.Store
+}
+
+func newRepository(store storage.Store) repository {
+	return storeRepository{store: store}
+}
+
+func (r storeRepository) Setup() error {
+	if err := r.store.CreateBucket(Bucket); err != nil {
+		return err
+	}
+	if err := r.store.CreateBucket(CalibrationBucket); err != nil {
+		return err
+	}
+	return r.store.CreateBucket(UsageBucket)
+}
+
+func (r storeRepository) List() ([]*TC, error) {
+	tcs := []*TC{}
+	fn := func(_ string, v []byte) error {
+		var tc TC
+		if err := json.Unmarshal(v, &tc); err != nil {
+			return err
+		}
+		tcs = append(tcs, &tc)
+		return nil
+	}
+	return tcs, r.store.List(Bucket, fn)
+}
+
+func (r storeRepository) Create(tc *TC) error {
+	fn := func(id string) interface{} {
+		tc.ID = id
+		return tc
+	}
+	return r.store.Create(Bucket, fn)
+}
+
+func (r storeRepository) Update(id string, tc *TC) error {
+	tc.ID = id
+	return r.store.Update(Bucket, id, tc)
+}
+
+func (r storeRepository) Delete(id string) error {
+	return r.store.Delete(Bucket, id)
+}
+
+func (r storeRepository) DeleteUsage(id string) error {
+	return r.store.Delete(UsageBucket, id)
+}
+
+func (r storeRepository) ListCalibrations() (map[string][]hal.Measurement, error) {
+	calibrations := map[string][]hal.Measurement{}
+	err := r.store.List(CalibrationBucket, func(k string, v []byte) error {
+		var ms []hal.Measurement
+		if err := json.Unmarshal(v, &ms); err != nil {
+			return err
+		}
+		calibrations[k] = ms
+		return nil
+	})
+	return calibrations, err
+}
+
+func (r storeRepository) UpdateCalibration(sensor string, ms []hal.Measurement) error {
+	return r.store.Update(CalibrationBucket, sensor, ms)
+}
+
+func (r storeRepository) DeleteCalibration(sensor string) error {
+	return r.store.Delete(CalibrationBucket, sensor)
+}

--- a/controller/modules/temperature/repository_test.go
+++ b/controller/modules/temperature/repository_test.go
@@ -1,0 +1,116 @@
+package temperature
+
+import (
+	"testing"
+	"time"
+
+	"github.com/reef-pi/hal"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+func testRepository(t *testing.T) repository {
+	t.Helper()
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		store.Close()
+	})
+	repo := newRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	return repo
+}
+
+func TestRepositoryCRUD(t *testing.T) {
+	repo := testRepository(t)
+
+	tc := &TC{
+		Name:   "Water",
+		Period: 5 * time.Second,
+		Sensor: "28-0001",
+		Min:    77,
+		Max:    81,
+	}
+	if err := repo.Create(tc); err != nil {
+		t.Fatal(err)
+	}
+	if tc.ID != "1" {
+		t.Fatalf("expected created id 1, got %s", tc.ID)
+	}
+
+	tcs, err := repo.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tcs) != 1 {
+		t.Fatalf("expected 1 temperature controller, got %d", len(tcs))
+	}
+	if tcs[0].Name != "Water" || tcs[0].Sensor != "28-0001" {
+		t.Fatalf("unexpected temperature controller: %+v", tcs[0])
+	}
+
+	tc.Name = "Sump"
+	if err := repo.Update(tc.ID, tc); err != nil {
+		t.Fatal(err)
+	}
+	tcs, err = repo.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tcs[0].Name != "Sump" {
+		t.Fatalf("expected updated name Sump, got %s", tcs[0].Name)
+	}
+
+	if err := repo.Delete(tc.ID); err != nil {
+		t.Fatal(err)
+	}
+	tcs, err = repo.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tcs) != 0 {
+		t.Fatalf("expected no temperature controllers, got %d", len(tcs))
+	}
+}
+
+func TestRepositoryCalibrationPersistence(t *testing.T) {
+	repo := testRepository(t)
+
+	ms := []hal.Measurement{
+		{Observed: 77.1, Expected: 78.2},
+		{Observed: 80.1, Expected: 81.2},
+	}
+	if err := repo.UpdateCalibration("28-0001", ms); err != nil {
+		t.Fatal(err)
+	}
+
+	calibrations, err := repo.ListCalibrations()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := calibrations["28-0001"]
+	if !ok {
+		t.Fatal("expected persisted calibration for sensor")
+	}
+	if len(got) != len(ms) {
+		t.Fatalf("expected %d measurements, got %d", len(ms), len(got))
+	}
+	if got[0].Observed != 77.1 || got[0].Expected != 78.2 {
+		t.Fatalf("unexpected first measurement: %+v", got[0])
+	}
+
+	if err := repo.DeleteCalibration("28-0001"); err != nil {
+		t.Fatal(err)
+	}
+	calibrations, err = repo.ListCalibrations()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := calibrations["28-0001"]; ok {
+		t.Fatal("expected calibration to be deleted")
+	}
+}

--- a/controller/modules/temperature/tc.go
+++ b/controller/modules/temperature/tc.go
@@ -1,7 +1,6 @@
 package temperature
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"sync"
@@ -78,16 +77,7 @@ func (c *Controller) Get(id string) (*TC, error) {
 }
 
 func (c *Controller) List() ([]*TC, error) {
-	tcs := []*TC{}
-	fn := func(_ string, v []byte) error {
-		var tc TC
-		if err := json.Unmarshal(v, &tc); err != nil {
-			return err
-		}
-		tcs = append(tcs, &tc)
-		return nil
-	}
-	return tcs, c.c.Store().List(Bucket, fn)
+	return c.repo.List()
 }
 
 func (c *Controller) Create(tc *TC) error {
@@ -96,11 +86,7 @@ func (c *Controller) Create(tc *TC) error {
 	if tc.Period <= 0 {
 		return fmt.Errorf("Check period for temperature controller must be greater than zero")
 	}
-	fn := func(id string) interface{} {
-		tc.ID = id
-		return tc
-	}
-	if err := c.c.Store().Create(Bucket, fn); err != nil {
+	if err := c.repo.Create(tc); err != nil {
 		return err
 	}
 
@@ -125,7 +111,7 @@ func (c *Controller) Update(id string, tc *TC) error {
 	if tc.Period <= 0 {
 		return fmt.Errorf("Period should be positive. Supplied:%d", tc.Period)
 	}
-	if err := c.c.Store().Update(Bucket, id, tc); err != nil {
+	if err := c.repo.Update(id, tc); err != nil {
 		return err
 	}
 	quit, ok := c.quitters[tc.ID]
@@ -169,14 +155,14 @@ func (c *Controller) Delete(id string) error {
 
 	if deleteCalibration {
 
-		c.c.Store().Delete(CalibrationBucket, tc.Sensor)
+		c.repo.DeleteCalibration(tc.Sensor)
 		delete(c.calibrators, tc.Sensor)
 	}
 
-	if err := c.c.Store().Delete(Bucket, id); err != nil {
+	if err := c.repo.Delete(id); err != nil {
 		return err
 	}
-	if err := c.c.Store().Delete(UsageBucket, id); err != nil {
+	if err := c.repo.DeleteUsage(id); err != nil {
 		log.Println("ERROR:  temperature sub-system: Failed to delete usage details for sensor:", id)
 	}
 
@@ -278,7 +264,7 @@ func (c *Controller) Calibrate(id string, ms []hal.Measurement) error {
 	defer c.Unlock()
 
 	c.calibrators[tc.Sensor] = cal
-	return c.c.Store().Update(CalibrationBucket, tc.Sensor, ms)
+	return c.repo.UpdateCalibration(tc.Sensor, ms)
 }
 
 func (t *TC) WithinRange(v float64) bool {


### PR DESCRIPTION
## Summary
- add a narrow repository seam for temperature storage operations
- route setup, temperature controller CRUD, usage cleanup, and calibration persistence/list/delete through the repository
- add repository coverage for CRUD and calibration persistence behavior

## Scope
- Slice 05: backend storage and service seams
- focused on `controller/modules/temperature`
- no API path, bucket name, payload, calibration, usage, telemetry, sensor, or control behavior changes intended

## Tests
- `rtk go test ./controller/modules/temperature`
- `rtk go test ./controller/...`
- `rtk git diff --check`

## Notes
- Local test execution modified `front-end/test/images/thumbnail-01.png`; it is unstaged and not part of this PR.
