### PR TITLE
Slice 05: add daemon settings repository seam

### DIFF
--- a/controller/daemon/settings.go
+++ b/controller/daemon/settings.go
@@ -12,8 +12,7 @@ import (
 )
 
 func loadSettings(store storage.Store) (settings.Settings, error) {
-	var s settings.Settings
-	return s, store.Get(Bucket, "settings", &s)
+	return newSettingsRepository(store).Load()
 }
 
 func initializeSettings(store storage.Store) (settings.Settings, error) {
@@ -32,17 +31,17 @@ func initializeSettings(store storage.Store) (settings.Settings, error) {
 		settings.DefaultSettings.Address = "0.0.0.0:8080"
 		log.Println("DEV_MODE environment variable set. Turning on dev_mode. Address set to localhost:8080")
 	}
-	if err := store.CreateBucket(Bucket); err != nil {
+	if err := newSettingsRepository(store).Setup(settings.DefaultSettings); err != nil {
 		log.Println("ERROR:Failed to create bucket:", Bucket, ". Error:", err)
 		return settings.DefaultSettings, err
 	}
-	return settings.DefaultSettings, store.Update(Bucket, "settings", settings.DefaultSettings)
+	return settings.DefaultSettings, nil
 }
 
 func (r *ReefPi) GetSettings(w http.ResponseWriter, req *http.Request) {
 	fn := func(_ string) (interface{}, error) {
-		var s settings.Settings
-		return &s, r.store.Get(Bucket, "settings", &s)
+		s, err := newSettingsRepository(r.store).Load()
+		return &s, err
 	}
 	utils.JSONGetResponse(fn, w, req)
 }
@@ -53,7 +52,7 @@ func (r *ReefPi) UpdateSettings(w http.ResponseWriter, req *http.Request) {
 		if err := s.Validate(); err != nil {
 			return err
 		}
-		return r.store.Update(Bucket, "settings", s)
+		return newSettingsRepository(r.store).Update(s)
 	}
 	utils.JSONUpdateResponse(&s, fn, w, req)
 }

--- a/controller/daemon/settings_repository.go
+++ b/controller/daemon/settings_repository.go
@@ -1,0 +1,32 @@
+package daemon
+
+import (
+	"github.com/reef-pi/reef-pi/controller/settings"
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+const settingsKey = "settings"
+
+type settingsRepository struct {
+	store storage.Store
+}
+
+func newSettingsRepository(store storage.Store) settingsRepository {
+	return settingsRepository{store: store}
+}
+
+func (r settingsRepository) Load() (settings.Settings, error) {
+	var s settings.Settings
+	return s, r.store.Get(Bucket, settingsKey, &s)
+}
+
+func (r settingsRepository) Setup(s settings.Settings) error {
+	if err := r.store.CreateBucket(Bucket); err != nil {
+		return err
+	}
+	return r.Update(s)
+}
+
+func (r settingsRepository) Update(s settings.Settings) error {
+	return r.store.Update(Bucket, settingsKey, s)
+}

--- a/controller/daemon/settings_repository_test.go
+++ b/controller/daemon/settings_repository_test.go
@@ -1,0 +1,90 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/reef-pi/reef-pi/controller/settings"
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+func testSettingsStore(t *testing.T) storage.Store {
+	t.Helper()
+
+	store, err := storage.NewStore(filepath.Join(t.TempDir(), "reef-pi.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	return store
+}
+
+func TestSettingsRepositorySetupLoadAndUpdate(t *testing.T) {
+	store := testSettingsStore(t)
+	repo := newSettingsRepository(store)
+
+	initial := settings.DefaultSettings
+	initial.Name = "initial"
+	if err := repo.Setup(initial); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := repo.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Name != "initial" {
+		t.Errorf("expected initial settings name, got %q", loaded.Name)
+	}
+
+	updated := loaded
+	updated.Name = "updated"
+	updated.Address = "127.0.0.1:8080"
+	if err := repo.Update(updated); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err = repo.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Name != "updated" {
+		t.Errorf("expected updated settings name, got %q", loaded.Name)
+	}
+	if loaded.Address != "127.0.0.1:8080" {
+		t.Errorf("expected updated settings address, got %q", loaded.Address)
+	}
+}
+
+func TestInitializeSettingsPersistsDevModeDefaults(t *testing.T) {
+	originalDefaultSettings := settings.DefaultSettings
+	t.Cleanup(func() {
+		settings.DefaultSettings = originalDefaultSettings
+	})
+	t.Setenv("DEV_MODE", "1")
+
+	store := testSettingsStore(t)
+	initialized, err := initializeSettings(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !initialized.Capabilities.DevMode {
+		t.Fatal("expected initialized settings to enable dev mode")
+	}
+
+	loaded, err := newSettingsRepository(store).Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loaded.Capabilities.DevMode {
+		t.Error("expected persisted settings to enable dev mode")
+	}
+	if loaded.Address != "0.0.0.0:8080" {
+		t.Errorf("expected persisted dev mode address, got %q", loaded.Address)
+	}
+}


### PR DESCRIPTION
Summary: adds a package-private repository for daemon settings persistence. loadSettings, initializeSettings, GetSettings, and UpdateSettings now go through the seam.\n\nScope: Slice 05 backend storage and service seams; focused on controller/daemon/settings*. No API path, response, bucket name, settings key, JSON shape, DEV_MODE behavior, validation behavior, or default settings behavior changes intended.\n\nValidation: rtk go test ./controller/daemon; rtk go test ./controller/...; rtk git diff --check.\n\nRollback: isolated to daemon settings storage indirection and focused tests.