### PR TITLE
Slice 05: add analog input storage repository seam

### DIFF
--- a/controller/device_manager/connectors/analog_input.go
+++ b/controller/device_manager/connectors/analog_input.go
@@ -1,7 +1,6 @@
 package connectors
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"net/http"
@@ -26,7 +25,7 @@ type AnalogInput struct {
 }
 
 type AnalogInputs struct {
-	store   storage.Store
+	repo    analogInputRepository
 	drivers *drivers.Drivers
 }
 
@@ -51,35 +50,21 @@ func (j AnalogInput) IsValid(drvrs *drivers.Drivers) error {
 
 func NewAnalogInputs(drivers *drivers.Drivers, store storage.Store) *AnalogInputs {
 	return &AnalogInputs{
-		store:   store,
+		repo:    newAnalogInputRepository(store),
 		drivers: drivers,
 	}
 }
 
 func (c *AnalogInputs) Setup() error {
-	if err := c.store.CreateBucket(AnalogInputBucket); err != nil {
-		return err
-	}
-
-	return nil
+	return c.repo.Setup()
 }
 
 func (c *AnalogInputs) Get(id string) (AnalogInput, error) {
-	var j AnalogInput
-	return j, c.store.Get(AnalogInputBucket, id, &j)
+	return c.repo.Get(id)
 }
 
 func (c *AnalogInputs) List() ([]AnalogInput, error) {
-	ais := []AnalogInput{}
-	fn := func(_ string, v []byte) error {
-		var j AnalogInput
-		if err := json.Unmarshal(v, &j); err != nil {
-			return err
-		}
-		ais = append(ais, j)
-		return nil
-	}
-	return ais, c.store.List(AnalogInputBucket, fn)
+	return c.repo.List()
 }
 
 func (c *AnalogInputs) Create(j AnalogInput) error {
@@ -87,25 +72,14 @@ func (c *AnalogInputs) Create(j AnalogInput) error {
 		return err
 	}
 
-	fn := func(id string) interface{} {
-		j.ID = id
-		return &j
-	}
-	if err := c.store.Create(AnalogInputBucket, fn); err != nil {
-		return err
-	}
-	return nil
+	return c.repo.Create(j)
 }
 
 func (c *AnalogInputs) Update(id string, j AnalogInput) error {
 	if err := j.IsValid(c.drivers); err != nil {
 		return err
 	}
-	j.ID = id
-	if err := c.store.Update(AnalogInputBucket, id, j); err != nil {
-		return err
-	}
-	return nil
+	return c.repo.Update(id, j)
 }
 
 func (c *AnalogInputs) Delete(id string) error {
@@ -113,7 +87,7 @@ func (c *AnalogInputs) Delete(id string) error {
 	if err != nil {
 		return err
 	}
-	return c.store.Delete(AnalogInputBucket, id)
+	return c.repo.Delete(id)
 }
 
 func (c *AnalogInputs) LoadAPI(r *mux.Router) {

--- a/controller/device_manager/connectors/analog_input_repository.go
+++ b/controller/device_manager/connectors/analog_input_repository.go
@@ -1,0 +1,63 @@
+package connectors
+
+import (
+	"encoding/json"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+type analogInputRepository interface {
+	Setup() error
+	Get(string) (AnalogInput, error)
+	List() ([]AnalogInput, error)
+	Create(AnalogInput) error
+	Update(string, AnalogInput) error
+	Delete(string) error
+}
+
+type storeAnalogInputRepository struct {
+	store storage.Store
+}
+
+func newAnalogInputRepository(store storage.Store) analogInputRepository {
+	return storeAnalogInputRepository{store: store}
+}
+
+func (r storeAnalogInputRepository) Setup() error {
+	return r.store.CreateBucket(AnalogInputBucket)
+}
+
+func (r storeAnalogInputRepository) Get(id string) (AnalogInput, error) {
+	var j AnalogInput
+	return j, r.store.Get(AnalogInputBucket, id, &j)
+}
+
+func (r storeAnalogInputRepository) List() ([]AnalogInput, error) {
+	ais := []AnalogInput{}
+	fn := func(_ string, v []byte) error {
+		var j AnalogInput
+		if err := json.Unmarshal(v, &j); err != nil {
+			return err
+		}
+		ais = append(ais, j)
+		return nil
+	}
+	return ais, r.store.List(AnalogInputBucket, fn)
+}
+
+func (r storeAnalogInputRepository) Create(j AnalogInput) error {
+	fn := func(id string) interface{} {
+		j.ID = id
+		return &j
+	}
+	return r.store.Create(AnalogInputBucket, fn)
+}
+
+func (r storeAnalogInputRepository) Update(id string, j AnalogInput) error {
+	j.ID = id
+	return r.store.Update(AnalogInputBucket, id, j)
+}
+
+func (r storeAnalogInputRepository) Delete(id string) error {
+	return r.store.Delete(AnalogInputBucket, id)
+}

--- a/controller/device_manager/connectors/analog_input_repository_test.go
+++ b/controller/device_manager/connectors/analog_input_repository_test.go
@@ -1,0 +1,58 @@
+package connectors
+
+import (
+	"testing"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+func TestStoreAnalogInputRepositoryCRUD(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	repo := newAnalogInputRepository(store)
+	if err := repo.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	input := AnalogInput{
+		Name:   "pH Probe",
+		Pin:    0,
+		Driver: "1",
+	}
+	if err := repo.Create(input); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := repo.Get("1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "1" || got.Name != "pH Probe" || got.Pin != 0 || got.Driver != "1" {
+		t.Fatalf("unexpected analog input: %#v", got)
+	}
+
+	got.Name = "ORP Probe"
+	got.Pin = 1
+	if err := repo.Update(got.ID, got); err != nil {
+		t.Fatal(err)
+	}
+
+	inputs, err := repo.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inputs) != 1 || inputs[0].ID != "1" || inputs[0].Name != "ORP Probe" || inputs[0].Pin != 1 || inputs[0].Driver != "1" {
+		t.Fatalf("unexpected analog input list: %#v", inputs)
+	}
+
+	if err := repo.Delete(got.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.Get(got.ID); err == nil {
+		t.Fatal("expected deleted analog input lookup to fail")
+	}
+}


### PR DESCRIPTION
Summary: adds a package-private repository for analog input connector persistence. Setup, CRUD, and list storage operations now go through the seam.\n\nScope: Slice 05 backend storage/service seams; focused on controller/device_manager/connectors/analog_input*. No API path, bucket name, JSON shape, generated ID behavior, validation, analog channel lookup, HAL read behavior, calibration behavior, or delete guard behavior changes intended.\n\nValidation: rtk go test ./controller/device_manager/connectors; rtk go test ./controller/...; rtk git diff --check.\n\nRollback: isolated to analog input storage indirection and focused tests.