### PR TITLE
Slice 05: add camera storage repository seam

### DIFF
--- a/controller/modules/camera/api.go
+++ b/controller/modules/camera/api.go
@@ -81,9 +81,9 @@ func (c *Controller) shoot(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *Controller) latest(w http.ResponseWriter, r *http.Request) {
-	var data map[string]string
 	fn := func(_ string) (interface{}, error) {
-		return &data, c.c.Store().Get(Bucket, "latest", &data)
+		data, err := c.repo.Latest()
+		return &data, err
 	}
 	utils.JSONGetResponse(fn, w, r)
 }
@@ -91,7 +91,7 @@ func (c *Controller) latest(w http.ResponseWriter, r *http.Request) {
 func (c *Controller) update(w http.ResponseWriter, r *http.Request) {
 	var conf Config
 	fn := func(id string) error {
-		if err := saveConfig(c.c.Store(), conf); err != nil {
+		if err := c.repo.SaveConfig(conf); err != nil {
 			return err
 		}
 		c.Stop()

--- a/controller/modules/camera/camera.go
+++ b/controller/modules/camera/camera.go
@@ -22,6 +22,7 @@ type Controller struct {
 	mu      sync.Mutex
 	DevMode bool
 	c       controller.Controller
+	repo    repository
 }
 
 func New(devMode bool, c controller.Controller) (*Controller, error) {
@@ -31,6 +32,7 @@ func New(devMode bool, c controller.Controller) (*Controller, error) {
 		DevMode: devMode,
 		stopCh:  make(chan struct{}),
 		c:       c,
+		repo:    newRepository(c.Store()),
 	}, nil
 }
 
@@ -85,14 +87,14 @@ func (c *Controller) Stop() {
 }
 
 func (c *Controller) Setup() error {
-	if err := c.c.Store().CreateBucket(Bucket); err != nil {
+	if err := c.repo.Setup(); err != nil {
 		return err
 	}
-	conf, err := loadConfig(c.c.Store())
+	conf, err := c.repo.LoadConfig()
 	if err != nil {
 		log.Println("WARNING: camera config not found. Initializing default config")
 		conf = Default
-		if err := saveConfig(c.c.Store(), conf); err != nil {
+		if err := c.repo.SaveConfig(conf); err != nil {
 			log.Println("ERROR: Failed to save camera config. Error:", err)
 			return err
 		}
@@ -100,9 +102,6 @@ func (c *Controller) Setup() error {
 	c.mu.Lock()
 	c.config = conf
 	c.mu.Unlock()
-	if err := c.c.Store().CreateBucket(ItemBucket); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -122,10 +121,8 @@ func (c *Controller) Capture() (string, error) {
 		log.Println("ERROR: Failed to execute image capture command:", command, "Error:", err)
 		return "", err
 	}
-	data := make(map[string]string)
-	data["image"] = imgName
 	log.Println("Camera subsystem: Image captured:", imgPath)
-	return imgName, c.c.Store().Update(Bucket, "latest", data)
+	return imgName, c.repo.SaveLatest(imgName)
 }
 
 func (c *Controller) uploadImage(imgName string) {

--- a/controller/modules/camera/camera_test.go
+++ b/controller/modules/camera/camera_test.go
@@ -75,12 +75,12 @@ func TestCamera(t *testing.T) {
 	c.run()
 	conf := c.config
 	conf.TickInterval = -1
-	if err := saveConfig(con.Store(), conf); err == nil {
+	if err := c.repo.SaveConfig(conf); err == nil {
 		t.Error("config should not be saved if period is negative")
 	}
 	conf = c.config
 	conf.ImageDirectory = ""
-	if err := saveConfig(con.Store(), conf); err == nil {
+	if err := c.repo.SaveConfig(conf); err == nil {
 		t.Error("config should not be saved if image directory is empty")
 	}
 	if err := c.On("1", true); err == nil {

--- a/controller/modules/camera/config.go
+++ b/controller/modules/camera/config.go
@@ -3,8 +3,6 @@ package camera
 import (
 	"fmt"
 	"time"
-
-	"github.com/reef-pi/reef-pi/controller/storage"
 )
 
 const DefaulCaptureFlags = ""
@@ -36,17 +34,12 @@ var Default = Config{
 	},
 }
 
-func loadConfig(store storage.Store) (Config, error) {
-	var conf Config
-	return conf, store.Get(Bucket, "config", &conf)
-}
-
-func saveConfig(store storage.Store, conf Config) error {
+func validateConfig(conf Config) error {
 	if conf.TickInterval <= 0 {
 		return fmt.Errorf("Tick Interval for camera controller must be greater than zero")
 	}
 	if conf.ImageDirectory == "" {
 		return fmt.Errorf("Image directory cant not be empty")
 	}
-	return store.Update(Bucket, "config", conf)
+	return nil
 }

--- a/controller/modules/camera/process.go
+++ b/controller/modules/camera/process.go
@@ -1,7 +1,6 @@
 package camera
 
 import (
-	"encoding/json"
 	"image"
 	"image/jpeg"
 	_ "image/png"
@@ -46,22 +45,9 @@ func (c *Controller) Process(name string) error {
 	i := ImageItem{
 		Name: name,
 	}
-	fn := func(id string) interface{} {
-		i.ID = id
-		return &i
-	}
-	return c.c.Store().Create(ItemBucket, fn)
+	return c.repo.CreateItem(i)
 }
 
 func (c *Controller) List() ([]ImageItem, error) {
-	items := []ImageItem{}
-	fn := func(_ string, v []byte) error {
-		var i ImageItem
-		if err := json.Unmarshal(v, &i); err != nil {
-			return err
-		}
-		items = append(items, i)
-		return nil
-	}
-	return items, c.c.Store().List(ItemBucket, fn)
+	return c.repo.ListItems()
 }

--- a/controller/modules/camera/repository.go
+++ b/controller/modules/camera/repository.go
@@ -1,0 +1,77 @@
+package camera
+
+import (
+	"encoding/json"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+type repository interface {
+	Setup() error
+	LoadConfig() (Config, error)
+	SaveConfig(Config) error
+	Latest() (map[string]string, error)
+	SaveLatest(string) error
+	ListItems() ([]ImageItem, error)
+	CreateItem(ImageItem) error
+}
+
+type storeRepository struct {
+	store storage.Store
+}
+
+func newRepository(store storage.Store) repository {
+	return storeRepository{store: store}
+}
+
+func (r storeRepository) Setup() error {
+	if err := r.store.CreateBucket(Bucket); err != nil {
+		return err
+	}
+	return r.store.CreateBucket(ItemBucket)
+}
+
+func (r storeRepository) LoadConfig() (Config, error) {
+	var conf Config
+	return conf, r.store.Get(Bucket, "config", &conf)
+}
+
+func (r storeRepository) SaveConfig(conf Config) error {
+	if err := validateConfig(conf); err != nil {
+		return err
+	}
+	return r.store.Update(Bucket, "config", conf)
+}
+
+func (r storeRepository) Latest() (map[string]string, error) {
+	data := map[string]string{}
+	return data, r.store.Get(Bucket, "latest", &data)
+}
+
+func (r storeRepository) SaveLatest(name string) error {
+	data := map[string]string{
+		"image": name,
+	}
+	return r.store.Update(Bucket, "latest", data)
+}
+
+func (r storeRepository) ListItems() ([]ImageItem, error) {
+	items := []ImageItem{}
+	fn := func(_ string, v []byte) error {
+		var i ImageItem
+		if err := json.Unmarshal(v, &i); err != nil {
+			return err
+		}
+		items = append(items, i)
+		return nil
+	}
+	return items, r.store.List(ItemBucket, fn)
+}
+
+func (r storeRepository) CreateItem(item ImageItem) error {
+	fn := func(id string) interface{} {
+		item.ID = id
+		return &item
+	}
+	return r.store.Create(ItemBucket, fn)
+}

--- a/controller/modules/camera/repository_test.go
+++ b/controller/modules/camera/repository_test.go
@@ -1,0 +1,93 @@
+package camera
+
+import (
+	"testing"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+func testRepository(t *testing.T) repository {
+	t.Helper()
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		store.Close()
+	})
+
+	repo := newRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	return repo
+}
+
+func TestStoreRepositoryConfigPersistence(t *testing.T) {
+	repo := testRepository(t)
+
+	conf := Default
+	conf.Enable = true
+	conf.ImageDirectory = "/tmp/camera-images"
+	conf.CaptureFlags = "--width 800"
+	conf.Upload = true
+	conf.Motion.Enable = true
+	if err := repo.SaveConfig(conf); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := repo.LoadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ImageDirectory != conf.ImageDirectory || got.CaptureFlags != conf.CaptureFlags || !got.Enable || !got.Upload || !got.Motion.Enable {
+		t.Fatalf("unexpected config: %#v", got)
+	}
+
+	conf.TickInterval = 0
+	if err := repo.SaveConfig(conf); err == nil {
+		t.Fatal("expected invalid tick interval to fail")
+	}
+	conf = Default
+	conf.ImageDirectory = ""
+	if err := repo.SaveConfig(conf); err == nil {
+		t.Fatal("expected empty image directory to fail")
+	}
+}
+
+func TestStoreRepositoryLatestAndItems(t *testing.T) {
+	repo := testRepository(t)
+
+	if err := repo.SaveLatest("latest.jpg"); err != nil {
+		t.Fatal(err)
+	}
+	latest, err := repo.Latest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if latest["image"] != "latest.jpg" {
+		t.Fatalf("unexpected latest image: %#v", latest)
+	}
+
+	if err := repo.CreateItem(ImageItem{Name: "first.jpg"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.CreateItem(ImageItem{Name: "second.jpg"}); err != nil {
+		t.Fatal(err)
+	}
+	items, err := repo.ListItems()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %#v", items)
+	}
+
+	names := map[string]string{}
+	for _, item := range items {
+		names[item.ID] = item.Name
+	}
+	if names["1"] != "first.jpg" || names["2"] != "second.jpg" {
+		t.Fatalf("unexpected items: %#v", items)
+	}
+}


### PR DESCRIPTION
Summary: adds a narrow repository seam for camera config, latest image metadata, and gallery item storage while leaving command execution, file IO, thumbnail generation, API paths, and capture/process behavior outside the repository. Tests: rtk go test ./controller/modules/camera; rtk go test ./controller/...; rtk git diff --check; rtk git diff --cached --check.