### PR TITLE
Slice 05: add daemon error repository seam

### DIFF
--- a/controller/daemon/error.go
+++ b/controller/daemon/error.go
@@ -1,10 +1,8 @@
 package daemon
 
 import (
-	"encoding/json"
 	"log"
 	"net/http"
-	"time"
 
 	"github.com/reef-pi/reef-pi/controller/storage"
 	"github.com/reef-pi/reef-pi/controller/utils"
@@ -19,7 +17,7 @@ type Error struct {
 }
 
 func (r *ReefPi) setUpErrorBucket() error {
-	return r.store.CreateBucket(storage.ErrorBucket)
+	return newErrorRepository(r.store).Setup()
 }
 
 func (r *ReefPi) DeleteErrors() error {
@@ -43,16 +41,7 @@ func (r *ReefPi) clearErrors(w http.ResponseWriter, req *http.Request) {
 }
 
 func (r *ReefPi) ListErrors() ([]Error, error) {
-	errors := []Error{}
-	fn := func(_ string, v []byte) error {
-		var a Error
-		if err := json.Unmarshal(v, &a); err != nil {
-			return err
-		}
-		errors = append(errors, a)
-		return nil
-	}
-	return errors, r.store.List(storage.ErrorBucket, fn)
+	return newErrorRepository(r.store).List()
 }
 
 func (r *ReefPi) listErrors(w http.ResponseWriter, req *http.Request) {
@@ -74,7 +63,7 @@ func (r *ReefPi) deleteError(w http.ResponseWriter, req *http.Request) {
 }
 
 func (r *ReefPi) DeleteError(id string) error {
-	return r.store.Delete(storage.ErrorBucket, id)
+	return newErrorRepository(r.store).Delete(id)
 }
 
 func (r *ReefPi) LogError(id, msg string) error {
@@ -82,17 +71,9 @@ func (r *ReefPi) LogError(id, msg string) error {
 }
 
 func logError(store storage.Store, id, msg string) error {
-	var e Error
-	if err := store.Get(storage.ErrorBucket, id, &e); err != nil {
-		e = Error{ID: id}
-	}
-	e.Message = msg
-	e.Time = time.Now().Format("Jan 2 15:04:05")
-	e.Count++
-	return store.Update(storage.ErrorBucket, id, e)
+	return newErrorRepository(store).Log(id, msg)
 }
 
 func (r *ReefPi) GetError(id string) (Error, error) {
-	var a Error
-	return a, r.store.Get(storage.ErrorBucket, id, &a)
+	return newErrorRepository(r.store).Get(id)
 }

--- a/controller/daemon/error_repository.go
+++ b/controller/daemon/error_repository.go
@@ -1,0 +1,61 @@
+package daemon
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+type errorRepository interface {
+	Setup() error
+	List() ([]Error, error)
+	Get(string) (Error, error)
+	Delete(string) error
+	Log(string, string) error
+}
+
+type storeErrorRepository struct {
+	store storage.Store
+}
+
+func newErrorRepository(store storage.Store) errorRepository {
+	return storeErrorRepository{store: store}
+}
+
+func (r storeErrorRepository) Setup() error {
+	return r.store.CreateBucket(storage.ErrorBucket)
+}
+
+func (r storeErrorRepository) List() ([]Error, error) {
+	errors := []Error{}
+	fn := func(_ string, v []byte) error {
+		var e Error
+		if err := json.Unmarshal(v, &e); err != nil {
+			return err
+		}
+		errors = append(errors, e)
+		return nil
+	}
+	return errors, r.store.List(storage.ErrorBucket, fn)
+}
+
+func (r storeErrorRepository) Get(id string) (Error, error) {
+	var e Error
+	return e, r.store.Get(storage.ErrorBucket, id, &e)
+}
+
+func (r storeErrorRepository) Delete(id string) error {
+	return r.store.Delete(storage.ErrorBucket, id)
+}
+
+func (r storeErrorRepository) Log(id, msg string) error {
+	e, err := r.Get(id)
+	if err != nil {
+		e = Error{ID: id}
+	}
+	e.Message = msg
+	e.Time = time.Now().Format("Jan 2 15:04:05")
+	e.Count++
+	return r.store.Update(storage.ErrorBucket, id, e)
+}

--- a/controller/daemon/error_repository_test.go
+++ b/controller/daemon/error_repository_test.go
@@ -1,0 +1,129 @@
+package daemon
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+func newErrorRepositoryTestStore(t *testing.T) storage.Store {
+	t.Helper()
+
+	store, err := storage.NewStore(filepath.Join(t.TempDir(), "reef-pi.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	return store
+}
+
+func TestErrorRepositorySetupCreatesErrorBucket(t *testing.T) {
+	store := newErrorRepositoryTestStore(t)
+	repo := newErrorRepository(store)
+
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	buckets, err := store.Buckets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, bucket := range buckets {
+		if bucket == storage.ErrorBucket {
+			return
+		}
+	}
+	t.Fatalf("expected bucket %q in %v", storage.ErrorBucket, buckets)
+}
+
+func TestErrorRepositoryListGetDelete(t *testing.T) {
+	store := newErrorRepositoryTestStore(t)
+	repo := newErrorRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repo.Log("test-error", "test message"); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Log("test-error-2", "another message"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := repo.Get("test-error")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "test-error" || got.Message != "test message" || got.Count != 1 {
+		t.Fatalf("unexpected error: %#v", got)
+	}
+	if _, err := time.Parse("Jan 2 15:04:05", got.Time); err != nil {
+		t.Fatalf("expected legacy time format, got %q: %v", got.Time, err)
+	}
+
+	errors, err := repo.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(errors) != 2 {
+		t.Fatalf("expected 2 errors, got %d: %#v", len(errors), errors)
+	}
+
+	if err := repo.Delete("test-error"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.Get("test-error"); err == nil {
+		t.Fatal("expected deleted error lookup to fail")
+	}
+}
+
+func TestErrorRepositoryLogIncrementsExistingErrorCount(t *testing.T) {
+	store := newErrorRepositoryTestStore(t)
+	repo := newErrorRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repo.Log("test-error", "first message"); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Log("test-error", "second message"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := repo.Get("test-error")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "test-error" {
+		t.Fatalf("expected ID to be preserved, got %q", got.ID)
+	}
+	if got.Message != "second message" {
+		t.Fatalf("expected latest message, got %q", got.Message)
+	}
+	if got.Count != 2 {
+		t.Fatalf("expected count 2, got %d", got.Count)
+	}
+
+	raw, err := store.RawGet(storage.ErrorBucket, "test-error")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stored map[string]interface{}
+	if err := json.Unmarshal(raw, &stored); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"id", "message", "time", "count"} {
+		if _, ok := stored[key]; !ok {
+			t.Fatalf("expected stored JSON key %q in %s", key, raw)
+		}
+	}
+}


### PR DESCRIPTION
Summary: adds a package-private repository for daemon error persistence. Error setup, list, get, delete, and log/count-increment operations now go through the seam.\n\nScope: Slice 05 backend storage and service seams; focused on controller/daemon/error*. No API path, response, bucket name, stored JSON shape, ID behavior, legacy time format, or count increment behavior changes intended.\n\nValidation: rtk go test ./controller/daemon; rtk go test ./controller/...; rtk git diff --check.\n\nRollback: isolated to daemon error storage indirection and focused tests.