### PR TITLE
Slice 05: add daemon dashboard repository seam

### DIFF
--- a/controller/daemon/dashboard.go
+++ b/controller/daemon/dashboard.go
@@ -33,32 +33,30 @@ var DefaultDashboard = Dashboard{
 }
 
 func loadDashboard(store storage.Store) (Dashboard, error) {
-	var d Dashboard
-	if err := store.Get(Bucket, "dashboard", &d); err != nil {
-		return d, err
-	}
-	return d, nil
+	return newDashboardRepository(store).Get()
 }
 
 func initializeDashboard(store storage.Store) (Dashboard, error) {
-	if err := store.CreateBucket(Bucket); err != nil {
+	if err := newDashboardRepository(store).Setup(); err != nil {
 		log.Println("ERROR:Failed to create bucket:", Bucket, ". Error:", err)
 		return DefaultDashboard, err
 	}
-	return DefaultDashboard, store.Update(Bucket, "dashboard", DefaultDashboard)
+	return DefaultDashboard, nil
 }
 
 func (r *ReefPi) GetDashboard(w http.ResponseWriter, req *http.Request) {
+	repo := newDashboardRepository(r.store)
 	fn := func(_ string) (interface{}, error) {
-		return loadDashboard(r.store)
+		return repo.Get()
 	}
 	utils.JSONGetResponse(fn, w, req)
 }
 
 func (r *ReefPi) UpdateDashboard(w http.ResponseWriter, req *http.Request) {
 	var d Dashboard
+	repo := newDashboardRepository(r.store)
 	fn := func(_ string) error {
-		return r.store.Update(Bucket, "dashboard", d)
+		return repo.Update(d)
 	}
 	utils.JSONUpdateResponse(&d, fn, w, req)
 }

--- a/controller/daemon/dashboard_repository.go
+++ b/controller/daemon/dashboard_repository.go
@@ -1,0 +1,34 @@
+package daemon
+
+import "github.com/reef-pi/reef-pi/controller/storage"
+
+const dashboardKey = "dashboard"
+
+type dashboardRepository struct {
+	store storage.Store
+}
+
+func newDashboardRepository(store storage.Store) dashboardRepository {
+	return dashboardRepository{
+		store: store,
+	}
+}
+
+func (r dashboardRepository) Setup() error {
+	if err := r.store.CreateBucket(Bucket); err != nil {
+		return err
+	}
+	return r.Update(DefaultDashboard)
+}
+
+func (r dashboardRepository) Get() (Dashboard, error) {
+	var d Dashboard
+	if err := r.store.Get(Bucket, dashboardKey, &d); err != nil {
+		return d, err
+	}
+	return d, nil
+}
+
+func (r dashboardRepository) Update(d Dashboard) error {
+	return r.store.Update(Bucket, dashboardKey, d)
+}

--- a/controller/daemon/dashboard_repository_test.go
+++ b/controller/daemon/dashboard_repository_test.go
@@ -1,0 +1,98 @@
+package daemon
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+func TestDashboardRepositorySetupPersistsDefaultDashboard(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	repo := newDashboardRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	var stored Dashboard
+	if err := store.Get(Bucket, dashboardKey, &stored); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(DefaultDashboard, stored) {
+		t.Fatalf("expected default dashboard, got %#v", stored)
+	}
+}
+
+func TestDashboardRepositoryGet(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	if err := store.CreateBucket(Bucket); err != nil {
+		t.Fatal(err)
+	}
+	expected := Dashboard{
+		Column: 2,
+		Row:    3,
+		Width:  640,
+		Height: 480,
+		GridDetails: [][]Chart{{{
+			Type: "temperature",
+			ID:   "temp-1",
+		}}},
+	}
+	if err := store.Update(Bucket, dashboardKey, expected); err != nil {
+		t.Fatal(err)
+	}
+
+	actual, err := newDashboardRepository(store).Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("expected %#v, got %#v", expected, actual)
+	}
+}
+
+func TestDashboardRepositoryUpdate(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	if err := store.CreateBucket(Bucket); err != nil {
+		t.Fatal(err)
+	}
+	expected := Dashboard{
+		Column: 4,
+		Row:    5,
+		Width:  800,
+		Height: 600,
+		GridDetails: [][]Chart{{{
+			Type: "health",
+		}, {
+			Type: "ato",
+			ID:   "ato-1",
+		}}},
+	}
+
+	if err := newDashboardRepository(store).Update(expected); err != nil {
+		t.Fatal(err)
+	}
+
+	var stored Dashboard
+	if err := store.Get(Bucket, dashboardKey, &stored); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(expected, stored) {
+		t.Fatalf("expected %#v, got %#v", expected, stored)
+	}
+}


### PR DESCRIPTION
Summary: adds a package-private dashboard repository for daemon dashboard persistence. loadDashboard, initializeDashboard, GetDashboard, and UpdateDashboard now go through the seam.\n\nScope: Slice 05 backend storage and service seams; focused on controller/daemon/dashboard*. No API path, response, bucket name, dashboard key, JSON shape, or default dashboard behavior changes intended.\n\nValidation: rtk go test ./controller/daemon; rtk go test ./controller/...; rtk git diff --check.\n\nRollback: isolated to daemon dashboard storage indirection and focused tests.