### PR TITLE
Slice 05: add drivers storage repository seam

### DIFF
--- a/controller/device_manager/drivers/drivers.go
+++ b/controller/device_manager/drivers/drivers.go
@@ -19,7 +19,7 @@ import (
 type Drivers struct {
 	sync.Mutex
 	drivers       map[string]hal.Driver
-	store         storage.Store
+	store         *driverRepository
 	pwm_freq      int
 	bus           i2c.Bus
 	t             telemetry.Telemetry
@@ -28,12 +28,13 @@ type Drivers struct {
 }
 
 func NewDrivers(s settings.Settings, bus i2c.Bus, store storage.Store, t telemetry.Telemetry) (*Drivers, error) {
-	if err := store.CreateBucket(DriverBucket); err != nil {
+	repository, err := newDriverRepository(store)
+	if err != nil {
 		return nil, err
 	}
 	d := &Drivers{
 		drivers:  make(map[string]hal.Driver),
-		store:    store,
+		store:    repository,
 		pwm_freq: s.RPI_PWMFreq,
 		bus:      bus,
 		t:        t,
@@ -59,8 +60,8 @@ func isPiArch(a string) bool {
 }
 
 func (d *Drivers) Get(id string) (Driver, error) {
-	var dr Driver
-	if err := d.store.Get(DriverBucket, id, &dr); err != nil {
+	dr, err := d.store.get(id)
+	if err != nil {
 		return dr, err
 	}
 	driver, ok := d.drivers[id]
@@ -135,10 +136,6 @@ func parseParams(data json.RawMessage) map[string]interface{} {
 }
 
 func (d *Drivers) Create(d1 Driver) error {
-	fn := func(id string) interface{} {
-		d1.ID = id
-		return &d1
-	}
 	factory, err := AbstractFactory(d1.Type)
 	if err != nil {
 		return err
@@ -149,13 +146,14 @@ func (d *Drivers) Create(d1 Driver) error {
 	}
 	factory.ValidateParameters(d1.Parameters)
 
-	if err := d.store.Create(DriverBucket, fn); err != nil {
+	d1, err = d.store.create(d1)
+	if err != nil {
 		return err
 	}
 
 	if err := d.register(d1, factory); err != nil {
 		// Registration has failed, we need to de-allocate the DB entry
-		_ = d.store.Delete(DriverBucket, d1.ID)
+		_ = d.store.delete(d1.ID)
 		return err
 	}
 	if d.OnCreate != nil {
@@ -170,7 +168,7 @@ func (d *Drivers) Update(id string, d1 Driver) error {
 	}
 
 	d1.ID = id
-	return d.store.Update(DriverBucket, id, d1)
+	return d.store.update(id, d1)
 }
 
 func (d *Drivers) Delete(id string) error {
@@ -184,27 +182,25 @@ func (d *Drivers) Delete(id string) error {
 		driver.Close()
 		delete(d.drivers, id)
 	}
-	return d.store.Delete(DriverBucket, id)
+	return d.store.delete(id)
 }
 
 func (d *Drivers) Size() int {
 	return len(d.drivers)
 }
 func (d *Drivers) List() ([]Driver, error) {
-	ds := []Driver{}
-	fn := func(_ string, v []byte) error {
-		var d1 Driver
-		if err := json.Unmarshal(v, &d1); err != nil {
-			return err
-		}
+	ds, err := d.store.list()
+	if err != nil {
+		return nil, err
+	}
+	for i := range ds {
+		d1 := &ds[i]
 		dr, ok := d.drivers[d1.ID]
 		if ok {
 			d1.loadPinMap(dr)
 		}
-		ds = append(ds, d1)
-		return nil
 	}
-	return ds, d.store.List(DriverBucket, fn)
+	return ds, nil
 }
 
 func (d *Drivers) ListOptions() (map[string][]hal.ConfigParameter, error) {

--- a/controller/device_manager/drivers/repository.go
+++ b/controller/device_manager/drivers/repository.go
@@ -1,0 +1,66 @@
+package drivers
+
+import (
+	"encoding/json"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+type driverRepository struct {
+	store storage.Store
+}
+
+func newDriverRepository(store storage.Store) (*driverRepository, error) {
+	if err := store.CreateBucket(DriverBucket); err != nil {
+		return nil, err
+	}
+	return &driverRepository{store: store}, nil
+}
+
+func (r *driverRepository) get(id string) (Driver, error) {
+	var d Driver
+	if err := r.store.Get(DriverBucket, id, &d); err != nil {
+		return d, err
+	}
+	return d, nil
+}
+
+func (r *driverRepository) Get(bucket, id string, d interface{}) error {
+	if bucket != DriverBucket {
+		return storage.ErrDoesNotExist
+	}
+	return r.store.Get(DriverBucket, id, d)
+}
+
+func (r *driverRepository) create(d Driver) (Driver, error) {
+	fn := func(id string) interface{} {
+		d.ID = id
+		return &d
+	}
+	if err := r.store.Create(DriverBucket, fn); err != nil {
+		return d, err
+	}
+	return d, nil
+}
+
+func (r *driverRepository) update(id string, d Driver) error {
+	d.ID = id
+	return r.store.Update(DriverBucket, id, d)
+}
+
+func (r *driverRepository) delete(id string) error {
+	return r.store.Delete(DriverBucket, id)
+}
+
+func (r *driverRepository) list() ([]Driver, error) {
+	ds := []Driver{}
+	fn := func(_ string, v []byte) error {
+		var d Driver
+		if err := json.Unmarshal(v, &d); err != nil {
+			return err
+		}
+		ds = append(ds, d)
+		return nil
+	}
+	return ds, r.store.List(DriverBucket, fn)
+}

--- a/controller/device_manager/drivers/repository_test.go
+++ b/controller/device_manager/drivers/repository_test.go
@@ -1,0 +1,86 @@
+package drivers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+func TestDriverRepositoryCRUD(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	repository, err := newDriverRepository(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := repository.create(Driver{
+		Name:   "main",
+		Type:   "pca9685",
+		Config: json.RawMessage(`{"address":64}`),
+		Parameters: map[string]interface{}{
+			"Address": float64(64),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.ID != "1" {
+		t.Fatalf("Expected created driver ID 1, got %s", created.ID)
+	}
+
+	raw, err := store.RawGet(DriverBucket, created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stored map[string]interface{}
+	if err := json.Unmarshal(raw, &stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored["id"] != created.ID || stored["name"] != "main" || stored["type"] != "pca9685" {
+		t.Fatalf("Stored driver JSON shape changed: %#v", stored)
+	}
+
+	fetched, err := repository.get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fetched.ID != created.ID || fetched.Name != "main" || fetched.Type != "pca9685" {
+		t.Fatalf("Fetched unexpected driver: %#v", fetched)
+	}
+
+	if err := repository.update(created.ID, Driver{Name: "updated", Type: "pca9685"}); err != nil {
+		t.Fatal(err)
+	}
+	fetched, err = repository.get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fetched.ID != created.ID || fetched.Name != "updated" {
+		t.Fatalf("Updated driver did not preserve requested ID: %#v", fetched)
+	}
+
+	drivers, err := repository.list()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(drivers) != 1 || drivers[0].ID != created.ID {
+		t.Fatalf("Expected one listed driver, got %#v", drivers)
+	}
+
+	if err := repository.delete(created.ID); err != nil {
+		t.Fatal(err)
+	}
+	drivers, err = repository.list()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(drivers) != 0 {
+		t.Fatalf("Expected no listed drivers after delete, got %#v", drivers)
+	}
+}


### PR DESCRIPTION
Summary: adds a package-private repository for device-manager driver persistence. Driver bucket setup, CRUD, and list storage operations now go through the seam.\n\nScope: Slice 05 backend storage/service seams; focused on controller/device_manager/drivers. No API path, bucket name, JSON shape, created ID behavior, driver registration/rollback, pin-map loading, readonly rpi behavior, validation, or HAL registry behavior changes intended.\n\nValidation: rtk go test ./controller/device_manager/drivers; rtk go test ./controller/...; rtk git diff --check.\n\nRollback: isolated to drivers storage indirection and focused tests.