### PR TITLE
Slice 05: add inlet storage repository seam

### DIFF
--- a/controller/device_manager/connectors/inlet.go
+++ b/controller/device_manager/connectors/inlet.go
@@ -1,7 +1,6 @@
 package connectors
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -28,7 +27,7 @@ type Inlet struct {
 }
 
 type Inlets struct {
-	store   storage.Store
+	repo    inletRepository
 	drivers *drivers.Drivers
 }
 
@@ -161,13 +160,13 @@ func (i Inlet) IsValid(drivers *drivers.Drivers) error {
 
 func NewInlets(drivers *drivers.Drivers, store storage.Store) *Inlets {
 	return &Inlets{
-		store:   store,
+		repo:    newInletRepository(store),
 		drivers: drivers,
 	}
 }
 
 func (c *Inlets) Setup() error {
-	return c.store.CreateBucket(InletBucket)
+	return c.repo.Setup()
 }
 
 func (c *Inlets) Read(id string) (int, error) {
@@ -195,11 +194,7 @@ func (c *Inlets) Create(i Inlet) error {
 	if err := i.IsValid(c.drivers); err != nil {
 		return err
 	}
-	fn := func(id string) interface{} {
-		i.ID = id
-		return &i
-	}
-	return c.store.Create(InletBucket, fn)
+	return c.repo.Create(i)
 }
 
 func (c *Inlets) Update(id string, i Inlet) error {
@@ -207,20 +202,11 @@ func (c *Inlets) Update(id string, i Inlet) error {
 	if err := i.IsValid(c.drivers); err != nil {
 		return err
 	}
-	return c.store.Update(InletBucket, id, i)
+	return c.repo.Update(id, i)
 }
 
 func (c *Inlets) List() ([]Inlet, error) {
-	inlets := []Inlet{}
-	fn := func(_ string, v []byte) error {
-		var i Inlet
-		if err := json.Unmarshal(v, &i); err != nil {
-			return err
-		}
-		inlets = append(inlets, i)
-		return nil
-	}
-	return inlets, c.store.List(InletBucket, fn)
+	return c.repo.List()
 }
 
 func (c *Inlets) Delete(id string) error {
@@ -231,12 +217,11 @@ func (c *Inlets) Delete(id string) error {
 	if i.Equipment != "" {
 		return fmt.Errorf("Inlet: %s has equipment: %s attached to it.", i.Name, i.Equipment)
 	}
-	return c.store.Delete(InletBucket, id)
+	return c.repo.Delete(id)
 }
 
 func (c *Inlets) Get(id string) (Inlet, error) {
-	var i Inlet
-	return i, c.store.Get(InletBucket, id, &i)
+	return c.repo.Get(id)
 }
 
 func (c *Inlets) get(w http.ResponseWriter, r *http.Request) {

--- a/controller/device_manager/connectors/inlet_repository.go
+++ b/controller/device_manager/connectors/inlet_repository.go
@@ -1,0 +1,63 @@
+package connectors
+
+import (
+	"encoding/json"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+type inletRepository interface {
+	Setup() error
+	Get(string) (Inlet, error)
+	List() ([]Inlet, error)
+	Create(Inlet) error
+	Update(string, Inlet) error
+	Delete(string) error
+}
+
+type storeInletRepository struct {
+	store storage.Store
+}
+
+func newInletRepository(store storage.Store) inletRepository {
+	return storeInletRepository{store: store}
+}
+
+func (r storeInletRepository) Setup() error {
+	return r.store.CreateBucket(InletBucket)
+}
+
+func (r storeInletRepository) Get(id string) (Inlet, error) {
+	var i Inlet
+	return i, r.store.Get(InletBucket, id, &i)
+}
+
+func (r storeInletRepository) List() ([]Inlet, error) {
+	inlets := []Inlet{}
+	fn := func(_ string, v []byte) error {
+		var i Inlet
+		if err := json.Unmarshal(v, &i); err != nil {
+			return err
+		}
+		inlets = append(inlets, i)
+		return nil
+	}
+	return inlets, r.store.List(InletBucket, fn)
+}
+
+func (r storeInletRepository) Create(i Inlet) error {
+	fn := func(id string) interface{} {
+		i.ID = id
+		return &i
+	}
+	return r.store.Create(InletBucket, fn)
+}
+
+func (r storeInletRepository) Update(id string, i Inlet) error {
+	i.ID = id
+	return r.store.Update(InletBucket, id, i)
+}
+
+func (r storeInletRepository) Delete(id string) error {
+	return r.store.Delete(InletBucket, id)
+}

--- a/controller/device_manager/connectors/inlet_repository_test.go
+++ b/controller/device_manager/connectors/inlet_repository_test.go
@@ -1,0 +1,61 @@
+package connectors
+
+import (
+	"testing"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+func TestStoreInletRepositoryCRUD(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	repo := newInletRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	inlet := Inlet{
+		Name:      "ATO Sensor",
+		Pin:       16,
+		Equipment: "1",
+		Reverse:   true,
+		Driver:    "rpi",
+	}
+	if err := repo.Create(inlet); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := repo.Get("1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "1" || got.Name != "ATO Sensor" || got.Pin != 16 || got.Equipment != "1" || !got.Reverse || got.Driver != "rpi" {
+		t.Fatalf("unexpected inlet: %#v", got)
+	}
+
+	got.Name = "Leak Sensor"
+	got.Equipment = ""
+	got.Reverse = false
+	if err := repo.Update(got.ID, got); err != nil {
+		t.Fatal(err)
+	}
+
+	inlets, err := repo.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inlets) != 1 || inlets[0].ID != "1" || inlets[0].Name != "Leak Sensor" || inlets[0].Equipment != "" || inlets[0].Reverse {
+		t.Fatalf("unexpected inlet list: %#v", inlets)
+	}
+
+	if err := repo.Delete(got.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.Get(got.ID); err == nil {
+		t.Fatal("expected deleted inlet lookup to fail")
+	}
+}


### PR DESCRIPTION
Summary: adds a package-private repository for inlet connector persistence. Setup, CRUD, and list storage operations now go through the seam.\n\nScope: Slice 05 backend storage/service seams; focused on controller/device_manager/connectors/inlet*. No API path, bucket name, JSON shape, generated ID behavior, validation, read/reverse logic, HAL pin lookup, or delete guard behavior changes intended.\n\nValidation: rtk go test ./controller/device_manager/connectors; rtk go test ./controller/...; rtk git diff --check; rtk git diff --cached --check.\n\nRollback: isolated to inlet storage indirection and focused tests.