### PR TITLE
Slice 05: add outlet storage repository seam

### DIFF
--- a/controller/device_manager/connectors/outlet.go
+++ b/controller/device_manager/connectors/outlet.go
@@ -1,7 +1,6 @@
 package connectors
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -56,19 +55,19 @@ func (o Outlet) IsValid(drivers *drivers.Drivers) error {
 }
 
 type Outlets struct {
-	store   storage.Store
+	repo    outletRepository
 	drivers *drivers.Drivers
 }
 
 func NewOutlets(drivers *drivers.Drivers, store storage.Store) *Outlets {
 	return &Outlets{
-		store:   store,
+		repo:    newOutletRepository(store),
 		drivers: drivers,
 	}
 }
 
 func (c *Outlets) Setup() error {
-	return c.store.CreateBucket(OutletBucket)
+	return c.repo.Setup()
 }
 
 func (c *Outlets) Configure(id string, on bool) error {
@@ -91,11 +90,7 @@ func (c *Outlets) Create(o Outlet) error {
 	if err := o.IsValid(c.drivers); err != nil {
 		return err
 	}
-	fn := func(id string) interface{} {
-		o.ID = id
-		return &o
-	}
-	return c.store.Create(OutletBucket, fn)
+	return c.repo.Create(o)
 }
 
 func (c *Outlets) Update(id string, o Outlet) error {
@@ -103,20 +98,11 @@ func (c *Outlets) Update(id string, o Outlet) error {
 	if err := o.IsValid(c.drivers); err != nil {
 		return err
 	}
-	return c.store.Update(OutletBucket, id, o)
+	return c.repo.Update(id, o)
 }
 
 func (c *Outlets) List() ([]Outlet, error) {
-	outlets := []Outlet{}
-	fn := func(_ string, v []byte) error {
-		var o Outlet
-		if err := json.Unmarshal(v, &o); err != nil {
-			return err
-		}
-		outlets = append(outlets, o)
-		return nil
-	}
-	return outlets, c.store.List(OutletBucket, fn)
+	return c.repo.List()
 }
 
 func (c *Outlets) Delete(id string) error {
@@ -127,12 +113,11 @@ func (c *Outlets) Delete(id string) error {
 	if o.Equipment != "" {
 		return fmt.Errorf("Outlet: %s has equipment: %s attached to it.", o.Name, o.Equipment)
 	}
-	return c.store.Delete(OutletBucket, id)
+	return c.repo.Delete(id)
 }
 
 func (c *Outlets) Get(id string) (Outlet, error) {
-	var o Outlet
-	return o, c.store.Get(OutletBucket, id, &o)
+	return c.repo.Get(id)
 }
 
 func (e *Outlets) LoadAPI(r *mux.Router) {

--- a/controller/device_manager/connectors/outlet_repository.go
+++ b/controller/device_manager/connectors/outlet_repository.go
@@ -1,0 +1,63 @@
+package connectors
+
+import (
+	"encoding/json"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+type outletRepository interface {
+	Setup() error
+	Get(string) (Outlet, error)
+	List() ([]Outlet, error)
+	Create(Outlet) error
+	Update(string, Outlet) error
+	Delete(string) error
+}
+
+type storeOutletRepository struct {
+	store storage.Store
+}
+
+func newOutletRepository(store storage.Store) outletRepository {
+	return storeOutletRepository{store: store}
+}
+
+func (r storeOutletRepository) Setup() error {
+	return r.store.CreateBucket(OutletBucket)
+}
+
+func (r storeOutletRepository) Get(id string) (Outlet, error) {
+	var o Outlet
+	return o, r.store.Get(OutletBucket, id, &o)
+}
+
+func (r storeOutletRepository) List() ([]Outlet, error) {
+	outlets := []Outlet{}
+	fn := func(_ string, v []byte) error {
+		var o Outlet
+		if err := json.Unmarshal(v, &o); err != nil {
+			return err
+		}
+		outlets = append(outlets, o)
+		return nil
+	}
+	return outlets, r.store.List(OutletBucket, fn)
+}
+
+func (r storeOutletRepository) Create(o Outlet) error {
+	fn := func(id string) interface{} {
+		o.ID = id
+		return &o
+	}
+	return r.store.Create(OutletBucket, fn)
+}
+
+func (r storeOutletRepository) Update(id string, o Outlet) error {
+	o.ID = id
+	return r.store.Update(OutletBucket, id, o)
+}
+
+func (r storeOutletRepository) Delete(id string) error {
+	return r.store.Delete(OutletBucket, id)
+}

--- a/controller/device_manager/connectors/outlet_repository_test.go
+++ b/controller/device_manager/connectors/outlet_repository_test.go
@@ -1,0 +1,61 @@
+package connectors
+
+import (
+	"testing"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+func TestStoreOutletRepositoryCRUD(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	repo := newOutletRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	outlet := Outlet{
+		Name:      "Return Pump",
+		Pin:       21,
+		Equipment: "1",
+		Reverse:   true,
+		Driver:    "rpi",
+	}
+	if err := repo.Create(outlet); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := repo.Get("1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "1" || got.Name != "Return Pump" || got.Pin != 21 || got.Equipment != "1" || !got.Reverse || got.Driver != "rpi" {
+		t.Fatalf("unexpected outlet: %#v", got)
+	}
+
+	got.Name = "Skimmer"
+	got.Equipment = ""
+	got.Reverse = false
+	if err := repo.Update(got.ID, got); err != nil {
+		t.Fatal(err)
+	}
+
+	outlets, err := repo.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(outlets) != 1 || outlets[0].ID != "1" || outlets[0].Name != "Skimmer" || outlets[0].Equipment != "" || outlets[0].Reverse {
+		t.Fatalf("unexpected outlet list: %#v", outlets)
+	}
+
+	if err := repo.Delete(got.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.Get(got.ID); err == nil {
+		t.Fatal("expected deleted outlet lookup to fail")
+	}
+}


### PR DESCRIPTION
Summary: adds a package-private repository for outlet connector persistence. Setup, CRUD, and list storage operations now go through the seam.\n\nScope: Slice 05 backend storage/service seams; focused on controller/device_manager/connectors/outlet*. No API path, bucket name, JSON shape, created ID behavior, validation, configure/reverse logic, HAL pin lookup, output writes, or delete guard behavior changes intended.\n\nValidation: rtk go test ./controller/device_manager/connectors; rtk go test ./controller/...; rtk git diff --check.\n\nRollback: isolated to outlet storage indirection and focused tests.