### PR TITLE
Slice 05: add ATO storage repository seam

### DIFF
--- a/controller/modules/ato/ato.go
+++ b/controller/modules/ato/ato.go
@@ -1,7 +1,6 @@
 package ato
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"time"
@@ -48,20 +47,10 @@ func (c *Controller) On(id string, b bool) error {
 }
 
 func (c *Controller) Get(id string) (ATO, error) {
-	var a ATO
-	return a, c.c.Store().Get(Bucket, id, &a)
+	return c.repo.Get(id)
 }
 func (c *Controller) List() ([]ATO, error) {
-	atos := []ATO{}
-	fn := func(_ string, v []byte) error {
-		var a ATO
-		if err := json.Unmarshal(v, &a); err != nil {
-			return err
-		}
-		atos = append(atos, a)
-		return nil
-	}
-	return atos, c.c.Store().List(Bucket, fn)
+	return c.repo.List()
 }
 
 func (c *Controller) Create(a ATO) error {
@@ -70,11 +59,9 @@ func (c *Controller) Create(a ATO) error {
 	if a.Period <= 0 {
 		return fmt.Errorf("Check period for ato controller must be greater than zero")
 	}
-	fn := func(id string) interface{} {
-		a.ID = id
-		return &a
-	}
-	if err := c.c.Store().Create(Bucket, fn); err != nil {
+	var err error
+	a, err = c.repo.Create(a)
+	if err != nil {
 		return err
 	}
 	c.statsMgr.Initialize(a.ID)
@@ -97,7 +84,7 @@ func (c *Controller) Update(id string, a ATO) error {
 	if a.Period <= 0 {
 		return fmt.Errorf("Period should be positive. Supplied:%d", a.Period)
 	}
-	if err := c.c.Store().Update(Bucket, id, a); err != nil {
+	if err := c.repo.Update(id, a); err != nil {
 		return err
 	}
 	quit, ok := c.quitters[a.ID]
@@ -130,7 +117,7 @@ func (c *Controller) Reset(id string) error {
 	if err := c.statsMgr.Delete(id); err != nil {
 		log.Println("ERROR:  ato-subsystem: Failed to deleted usage details for ato:", id, "error:", err)
 	}
-	if err := c.c.Store().Delete(UsageBucket, id); err != nil {
+	if err := c.repo.DeleteUsage(id); err != nil {
 		log.Println("ERROR:  ato-subsystem: Failed to deleted usage details for ato:", id, "error:", err)
 	}
 	c.mu.Lock()
@@ -144,11 +131,8 @@ func (c *Controller) Reset(id string) error {
 }
 
 func (c *Controller) Delete(id string) error {
-	if err := c.c.Store().Delete(Bucket, id); err != nil {
+	if err := c.repo.Delete(id); err != nil {
 		return err
-	}
-	if err := c.c.Store().Delete(UsageBucket, id); err != nil {
-		log.Println("ERROR:  ato-subsystem: Failed to deleted usage details for ato:", id)
 	}
 	quit, ok := c.quitters[id]
 	if ok {

--- a/controller/modules/ato/controller.go
+++ b/controller/modules/ato/controller.go
@@ -24,6 +24,7 @@ type Controller struct {
 	mu       *sync.Mutex
 	inlets   *connectors.Inlets
 	c        controller.Controller
+	repo     repository
 	lowSince map[string]*time.Time
 }
 
@@ -35,6 +36,7 @@ func New(devMode bool, c controller.Controller) (*Controller, error) {
 		quitters: make(map[string]chan struct{}),
 		statsMgr: c.Telemetry().NewStatsManager(UsageBucket),
 		c:        c,
+		repo:     newRepository(c.Store()),
 		lowSince: make(map[string]*time.Time),
 	}
 	return con, nil
@@ -63,10 +65,7 @@ func (c *Controller) sub(a ATO) (controller.Subsystem, error) {
 }
 
 func (c *Controller) Setup() error {
-	if err := c.c.Store().CreateBucket(Bucket); err != nil {
-		return err
-	}
-	return c.c.Store().CreateBucket(UsageBucket)
+	return c.repo.Setup()
 }
 
 func (c *Controller) Start() {

--- a/controller/modules/ato/repository.go
+++ b/controller/modules/ato/repository.go
@@ -1,0 +1,79 @@
+package ato
+
+import (
+	"encoding/json"
+	"log"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+type repository interface {
+	Setup() error
+	Get(string) (ATO, error)
+	List() ([]ATO, error)
+	Create(ATO) (ATO, error)
+	Update(string, ATO) error
+	Delete(string) error
+	DeleteUsage(string) error
+}
+
+type storeRepository struct {
+	store storage.Store
+}
+
+func newRepository(store storage.Store) repository {
+	return storeRepository{store: store}
+}
+
+func (r storeRepository) Setup() error {
+	if err := r.store.CreateBucket(Bucket); err != nil {
+		return err
+	}
+	return r.store.CreateBucket(UsageBucket)
+}
+
+func (r storeRepository) Get(id string) (ATO, error) {
+	var a ATO
+	return a, r.store.Get(Bucket, id, &a)
+}
+
+func (r storeRepository) List() ([]ATO, error) {
+	atos := []ATO{}
+	fn := func(_ string, v []byte) error {
+		var a ATO
+		if err := json.Unmarshal(v, &a); err != nil {
+			return err
+		}
+		atos = append(atos, a)
+		return nil
+	}
+	return atos, r.store.List(Bucket, fn)
+}
+
+func (r storeRepository) Create(a ATO) (ATO, error) {
+	created := a
+	fn := func(id string) interface{} {
+		created.ID = id
+		return &created
+	}
+	return created, r.store.Create(Bucket, fn)
+}
+
+func (r storeRepository) Update(id string, a ATO) error {
+	a.ID = id
+	return r.store.Update(Bucket, id, a)
+}
+
+func (r storeRepository) Delete(id string) error {
+	if err := r.store.Delete(Bucket, id); err != nil {
+		return err
+	}
+	if err := r.DeleteUsage(id); err != nil {
+		log.Println("ERROR:  ato-subsystem: Failed to deleted usage details for ato:", id)
+	}
+	return nil
+}
+
+func (r storeRepository) DeleteUsage(id string) error {
+	return r.store.Delete(UsageBucket, id)
+}

--- a/controller/modules/ato/repository_test.go
+++ b/controller/modules/ato/repository_test.go
@@ -1,0 +1,127 @@
+package ato
+
+import (
+	"testing"
+	"time"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+	"github.com/reef-pi/reef-pi/controller/telemetry"
+)
+
+func TestStoreRepositoryCRUD(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	repo := newRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	ato := ATO{
+		Name:    "Sump ATO",
+		Inlet:   "inlet-1",
+		Pump:    "pump-1",
+		Period:  5,
+		Control: true,
+		Enable:  true,
+	}
+	created, err := repo.Create(ato)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.ID != "1" {
+		t.Fatalf("expected created ID 1, got %q", created.ID)
+	}
+
+	got, err := repo.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "1" || got.Name != "Sump ATO" || got.Inlet != "inlet-1" {
+		t.Fatalf("unexpected ato: %#v", got)
+	}
+
+	got.ID = "stale"
+	got.Name = "Reservoir ATO"
+	if err := repo.Update(created.ID, got); err != nil {
+		t.Fatal(err)
+	}
+
+	atos, err := repo.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(atos) != 1 || atos[0].ID != "1" || atos[0].Name != "Reservoir ATO" {
+		t.Fatalf("unexpected atos: %#v", atos)
+	}
+
+	if err := repo.Delete(created.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.Get(created.ID); err == nil {
+		t.Fatal("expected deleted ato lookup to fail")
+	}
+}
+
+func TestStoreRepositoryDeleteUsage(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	repo := newRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := repo.Create(ATO{Name: "Usage ATO", Period: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	usage := Usage{Pump: 5, Time: telemetry.TeleTime(time.Now())}
+	if err := store.Update(UsageBucket, created.ID, usage); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.DeleteUsage(created.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	var got Usage
+	if err := store.Get(UsageBucket, created.ID, &got); err == nil {
+		t.Fatal("expected deleted usage lookup to fail")
+	}
+}
+
+func TestStoreRepositoryDeleteRemovesUsage(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	repo := newRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := repo.Create(ATO{Name: "Delete ATO", Period: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	usage := Usage{Pump: 7, Time: telemetry.TeleTime(time.Now())}
+	if err := store.Update(UsageBucket, created.ID, usage); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Delete(created.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	var got Usage
+	if err := store.Get(UsageBucket, created.ID, &got); err == nil {
+		t.Fatal("expected deleted usage lookup to fail")
+	}
+}


### PR DESCRIPTION
Summary: adds a narrow repository seam for ATO storage setup, CRUD/list/get, and usage deletion while leaving validation, stats, goroutines, API behavior, and hardware control in the controller. Tests: rtk go test ./controller/modules/ato; rtk go test ./controller/...; rtk git diff --check.