### PR TITLE
Slice 06: clean up system interface naming

### DIFF
--- a/controller/modules/system/info.go
+++ b/controller/modules/system/info.go
@@ -47,18 +47,18 @@ func (c *Controller) ComputeSummary() Summary {
 	return s
 }
 
-const _unknwonIface = "unknown"
+const unknownIface = "unknown"
 
 func HostIP(i string) string {
 	iface, err := net.InterfaceByName(i)
 	if err != nil {
-		log.Println("WARN: Failed to obatin interface details: "+i+". Error:", err)
-		return _unknwonIface
+		log.Println("WARN: Failed to obtain interface details: "+i+". Error:", err)
+		return unknownIface
 	}
 	addrs, err := iface.Addrs()
 	if err != nil {
 		log.Println("WARN: Failed to fetch address for interface: "+i+". Error:", err)
-		return _unknwonIface
+		return unknownIface
 	}
 	for _, v := range addrs {
 		switch s := v.(type) {
@@ -69,7 +69,7 @@ func HostIP(i string) string {
 		}
 	}
 	log.Println("WARN: interface " + i + " has no associated ip")
-	return _unknwonIface
+	return unknownIface
 }
 
 // temp=36.9'C


### PR DESCRIPTION
Summary: fixes an internal system interface constant typo and a warning log typo. No behavior, API, storage, or UI changes intended.\n\nScope: Slice 06 backend naming cleanup; focused on controller/modules/system/info.go.\n\nValidation: rtk go test ./controller/modules/system; rtk go test ./controller/...; rtk rg -n "unknwon|obatin" controller/modules/system; rtk git diff --check.\n\nRollback: one-file naming/log cleanup.