### PR TITLE
Slice 05: add telemetry config repository seam

### DIFF
--- a/controller/telemetry/api.go
+++ b/controller/telemetry/api.go
@@ -19,8 +19,8 @@ const AdafruitIOTokenStoredPlaceholder = "<stored>"
 
 func (t *telemetry) GetConfig(w http.ResponseWriter, req *http.Request) {
 	fn := func(_ string) (interface{}, error) {
-		var c TelemetryConfig
-		if err := t.store.Get(t.bucket, DBKey, &c); err != nil {
+		c, err := t.configRepository().get()
+		if err != nil {
 			return nil, err
 		}
 		if c.AdafruitIO.Token != "" {
@@ -37,8 +37,7 @@ func (t *telemetry) GetConfig(w http.ResponseWriter, req *http.Request) {
 func (t *telemetry) UpdateConfig(w http.ResponseWriter, req *http.Request) {
 	var c TelemetryConfig
 
-	var existingConfig TelemetryConfig
-	var readErr = t.store.Get(t.bucket, DBKey, &existingConfig)
+	existingConfig, readErr := t.configRepository().get()
 	if readErr != nil {
 		if errors.Is(readErr, storage.ErrDoesNotExist) {
 			utils.ErrorResponse(http.StatusInternalServerError, "Failed to update. Error: "+readErr.Error(), w)
@@ -55,7 +54,7 @@ func (t *telemetry) UpdateConfig(w http.ResponseWriter, req *http.Request) {
 				c.Mailer.Password = existingConfig.Mailer.Password
 			}
 		}
-		if err := t.store.Update(t.bucket, DBKey, c); err != nil {
+		if err := t.configRepository().update(c); err != nil {
 			return err
 		}
 		t.applyConfig(c)

--- a/controller/telemetry/repository.go
+++ b/controller/telemetry/repository.go
@@ -1,0 +1,32 @@
+package telemetry
+
+import "github.com/reef-pi/reef-pi/controller/storage"
+
+type telemetryConfigRepository struct {
+	store  storage.Store
+	bucket string
+}
+
+func newTelemetryConfigRepository(store storage.Store, bucket string) *telemetryConfigRepository {
+	return &telemetryConfigRepository{
+		store:  store,
+		bucket: bucket,
+	}
+}
+
+func (t *telemetry) configRepository() *telemetryConfigRepository {
+	if t.configRepo == nil {
+		t.configRepo = newTelemetryConfigRepository(t.store, t.bucket)
+	}
+	return t.configRepo
+}
+
+func (r *telemetryConfigRepository) get() (TelemetryConfig, error) {
+	var c TelemetryConfig
+	err := r.store.Get(r.bucket, DBKey, &c)
+	return c, err
+}
+
+func (r *telemetryConfigRepository) update(c TelemetryConfig) error {
+	return r.store.Update(r.bucket, DBKey, c)
+}

--- a/controller/telemetry/repository_test.go
+++ b/controller/telemetry/repository_test.go
@@ -1,0 +1,47 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+func TestTelemetryConfigRepositoryGetAndUpdate(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	store.CreateBucket("telemetry")
+
+	repo := newTelemetryConfigRepository(store, "telemetry")
+	expected := DefaultTelemetryConfig
+	expected.Notify = true
+	expected.AdafruitIO.Token = "aio-token"
+
+	if err := repo.update(expected); err != nil {
+		t.Fatal(err)
+	}
+
+	actual, err := repo.get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual.Notify != expected.Notify {
+		t.Fatalf("expected notify %t, got %t", expected.Notify, actual.Notify)
+	}
+	if actual.AdafruitIO.Token != expected.AdafruitIO.Token {
+		t.Fatalf("expected AIO token %q, got %q", expected.AdafruitIO.Token, actual.AdafruitIO.Token)
+	}
+	if actual.CurrentLimit != expected.CurrentLimit {
+		t.Fatalf("expected current limit %d, got %d", expected.CurrentLimit, actual.CurrentLimit)
+	}
+
+	var saved TelemetryConfig
+	if err := store.Get("telemetry", DBKey, &saved); err != nil {
+		t.Fatal(err)
+	}
+	if saved.AdafruitIO.Token != expected.AdafruitIO.Token {
+		t.Fatalf("expected persisted AIO token %q, got %q", expected.AdafruitIO.Token, saved.AdafruitIO.Token)
+	}
+}

--- a/controller/telemetry/telemetry.go
+++ b/controller/telemetry/telemetry.go
@@ -86,15 +86,17 @@ type telemetry struct {
 	logError   ErrorLogger
 	store      storage.Store
 	bucket     string
+	configRepo *telemetryConfigRepository
 	pMs        map[string]prometheus.Gauge
 }
 
 func Initialize(name, bucket string, store storage.Store, logError ErrorLogger, prom bool) Telemetry {
-	var c TelemetryConfig
-	if err := store.Get(bucket, DBKey, &c); err != nil {
+	repo := newTelemetryConfigRepository(store, bucket)
+	c, err := repo.get()
+	if err != nil {
 		log.Println("ERROR: Failed to load telemtry config from saved settings. Initializing")
 		c = DefaultTelemetryConfig
-		store.Update(bucket, DBKey, c)
+		repo.update(c)
 	}
 	c.Prometheus = prom
 	// for upgrades, this value will be 0. Remove in 3.0
@@ -122,6 +124,7 @@ func NewTelemetry(name, bucket string, store storage.Store, config TelemetryConf
 		logError:   lr,
 		store:      store,
 		bucket:     bucket,
+		configRepo: newTelemetryConfigRepository(store, bucket),
 		pMs:        make(map[string]prometheus.Gauge),
 	}
 	if config.AdafruitIO.Enable {


### PR DESCRIPTION
Summary: adds a package-private repository for telemetry config persistence. Initialize and API config read/update paths now route TelemetryConfig storage through the seam.\n\nScope: Slice 05 backend storage/service seams; focused on controller/telemetry config storage. No API path, response, bucket name, DBKey, JSON shape, default config, Prometheus override, or retention limit upgrade behavior changes intended.\n\nValidation: rtk go test ./controller/telemetry; rtk go test ./controller/...; rtk git diff --check.\n\nRollback: isolated to telemetry config storage indirection and focused tests. Existing "telemtry" log/error IDs are intentionally unchanged in this PR.