### PR TITLE
Slice 05: add jack storage repository seam

### DIFF
--- a/controller/device_manager/connectors/jack.go
+++ b/controller/device_manager/connectors/jack.go
@@ -1,7 +1,6 @@
 package connectors
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 
@@ -28,7 +27,7 @@ type Jack struct {
 }
 
 type Jacks struct {
-	store   storage.Store
+	repo    jackRepository
 	drivers *drivers.Drivers
 }
 
@@ -58,35 +57,21 @@ func (j Jack) IsValid(drvrs *drivers.Drivers) error {
 
 func NewJacks(drivers *drivers.Drivers, store storage.Store) *Jacks {
 	return &Jacks{
-		store:   store,
+		repo:    newJackRepository(store),
 		drivers: drivers,
 	}
 }
 
 func (c *Jacks) Setup() error {
-	if err := c.store.CreateBucket(JackBucket); err != nil {
-		return err
-	}
-
-	return nil
+	return c.repo.Setup()
 }
 
 func (c *Jacks) Get(id string) (Jack, error) {
-	var j Jack
-	return j, c.store.Get(JackBucket, id, &j)
+	return c.repo.Get(id)
 }
 
 func (c *Jacks) List() ([]Jack, error) {
-	jacks := []Jack{}
-	fn := func(_ string, v []byte) error {
-		var j Jack
-		if err := json.Unmarshal(v, &j); err != nil {
-			return err
-		}
-		jacks = append(jacks, j)
-		return nil
-	}
-	return jacks, c.store.List(JackBucket, fn)
+	return c.repo.List()
 }
 
 func (c *Jacks) Create(j Jack) error {
@@ -94,25 +79,14 @@ func (c *Jacks) Create(j Jack) error {
 		return err
 	}
 
-	fn := func(id string) interface{} {
-		j.ID = id
-		return &j
-	}
-	if err := c.store.Create(JackBucket, fn); err != nil {
-		return err
-	}
-	return nil
+	return c.repo.Create(j)
 }
 
 func (c *Jacks) Update(id string, j Jack) error {
 	if err := j.IsValid(c.drivers); err != nil {
 		return err
 	}
-	j.ID = id
-	if err := c.store.Update(JackBucket, id, j); err != nil {
-		return err
-	}
-	return nil
+	return c.repo.Update(id, j)
 }
 
 func (c *Jacks) Delete(id string) error {
@@ -120,7 +94,7 @@ func (c *Jacks) Delete(id string) error {
 	if err != nil {
 		return err
 	}
-	return c.store.Delete(JackBucket, id)
+	return c.repo.Delete(id)
 }
 
 func (c *Jacks) LoadAPI(r *mux.Router) {

--- a/controller/device_manager/connectors/jack_repository.go
+++ b/controller/device_manager/connectors/jack_repository.go
@@ -1,0 +1,63 @@
+package connectors
+
+import (
+	"encoding/json"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+type jackRepository interface {
+	Setup() error
+	Get(string) (Jack, error)
+	List() ([]Jack, error)
+	Create(Jack) error
+	Update(string, Jack) error
+	Delete(string) error
+}
+
+type storeJackRepository struct {
+	store storage.Store
+}
+
+func newJackRepository(store storage.Store) jackRepository {
+	return storeJackRepository{store: store}
+}
+
+func (r storeJackRepository) Setup() error {
+	return r.store.CreateBucket(JackBucket)
+}
+
+func (r storeJackRepository) Get(id string) (Jack, error) {
+	var j Jack
+	return j, r.store.Get(JackBucket, id, &j)
+}
+
+func (r storeJackRepository) List() ([]Jack, error) {
+	jacks := []Jack{}
+	fn := func(_ string, v []byte) error {
+		var j Jack
+		if err := json.Unmarshal(v, &j); err != nil {
+			return err
+		}
+		jacks = append(jacks, j)
+		return nil
+	}
+	return jacks, r.store.List(JackBucket, fn)
+}
+
+func (r storeJackRepository) Create(j Jack) error {
+	fn := func(id string) interface{} {
+		j.ID = id
+		return &j
+	}
+	return r.store.Create(JackBucket, fn)
+}
+
+func (r storeJackRepository) Update(id string, j Jack) error {
+	j.ID = id
+	return r.store.Update(JackBucket, id, j)
+}
+
+func (r storeJackRepository) Delete(id string) error {
+	return r.store.Delete(JackBucket, id)
+}

--- a/controller/device_manager/connectors/jack_repository_test.go
+++ b/controller/device_manager/connectors/jack_repository_test.go
@@ -1,0 +1,88 @@
+package connectors
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+func TestJackRepositoryCRUD(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	repository := newJackRepository(store)
+	if err := repository.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	jack := Jack{
+		Name:    "main",
+		Pins:    []int{0, 1},
+		Driver:  "rpi",
+		Reverse: true,
+	}
+	if err := repository.Create(jack); err != nil {
+		t.Fatal(err)
+	}
+
+	fetched, err := repository.Get("1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fetched.ID != "1" || fetched.Name != "main" || fetched.Driver != "rpi" || !fetched.Reverse {
+		t.Fatalf("Fetched unexpected jack: %#v", fetched)
+	}
+	if len(fetched.Pins) != 2 || fetched.Pins[0] != 0 || fetched.Pins[1] != 1 {
+		t.Fatalf("Fetched unexpected jack pins: %#v", fetched.Pins)
+	}
+
+	raw, err := store.RawGet(JackBucket, fetched.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stored map[string]interface{}
+	if err := json.Unmarshal(raw, &stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored["id"] != fetched.ID || stored["name"] != "main" || stored["driver"] != "rpi" || stored["reverse"] != true {
+		t.Fatalf("Stored jack JSON shape changed: %#v", stored)
+	}
+	pins, ok := stored["pins"].([]interface{})
+	if !ok || len(pins) != 2 || pins[0] != float64(0) || pins[1] != float64(1) {
+		t.Fatalf("Stored jack pins changed: %#v", stored["pins"])
+	}
+
+	if err := repository.Update(fetched.ID, Jack{Name: "updated", Pins: []int{1}, Driver: "rpi"}); err != nil {
+		t.Fatal(err)
+	}
+	fetched, err = repository.Get("1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fetched.ID != "1" || fetched.Name != "updated" || len(fetched.Pins) != 1 || fetched.Pins[0] != 1 {
+		t.Fatalf("Updated jack did not preserve requested ID: %#v", fetched)
+	}
+
+	jacks, err := repository.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(jacks) != 1 || jacks[0].ID != "1" {
+		t.Fatalf("Expected one listed jack, got %#v", jacks)
+	}
+
+	if err := repository.Delete("1"); err != nil {
+		t.Fatal(err)
+	}
+	jacks, err = repository.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(jacks) != 0 {
+		t.Fatalf("Expected no listed jacks after delete, got %#v", jacks)
+	}
+}


### PR DESCRIPTION
Summary: adds a package-private repository for jack connector persistence. Setup, CRUD, and list storage operations now go through the seam.\n\nScope: Slice 05 backend storage/service seams; focused on controller/device_manager/connectors/jack*. No API path, bucket name, JSON shape, generated ID behavior, validation, PWM channel lookup, HAL behavior, or delete guard behavior changes intended.\n\nValidation: rtk go test ./controller/device_manager/connectors; rtk go test ./controller/...; rtk git diff --check.\n\nRollback: isolated to jack storage indirection and focused tests.