### PR TITLE
Slice 05: add system storage repository seam

### DIFF
--- a/controller/modules/system/controller.go
+++ b/controller/modules/system/controller.go
@@ -25,6 +25,7 @@ type Config struct {
 type Controller struct {
 	config                    Config
 	c                         controller.Controller
+	repo                      repository
 	PowerFile, BrightnessFile string
 	isRaspberryPi             bool
 	model, ip                 string
@@ -34,6 +35,7 @@ func New(conf Config, c controller.Controller) *Controller {
 	con := &Controller{
 		config:         conf,
 		c:              c,
+		repo:           newRepository(c.Store()),
 		PowerFile:      PowerFile,
 		BrightnessFile: BrightnessFile,
 	}
@@ -55,7 +57,7 @@ func (c *Controller) Stop() {
 }
 
 func (c *Controller) Setup() error {
-	return c.c.Store().CreateBucket(Bucket)
+	return c.repo.Setup()
 }
 func (c *Controller) On(id string, on bool) error {
 	return nil

--- a/controller/modules/system/repository.go
+++ b/controller/modules/system/repository.go
@@ -1,0 +1,46 @@
+package system
+
+import "github.com/reef-pi/reef-pi/controller/storage"
+
+const (
+	startTimeID = "start_time"
+	stopTimeID  = "stop_time"
+)
+
+type repository interface {
+	Setup() error
+	LogStartTime(TimeLog) error
+	LogStopTime(TimeLog) error
+	LastStartTime() (TimeLog, error)
+	LastStopTime() (TimeLog, error)
+}
+
+type storeRepository struct {
+	store storage.Store
+}
+
+func newRepository(store storage.Store) repository {
+	return storeRepository{store: store}
+}
+
+func (r storeRepository) Setup() error {
+	return r.store.CreateBucket(Bucket)
+}
+
+func (r storeRepository) LogStartTime(l TimeLog) error {
+	return r.store.CreateWithID(Bucket, startTimeID, &l)
+}
+
+func (r storeRepository) LogStopTime(l TimeLog) error {
+	return r.store.CreateWithID(Bucket, stopTimeID, &l)
+}
+
+func (r storeRepository) LastStartTime() (TimeLog, error) {
+	var l TimeLog
+	return l, r.store.Get(Bucket, startTimeID, &l)
+}
+
+func (r storeRepository) LastStopTime() (TimeLog, error) {
+	var l TimeLog
+	return l, r.store.Get(Bucket, stopTimeID, &l)
+}

--- a/controller/modules/system/repository_test.go
+++ b/controller/modules/system/repository_test.go
@@ -1,0 +1,72 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+func TestStoreRepositoryUptime(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	repo := newRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	start := TimeLog{Time: "2026-04-29T10:00:00Z"}
+	if err := repo.LogStartTime(start); err != nil {
+		t.Fatal(err)
+	}
+	gotStart, err := repo.LastStartTime()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotStart.Time != start.Time {
+		t.Fatalf("expected start time %q, got %q", start.Time, gotStart.Time)
+	}
+
+	stop := TimeLog{Time: "2026-04-29T11:00:00Z"}
+	if err := repo.LogStopTime(stop); err != nil {
+		t.Fatal(err)
+	}
+	gotStop, err := repo.LastStopTime()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotStop.Time != stop.Time {
+		t.Fatalf("expected stop time %q, got %q", stop.Time, gotStop.Time)
+	}
+}
+
+func TestStoreRepositoryUptimeOverwritesExistingValues(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	repo := newRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repo.LogStartTime(TimeLog{Time: "2026-04-29T10:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.LogStartTime(TimeLog{Time: "2026-04-29T10:05:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := repo.LastStartTime()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Time != "2026-04-29T10:05:00Z" {
+		t.Fatalf("expected overwritten start time, got %q", got.Time)
+	}
+}

--- a/controller/modules/system/uptime.go
+++ b/controller/modules/system/uptime.go
@@ -15,24 +15,24 @@ func (c *Controller) logStartTime() error {
 	l := TimeLog{
 		Time: time.Now().Format(time.RFC3339),
 	}
-	return c.c.Store().CreateWithID(Bucket, "start_time", &l)
+	return c.repo.LogStartTime(l)
 }
 
 func (c *Controller) logStopTime() error {
 	l := TimeLog{
 		Time: time.Now().Format(time.RFC3339),
 	}
-	return c.c.Store().CreateWithID(Bucket, "stop_time", &l)
+	return c.repo.LogStopTime(l)
 }
 
 func (c *Controller) lastStartTime() (string, error) {
-	var t TimeLog
-	return t.Time, c.c.Store().Get(Bucket, "start_time", &t)
+	t, err := c.repo.LastStartTime()
+	return t.Time, err
 }
 
 func (c *Controller) lastStopTime() (string, error) {
-	var t TimeLog
-	return t.Time, c.c.Store().Get(Bucket, "stop_time", &t)
+	t, err := c.repo.LastStopTime()
+	return t.Time, err
 }
 
 func (c *Controller) Uptime() string {


### PR DESCRIPTION
Summary: adds a narrow repository seam for the system bucket and uptime timestamp storage. Setup, start-time writes, stop-time writes, and last-start/last-stop reads now go through the repository. Backup and restore file handling remains unchanged because it operates on the DB file path rather than subsystem object storage.\n\nScope: Slice 05 backend storage and service seams; focused on controller/modules/system. No API path, payload, bucket name, timestamp key, uptime formatting, backup, restore, or hardware/display behavior changes intended.\n\nValidation: rtk go test ./controller/modules/system; rtk go test ./controller/...; rtk rg -n "Store\(\)\.(Get|List|Create|Update|Delete|CreateBucket|CreateWithID)" controller/modules; rtk git diff --check; rtk git diff --cached --check.\n\nRollback: isolated to system storage indirection and repository tests.