### PR TITLE
Add pH storage repository seam

### DIFF
--- a/controller/modules/ph/controller.go
+++ b/controller/modules/ph/controller.go
@@ -21,6 +21,7 @@ const CalibrationBucket = storage.PhCalibrationBucket
 type Controller struct {
 	sync.Mutex
 	c           controller.Controller
+	repo        repository
 	quitters    map[string]chan struct{}
 	statsMgr    telemetry.StatsManager
 	devMode     bool
@@ -32,6 +33,7 @@ func New(devMode bool, c controller.Controller) *Controller {
 	return &Controller{
 		quitters:    make(map[string]chan struct{}),
 		c:           c,
+		repo:        newRepository(c.Store()),
 		devMode:     devMode,
 		ais:         c.DM().AnalogInputs(),
 		statsMgr:    c.Telemetry().NewStatsManager(ReadingsBucket),
@@ -40,20 +42,15 @@ func New(devMode bool, c controller.Controller) *Controller {
 }
 
 func (c *Controller) Setup() error {
-	if err := c.c.Store().CreateBucket(Bucket); err != nil {
+	if err := c.repo.Setup(); err != nil {
 		return err
 	}
-	if err := c.c.Store().CreateBucket(CalibrationBucket); err != nil {
+	calibrations, err := c.repo.ListCalibrations()
+	if err != nil {
 		return err
 	}
-
-	err := c.c.Store().List(CalibrationBucket, func(k string, v []byte) error {
-		var ms []hal.Measurement
-		if err := json.Unmarshal(v, &ms); err != nil {
-			return err
-		}
+	for id, ms := range calibrations {
 		c.Lock()
-		defer c.Unlock()
 
 		var calibrator hal.Calibrator
 		var cerr error
@@ -63,15 +60,14 @@ func (c *Controller) Setup() error {
 			calibrator, cerr = hal.CalibratorFactory(ms)
 		}
 		if cerr == nil {
-			c.calibrators[k] = calibrator
+			c.calibrators[id] = calibrator
 		}
-		return cerr
-	})
-	if err != nil {
-		return err
+		c.Unlock()
+		if cerr != nil {
+			return cerr
+		}
 	}
-
-	return c.c.Store().CreateBucket(ReadingsBucket)
+	return nil
 }
 
 func (c *Controller) Start() {

--- a/controller/modules/ph/probe.go
+++ b/controller/modules/ph/probe.go
@@ -1,7 +1,6 @@
 package ph
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"math/rand"
@@ -77,21 +76,11 @@ type CalibrationPoint struct {
 }
 
 func (c *Controller) Get(id string) (Probe, error) {
-	var p Probe
-	return p, c.c.Store().Get(Bucket, id, &p)
+	return c.repo.Get(id)
 }
 
 func (c *Controller) List() ([]Probe, error) {
-	probes := []Probe{}
-	fn := func(_ string, v []byte) error {
-		var p Probe
-		if err := json.Unmarshal(v, &p); err != nil {
-			return err
-		}
-		probes = append(probes, p)
-		return nil
-	}
-	return probes, c.c.Store().List(Bucket, fn)
+	return c.repo.List()
 }
 
 func (p Probe) Validate() error {
@@ -121,11 +110,8 @@ func (c *Controller) Create(p Probe) error {
 	if err := p.Validate(); err != nil {
 		return err
 	}
-	fn := func(id string) interface{} {
-		p.ID = id
-		return &p
-	}
-	if err := c.c.Store().Create(Bucket, fn); err != nil {
+	p, err := c.repo.Create(p)
+	if err != nil {
 		return err
 	}
 	c.statsMgr.Initialize(p.ID)
@@ -143,7 +129,7 @@ func (c *Controller) Update(id string, p Probe) error {
 	if err := p.Validate(); err != nil {
 		return err
 	}
-	if err := c.c.Store().Update(Bucket, id, p); err != nil {
+	if err := c.repo.Update(id, p); err != nil {
 		return err
 	}
 	quit, ok := c.quitters[p.ID]
@@ -163,14 +149,13 @@ func (c *Controller) Update(id string, p Probe) error {
 func (c *Controller) Delete(id string) error {
 	c.Lock()
 	defer c.Unlock()
-	if err := c.c.Store().Delete(Bucket, id); err != nil {
+	if err := c.repo.Delete(id); err != nil {
 		return err
 	}
 	if err := c.statsMgr.Delete(id); err != nil {
 		log.Println("ERROR: ph sub-system: Failed to deleted readings for probe:", id)
 	}
 
-	c.c.Store().Delete(CalibrationBucket, id)
 	delete(c.calibrators, id)
 
 	quit, ok := c.quitters[id]
@@ -290,7 +275,7 @@ func (c *Controller) Calibrate(id string, ms []hal.Measurement) error {
 	defer c.Unlock()
 
 	c.calibrators[p.ID] = cal
-	return c.c.Store().Update(CalibrationBucket, p.ID, ms)
+	return c.repo.SaveCalibration(p.ID, ms)
 }
 
 func (c *Controller) CalibratePoint(id string, point CalibrationPoint) error {
@@ -307,7 +292,9 @@ func (c *Controller) CalibratePoint(id string, point CalibrationPoint) error {
 	//Append to existing calibration unless the point is the mid point.
 	//Receiving a mid point calibration resets the calibration process.
 	if point.Type != "mid" {
-		if err := c.c.Store().Get(CalibrationBucket, p.ID, &calibration); err != nil {
+		var err error
+		calibration, err = c.repo.GetCalibration(p.ID)
+		if err != nil {
 			log.Println("ph-subsystem. No calibration data found for probe:", p.Name)
 		}
 		// Remove any existing point with the same expected value so re-calibrating
@@ -335,7 +322,7 @@ func (c *Controller) CalibratePoint(id string, point CalibrationPoint) error {
 		return err
 	}
 	c.calibrators[p.ID] = cal
-	return c.c.Store().Update(CalibrationBucket, p.ID, calibration)
+	return c.repo.SaveCalibration(p.ID, calibration)
 }
 
 func (p Probe) CreateFeed(t telemetry.Telemetry) {

--- a/controller/modules/ph/repository.go
+++ b/controller/modules/ph/repository.go
@@ -1,0 +1,100 @@
+package ph
+
+import (
+	"encoding/json"
+
+	"github.com/reef-pi/hal"
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+type repository interface {
+	Setup() error
+	Get(string) (Probe, error)
+	List() ([]Probe, error)
+	Create(Probe) (Probe, error)
+	Update(string, Probe) error
+	Delete(string) error
+	GetCalibration(string) ([]hal.Measurement, error)
+	ListCalibrations() (map[string][]hal.Measurement, error)
+	SaveCalibration(string, []hal.Measurement) error
+}
+
+type storeRepository struct {
+	store storage.Store
+}
+
+func newRepository(store storage.Store) repository {
+	return storeRepository{store: store}
+}
+
+func (r storeRepository) Setup() error {
+	if err := r.store.CreateBucket(Bucket); err != nil {
+		return err
+	}
+	if err := r.store.CreateBucket(CalibrationBucket); err != nil {
+		return err
+	}
+	return r.store.CreateBucket(ReadingsBucket)
+}
+
+func (r storeRepository) Get(id string) (Probe, error) {
+	var p Probe
+	return p, r.store.Get(Bucket, id, &p)
+}
+
+func (r storeRepository) List() ([]Probe, error) {
+	probes := []Probe{}
+	fn := func(_ string, v []byte) error {
+		var p Probe
+		if err := json.Unmarshal(v, &p); err != nil {
+			return err
+		}
+		probes = append(probes, p)
+		return nil
+	}
+	return probes, r.store.List(Bucket, fn)
+}
+
+func (r storeRepository) Create(p Probe) (Probe, error) {
+	created := p
+	fn := func(id string) interface{} {
+		created.ID = id
+		return &created
+	}
+	return created, r.store.Create(Bucket, fn)
+}
+
+func (r storeRepository) Update(id string, p Probe) error {
+	p.ID = id
+	return r.store.Update(Bucket, id, p)
+}
+
+func (r storeRepository) Delete(id string) error {
+	if err := r.store.Delete(Bucket, id); err != nil {
+		return err
+	}
+	r.store.Delete(CalibrationBucket, id)
+	return nil
+}
+
+func (r storeRepository) GetCalibration(id string) ([]hal.Measurement, error) {
+	var calibration []hal.Measurement
+	return calibration, r.store.Get(CalibrationBucket, id, &calibration)
+}
+
+func (r storeRepository) ListCalibrations() (map[string][]hal.Measurement, error) {
+	calibrations := map[string][]hal.Measurement{}
+	fn := func(id string, v []byte) error {
+		var ms []hal.Measurement
+		if err := json.Unmarshal(v, &ms); err != nil {
+			return err
+		}
+		calibrations[id] = ms
+		return nil
+	}
+	return calibrations, r.store.List(CalibrationBucket, fn)
+}
+
+func (r storeRepository) SaveCalibration(id string, ms []hal.Measurement) error {
+	return r.store.Update(CalibrationBucket, id, ms)
+}

--- a/controller/modules/ph/repository_test.go
+++ b/controller/modules/ph/repository_test.go
@@ -1,0 +1,112 @@
+package ph
+
+import (
+	"testing"
+	"time"
+
+	"github.com/reef-pi/hal"
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+func TestStoreRepositoryCRUD(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	repo := newRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	probe := Probe{
+		Name:        "Main pH",
+		Period:      5 * time.Second,
+		AnalogInput: "analog-1",
+		Enable:      true,
+	}
+	created, err := repo.Create(probe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.ID != "1" {
+		t.Fatalf("expected created ID 1, got %q", created.ID)
+	}
+
+	got, err := repo.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "Main pH" || got.AnalogInput != "analog-1" {
+		t.Fatalf("unexpected probe: %#v", got)
+	}
+
+	got.Name = "Sump pH"
+	if err := repo.Update(got.ID, got); err != nil {
+		t.Fatal(err)
+	}
+
+	probes, err := repo.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(probes) != 1 || probes[0].Name != "Sump pH" {
+		t.Fatalf("unexpected probes: %#v", probes)
+	}
+
+	if err := repo.Delete(got.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.Get(got.ID); err == nil {
+		t.Fatal("expected deleted probe lookup to fail")
+	}
+}
+
+func TestStoreRepositoryCalibrationPersistence(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	repo := newRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	probe, err := repo.Create(Probe{Name: "Calibrated pH", Period: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	measurements := []hal.Measurement{
+		{Observed: 7.8, Expected: 8.0},
+		{Observed: 9.8, Expected: 10.0},
+	}
+	if err := repo.SaveCalibration(probe.ID, measurements); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := repo.GetCalibration(probe.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0].Observed != 7.8 || got[1].Expected != 10.0 {
+		t.Fatalf("unexpected calibration: %#v", got)
+	}
+
+	calibrations, err := repo.ListCalibrations()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(calibrations) != 1 || len(calibrations[probe.ID]) != 2 {
+		t.Fatalf("unexpected calibrations: %#v", calibrations)
+	}
+
+	if err := repo.Delete(probe.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.GetCalibration(probe.ID); err == nil {
+		t.Fatal("expected deleted calibration lookup to fail")
+	}
+}


### PR DESCRIPTION
## Summary
- add a narrow repository seam for pH storage operations
- route probe CRUD and calibration persistence through the repository
- add repository coverage for probe CRUD and calibration behavior

## Scope
- Slice 05: backend storage and service seams
- focused on `controller/modules/ph`
- no API path, bucket name, payload, calibration, readings, telemetry, analog-input, or run-loop behavior changes intended

## Tests
- `rtk go test ./controller/modules/ph`
- `rtk go test ./controller/...`
- `rtk git diff --check`

## Notes
- Local test execution modified `front-end/test/images/thumbnail-01.png`; it is unstaged and not part of this PR.
