### PR TITLE
Add doser storage repository seam

### DIFF
--- a/controller/modules/doser/controller.go
+++ b/controller/modules/doser/controller.go
@@ -24,6 +24,7 @@ type Controller struct {
 	DevMode  bool
 	statsMgr telemetry.StatsManager
 	c        controller.Controller
+	repo     repository
 	mu       *sync.Mutex
 	runner   *cron.Cron
 	cronIDs  map[string]cron.EntryID
@@ -39,6 +40,7 @@ func New(devMode bool, c controller.Controller) (*Controller, error) {
 		runner:   cron.New(cron.WithParser(cron.NewParser(_cronParserSpec))),
 		statsMgr: c.Telemetry().NewStatsManager(UsageBucket),
 		c:        c,
+		repo:     newRepository(c.Store()),
 	}, nil
 }
 func (c *Controller) GetEntity(id string) (controller.Entity, error) {
@@ -57,10 +59,7 @@ func (c *Controller) Stop() {
 }
 
 func (c *Controller) Setup() error {
-	if err := c.c.Store().CreateBucket(Bucket); err != nil {
-		return err
-	}
-	return c.c.Store().CreateBucket(UsageBucket)
+	return c.repo.Setup()
 }
 
 func (c *Controller) Start() {

--- a/controller/modules/doser/pump.go
+++ b/controller/modules/doser/pump.go
@@ -1,7 +1,6 @@
 package doser
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 
@@ -70,19 +69,16 @@ func (p *Pump) IsValid() error {
 }
 
 func (c *Controller) Get(id string) (Pump, error) {
-	var p Pump
-	return p, c.c.Store().Get(Bucket, id, &p)
+	return c.repo.Get(id)
 }
 
 func (c *Controller) Create(p Pump) error {
 	if err := p.IsValid(); err != nil {
 		return err
 	}
-	fn := func(id string) interface{} {
-		p.ID = id
-		return &p
-	}
-	if err := c.c.Store().Create(Bucket, fn); err != nil {
+	var err error
+	p, err = c.repo.Create(p)
+	if err != nil {
 		return err
 	}
 	c.statsMgr.Initialize(p.ID)
@@ -97,16 +93,7 @@ func (c *Controller) Create(p Pump) error {
 }
 
 func (c *Controller) List() ([]Pump, error) {
-	pumps := []Pump{}
-	fn := func(_ string, v []byte) error {
-		var p Pump
-		if err := json.Unmarshal(v, &p); err != nil {
-			return err
-		}
-		pumps = append(pumps, p)
-		return nil
-	}
-	return pumps, c.c.Store().List(Bucket, fn)
+	return c.repo.List()
 }
 
 //swagger:model doserCalibrationDetails
@@ -131,7 +118,7 @@ func (c *Controller) SaveCalibrationResult(id string, cal CalibrationDetails) er
 		return err
 	}
 	p.Regiment.VolumePerSecond = cal.Volume / cal.Duration
-	return c.c.Store().Update(Bucket, id, p)
+	return c.repo.Update(id, p)
 }
 
 func (c *Controller) Calibrate(id string, cal CalibrationDetails) error {
@@ -157,7 +144,7 @@ func (c *Controller) Update(id string, p Pump) error {
 		return err
 	}
 	p.ID = id
-	if err := c.c.Store().Update(Bucket, id, p); err != nil {
+	if err := c.repo.Update(id, p); err != nil {
 		return err
 	}
 	c.mu.Lock()
@@ -196,7 +183,7 @@ func (c *Controller) Delete(id string) error {
 	}
 	c.mu.Unlock()
 	c.stopContinuous(id)
-	return c.c.Store().Delete(Bucket, id)
+	return c.repo.Delete(id)
 }
 
 func (p *Pump) Runner(dm *device_manager.DeviceManager, t telemetry.Telemetry, sm telemetry.StatsManager) cron.Job {

--- a/controller/modules/doser/repository.go
+++ b/controller/modules/doser/repository.go
@@ -1,0 +1,67 @@
+package doser
+
+import (
+	"encoding/json"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+type repository interface {
+	Setup() error
+	Get(string) (Pump, error)
+	List() ([]Pump, error)
+	Create(Pump) (Pump, error)
+	Update(string, Pump) error
+	Delete(string) error
+}
+
+type storeRepository struct {
+	store storage.Store
+}
+
+func newRepository(store storage.Store) repository {
+	return storeRepository{store: store}
+}
+
+func (r storeRepository) Setup() error {
+	if err := r.store.CreateBucket(Bucket); err != nil {
+		return err
+	}
+	return r.store.CreateBucket(UsageBucket)
+}
+
+func (r storeRepository) Get(id string) (Pump, error) {
+	var p Pump
+	return p, r.store.Get(Bucket, id, &p)
+}
+
+func (r storeRepository) List() ([]Pump, error) {
+	pumps := []Pump{}
+	fn := func(_ string, v []byte) error {
+		var p Pump
+		if err := json.Unmarshal(v, &p); err != nil {
+			return err
+		}
+		pumps = append(pumps, p)
+		return nil
+	}
+	return pumps, r.store.List(Bucket, fn)
+}
+
+func (r storeRepository) Create(p Pump) (Pump, error) {
+	created := p
+	fn := func(id string) interface{} {
+		created.ID = id
+		return &created
+	}
+	return created, r.store.Create(Bucket, fn)
+}
+
+func (r storeRepository) Update(id string, p Pump) error {
+	p.ID = id
+	return r.store.Update(Bucket, id, p)
+}
+
+func (r storeRepository) Delete(id string) error {
+	return r.store.Delete(Bucket, id)
+}

--- a/controller/modules/doser/repository_test.go
+++ b/controller/modules/doser/repository_test.go
@@ -1,0 +1,66 @@
+package doser
+
+import (
+	"testing"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+func TestStoreRepositoryCRUD(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	repo := newRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	pump := Pump{
+		Name: "alk",
+		Jack: "jack-1",
+		Pin:  1,
+		Regiment: DosingRegiment{
+			Schedule: Schedule{Second: "0", Minute: "*", Hour: "*", Day: "*", Month: "*", Week: "*"},
+			Duration: 2,
+			Speed:    50,
+		},
+	}
+	created, err := repo.Create(pump)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.ID != "1" {
+		t.Fatalf("expected created ID 1, got %q", created.ID)
+	}
+
+	got, err := repo.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "alk" || got.Jack != "jack-1" {
+		t.Fatalf("unexpected pump: %#v", got)
+	}
+
+	got.Name = "calcium"
+	if err := repo.Update(got.ID, got); err != nil {
+		t.Fatal(err)
+	}
+
+	pumps, err := repo.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pumps) != 1 || pumps[0].Name != "calcium" {
+		t.Fatalf("unexpected pumps: %#v", pumps)
+	}
+
+	if err := repo.Delete(got.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.Get(got.ID); err == nil {
+		t.Fatal("expected deleted pump lookup to fail")
+	}
+}

--- a/controller/modules/doser/repository_test.go
+++ b/controller/modules/doser/repository_test.go
@@ -19,13 +19,13 @@ func TestStoreRepositoryCRUD(t *testing.T) {
 	}
 
 	pump := Pump{
-		Name: "alk",
+		Name: "Alkalinity",
 		Jack: "jack-1",
 		Pin:  1,
 		Regiment: DosingRegiment{
 			Schedule: Schedule{Second: "0", Minute: "*", Hour: "*", Day: "*", Month: "*", Week: "*"},
-			Duration: 2,
-			Speed:    50,
+			Duration: 5,
+			Speed:    60,
 		},
 	}
 	created, err := repo.Create(pump)
@@ -40,12 +40,13 @@ func TestStoreRepositoryCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Name != "alk" || got.Jack != "jack-1" {
+	if got.ID != "1" || got.Name != "Alkalinity" || got.Jack != "jack-1" {
 		t.Fatalf("unexpected pump: %#v", got)
 	}
 
-	got.Name = "calcium"
-	if err := repo.Update(got.ID, got); err != nil {
+	got.ID = "stale"
+	got.Name = "Calcium"
+	if err := repo.Update(created.ID, got); err != nil {
 		t.Fatal(err)
 	}
 
@@ -53,14 +54,14 @@ func TestStoreRepositoryCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(pumps) != 1 || pumps[0].Name != "calcium" {
+	if len(pumps) != 1 || pumps[0].ID != "1" || pumps[0].Name != "Calcium" {
 		t.Fatalf("unexpected pumps: %#v", pumps)
 	}
 
-	if err := repo.Delete(got.ID); err != nil {
+	if err := repo.Delete(created.ID); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := repo.Get(got.ID); err == nil {
+	if _, err := repo.Get(created.ID); err == nil {
 		t.Fatal("expected deleted pump lookup to fail")
 	}
 }


### PR DESCRIPTION
## Summary
- add a narrow repository seam for doser storage operations
- route doser setup, CRUD, and calibration persistence through the repository
- add repository CRUD coverage to preserve bucket, payload, and created-ID behavior

## Scope
- Slice 05: backend storage and service seams
- focused on `controller/modules/doser`
- no API path, bucket name, payload, schedule, calibration, usage, telemetry, or hardware behavior changes intended

## Tests
- `rtk go test ./controller/modules/doser`
- `rtk go test ./controller/...`
- `rtk git diff --check`

## Notes
- Local test execution modified `front-end/test/images/thumbnail-01.png`; it is unstaged and not part of this PR.
