### PR TITLE
Slice 05: add equipment storage repository seam

### DIFF
--- a/controller/modules/equipment/controller.go
+++ b/controller/modules/equipment/controller.go
@@ -13,20 +13,20 @@ import (
 
 type Controller struct {
 	telemetry telemetry.Telemetry
-	store     storage.Store
+	repo      repository
 	outlets   *connectors.Outlets
 }
 
 func New(c controller.Controller) *Controller {
 	return &Controller{
 		telemetry: c.Telemetry(),
-		store:     c.Store(),
+		repo:      newRepository(c.Store()),
 		outlets:   c.DM().Outlets(),
 	}
 }
 
 func (c *Controller) Setup() error {
-	return c.store.CreateBucket(Bucket)
+	return c.repo.Setup()
 }
 
 func (c *Controller) Start() {

--- a/controller/modules/equipment/equipment.go
+++ b/controller/modules/equipment/equipment.go
@@ -1,7 +1,6 @@
 package equipment
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 
@@ -21,21 +20,11 @@ type Equipment struct {
 }
 
 func (c *Controller) Get(id string) (Equipment, error) {
-	var eq Equipment
-	return eq, c.store.Get(Bucket, id, &eq)
+	return c.repo.Get(id)
 }
 
 func (c Controller) List() ([]Equipment, error) {
-	es := []Equipment{}
-	fn := func(_ string, v []byte) error {
-		var eq Equipment
-		if err := json.Unmarshal(v, &eq); err != nil {
-			return err
-		}
-		es = append(es, eq)
-		return nil
-	}
-	return es, c.store.List(Bucket, fn)
+	return c.repo.List()
 }
 
 func (c *Controller) validateOutlet(eq Equipment) error {
@@ -55,14 +44,11 @@ func (c *Controller) Create(eq Equipment) error {
 	if err := c.validateOutlet(eq); err != nil {
 		return err
 	}
-	fn := func(id string) interface{} {
-		eq.ID = id
-		return &eq
-	}
-	if err := c.store.Create(Bucket, fn); err != nil {
+	created, err := c.repo.Create(eq)
+	if err != nil {
 		return err
 	}
-	if err := c.updateOutlet(eq); err != nil {
+	if err := c.updateOutlet(created); err != nil {
 		log.Println("Failed to configure outlet")
 		return err
 	}
@@ -74,7 +60,7 @@ func (c *Controller) Update(id string, eq Equipment) error {
 	if err := c.validateOutlet(eq); err != nil {
 		return err
 	}
-	if err := c.store.Update(Bucket, id, eq); err != nil {
+	if err := c.repo.Update(id, eq); err != nil {
 		return err
 	}
 	return c.updateOutlet(eq)
@@ -85,7 +71,7 @@ func (c *Controller) Delete(id string) error {
 	if err != nil {
 		return err
 	}
-	return c.store.Delete(Bucket, id)
+	return c.repo.Delete(id)
 }
 
 func (c *Controller) synEquipment() {

--- a/controller/modules/equipment/repository.go
+++ b/controller/modules/equipment/repository.go
@@ -1,0 +1,65 @@
+package equipment
+
+import (
+	"encoding/json"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+type repository interface {
+	Setup() error
+	Get(string) (Equipment, error)
+	List() ([]Equipment, error)
+	Create(Equipment) (Equipment, error)
+	Update(string, Equipment) error
+	Delete(string) error
+}
+
+type storeRepository struct {
+	store storage.Store
+}
+
+func newRepository(store storage.Store) repository {
+	return storeRepository{store: store}
+}
+
+func (r storeRepository) Setup() error {
+	return r.store.CreateBucket(Bucket)
+}
+
+func (r storeRepository) Get(id string) (Equipment, error) {
+	var eq Equipment
+	return eq, r.store.Get(Bucket, id, &eq)
+}
+
+func (r storeRepository) List() ([]Equipment, error) {
+	equipment := []Equipment{}
+	fn := func(_ string, v []byte) error {
+		var eq Equipment
+		if err := json.Unmarshal(v, &eq); err != nil {
+			return err
+		}
+		equipment = append(equipment, eq)
+		return nil
+	}
+	return equipment, r.store.List(Bucket, fn)
+}
+
+func (r storeRepository) Create(eq Equipment) (Equipment, error) {
+	created := eq
+	fn := func(id string) interface{} {
+		created.ID = id
+		return &created
+	}
+	err := r.store.Create(Bucket, fn)
+	return created, err
+}
+
+func (r storeRepository) Update(id string, eq Equipment) error {
+	eq.ID = id
+	return r.store.Update(Bucket, id, eq)
+}
+
+func (r storeRepository) Delete(id string) error {
+	return r.store.Delete(Bucket, id)
+}

--- a/controller/modules/equipment/repository_test.go
+++ b/controller/modules/equipment/repository_test.go
@@ -1,0 +1,64 @@
+package equipment
+
+import (
+	"testing"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+func TestStoreRepositoryCRUD(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	repo := newRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	eq := Equipment{
+		Name:          "Return Pump",
+		Outlet:        "1",
+		On:            true,
+		StayOffOnBoot: true,
+		BootDelay:     5,
+	}
+	created, err := repo.Create(eq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.ID != "1" {
+		t.Fatalf("expected created ID 1, got %q", created.ID)
+	}
+
+	got, err := repo.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "1" || got.Name != "Return Pump" || got.Outlet != "1" || !got.On || !got.StayOffOnBoot || got.BootDelay != 5 {
+		t.Fatalf("unexpected equipment: %#v", got)
+	}
+
+	got.Name = "Skimmer"
+	got.On = false
+	if err := repo.Update(got.ID, got); err != nil {
+		t.Fatal(err)
+	}
+
+	equipment, err := repo.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(equipment) != 1 || equipment[0].Name != "Skimmer" || equipment[0].On {
+		t.Fatalf("unexpected equipment list: %#v", equipment)
+	}
+
+	if err := repo.Delete(got.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.Get(got.ID); err == nil {
+		t.Fatal("expected deleted equipment lookup to fail")
+	}
+}


### PR DESCRIPTION
Summary: adds a narrow repository seam for equipment storage setup and CRUD/list/get while keeping outlet validation, outlet sync, telemetry, and boot behavior in the controller. Tests: rtk go test ./controller/modules/equipment; rtk go test ./controller/...; rtk git diff --check; rtk git diff --cached --check.