### PR TITLE
Slice 05: add journal storage repository seam

### DIFF
--- a/controller/modules/journal/parameter.go
+++ b/controller/modules/journal/parameter.go
@@ -35,47 +35,27 @@ func (s *Subsystem) On(_ string, _ bool) error {
 }
 
 func (s *Subsystem) Get(id string) (Parameter, error) {
-	var p Parameter
-	return p, s.c.Store().Get(Bucket, id, &p)
+	return s.repo.Get(id)
 }
 func (s *Subsystem) List() ([]Parameter, error) {
-	params := []Parameter{}
-	fn := func(_ string, v []byte) error {
-		var p Parameter
-		if err := json.Unmarshal(v, &p); err != nil {
-			return err
-		}
-		params = append(params, p)
-		return nil
-	}
-	return params, s.c.Store().List(Bucket, fn)
+	return s.repo.List()
 }
 
 func (s *Subsystem) Create(p Parameter) error {
-	fn := func(id string) interface{} {
-		p.ID = id
-		return &p
-	}
-	if err := s.c.Store().Create(Bucket, fn); err != nil {
+	created, err := s.repo.Create(p)
+	if err != nil {
 		return err
 	}
-	s.statsMgr.Initialize(p.ID)
+	s.statsMgr.Initialize(created.ID)
 	return nil
 }
 
 func (s *Subsystem) Update(id string, p Parameter) error {
-	p.ID = id
-	return s.c.Store().Update(Bucket, id, p)
+	return s.repo.Update(id, p)
 }
 
 func (s *Subsystem) Delete(id string) error {
-	if err := s.c.Store().Delete(Bucket, id); err != nil {
-		return err
-	}
-	if err := s.c.Store().Delete(UsageBucket, id); err != nil {
-		log.Println("ERROR: journal-subsystem: Failed to deleted usage details for journal:", id)
-	}
-	return nil
+	return s.repo.Delete(id)
 }
 
 func (s *Subsystem) AddEntry(id string, e Entry) error {

--- a/controller/modules/journal/repository.go
+++ b/controller/modules/journal/repository.go
@@ -1,0 +1,74 @@
+package journal
+
+import (
+	"encoding/json"
+	"log"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+type repository interface {
+	Setup() error
+	Get(string) (Parameter, error)
+	List() ([]Parameter, error)
+	Create(Parameter) (Parameter, error)
+	Update(string, Parameter) error
+	Delete(string) error
+}
+
+type storeRepository struct {
+	store storage.Store
+}
+
+func newRepository(store storage.Store) repository {
+	return storeRepository{store: store}
+}
+
+func (r storeRepository) Setup() error {
+	if err := r.store.CreateBucket(Bucket); err != nil {
+		return err
+	}
+	return r.store.CreateBucket(UsageBucket)
+}
+
+func (r storeRepository) Get(id string) (Parameter, error) {
+	var p Parameter
+	return p, r.store.Get(Bucket, id, &p)
+}
+
+func (r storeRepository) List() ([]Parameter, error) {
+	params := []Parameter{}
+	fn := func(_ string, v []byte) error {
+		var p Parameter
+		if err := json.Unmarshal(v, &p); err != nil {
+			return err
+		}
+		params = append(params, p)
+		return nil
+	}
+	return params, r.store.List(Bucket, fn)
+}
+
+func (r storeRepository) Create(p Parameter) (Parameter, error) {
+	created := p
+	fn := func(id string) interface{} {
+		created.ID = id
+		return &created
+	}
+	return created, r.store.Create(Bucket, fn)
+}
+
+func (r storeRepository) Update(id string, p Parameter) error {
+	p.ID = id
+	return r.store.Update(Bucket, id, p)
+}
+
+func (r storeRepository) Delete(id string) error {
+	if err := r.store.Delete(Bucket, id); err != nil {
+		return err
+	}
+	if err := r.store.Delete(UsageBucket, id); err != nil {
+		log.Println("ERROR: journal-subsystem: Failed to deleted usage details for journal:", id)
+	}
+	return nil
+}

--- a/controller/modules/journal/repository_test.go
+++ b/controller/modules/journal/repository_test.go
@@ -1,0 +1,88 @@
+package journal
+
+import (
+	"testing"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+func TestStoreRepositoryCRUD(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	repo := newRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	param := Parameter{Name: "Salinity", Unit: "ppt", Description: "Salt level"}
+	created, err := repo.Create(param)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.ID != "1" {
+		t.Fatalf("expected created ID 1, got %q", created.ID)
+	}
+
+	got, err := repo.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "1" || got.Name != "Salinity" || got.Unit != "ppt" {
+		t.Fatalf("unexpected parameter: %#v", got)
+	}
+
+	got.ID = "stale"
+	got.Name = "Alkalinity"
+	if err := repo.Update(created.ID, got); err != nil {
+		t.Fatal(err)
+	}
+
+	params, err := repo.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(params) != 1 || params[0].ID != "1" || params[0].Name != "Alkalinity" {
+		t.Fatalf("unexpected parameters: %#v", params)
+	}
+
+	if err := repo.Delete(created.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.Get(created.ID); err == nil {
+		t.Fatal("expected deleted parameter lookup to fail")
+	}
+}
+
+func TestStoreRepositoryDeleteRemovesUsage(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	repo := newRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := repo.Create(Parameter{Name: "pH", Unit: "pH"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateWithID(UsageBucket, created.ID, []Entry{{Value: 8.2}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repo.Delete(created.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	var entries []Entry
+	if err := store.Get(UsageBucket, created.ID, &entries); err == nil {
+		t.Fatal("expected deleted usage lookup to fail")
+	}
+}

--- a/controller/modules/journal/subsystem.go
+++ b/controller/modules/journal/subsystem.go
@@ -14,20 +14,19 @@ const UsageBucket = storage.JournalUsageBucket
 type Subsystem struct {
 	statsMgr telemetry.StatsManager
 	c        controller.Controller
+	repo     repository
 }
 
 func New(c controller.Controller) *Subsystem {
 	return &Subsystem{
 		c:        c,
+		repo:     newRepository(c.Store()),
 		statsMgr: c.Telemetry().NewStatsManager(UsageBucket),
 	}
 }
 
 func (s *Subsystem) Setup() error {
-	if err := s.c.Store().CreateBucket(Bucket); err != nil {
-		return err
-	}
-	return s.c.Store().CreateBucket(UsageBucket)
+	return s.repo.Setup()
 }
 
 func (s *Subsystem) Start() {}


### PR DESCRIPTION
Summary: adds a narrow repository seam for journal parameter storage setup, CRUD/list/get, and usage cleanup while keeping telemetry/stat behavior in the subsystem. Tests: rtk go test ./controller/modules/journal; rtk go test ./controller/...; rtk git diff --check.