### PR TITLE
Slice 05: add telemetry stats repository seam

### DIFF
--- a/controller/telemetry/stats_manager.go
+++ b/controller/telemetry/stats_manager.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"sort"
 	"sync"
-
-	"github.com/reef-pi/reef-pi/controller/storage"
 )
 
 type Metric interface {
@@ -47,7 +45,7 @@ type mgr struct {
 	bucket          string
 	CurrentLimit    int
 	HistoricalLimit int
-	store           storage.Store
+	repo            statsRepository
 }
 
 func (m *mgr) IsLoaded(id string) bool {
@@ -94,7 +92,7 @@ func (m *mgr) NewStats() Stats {
 
 func (m *mgr) Load(id string, fn func(json.RawMessage) interface{}) error {
 	var resp StatsOnDisk
-	if err := m.store.Get(m.bucket, id, &resp); err != nil {
+	if err := m.repo.Load(id, &resp); err != nil {
 		return err
 	}
 	stats := m.NewStats()
@@ -119,7 +117,7 @@ func (m *mgr) Save(id string) error {
 	if err != nil {
 		return err
 	}
-	return m.store.Update(m.bucket, id, stats)
+	return m.repo.Save(id, stats)
 }
 
 func (m *mgr) Update(id string, metric Metric) {
@@ -143,7 +141,7 @@ func (m *mgr) Update(id string, metric Metric) {
 		m1, moved := stats.Historical.Value.(Metric).Rollup(metric)
 		move = moved
 		if moved {
-			m.store.Update(m.bucket, id, stats)
+			m.repo.Save(id, stats)
 			stats.Historical = stats.Historical.Next()
 		}
 		stats.Historical.Value = m1
@@ -165,5 +163,5 @@ func (m *mgr) Delete(id string) error {
 	m.Lock()
 	defer m.Unlock()
 	delete(m.inMemory, id)
-	return m.store.Delete(m.bucket, id)
+	return m.repo.Delete(id)
 }

--- a/controller/telemetry/stats_manager_test.go
+++ b/controller/telemetry/stats_manager_test.go
@@ -27,7 +27,7 @@ func newTestMgr(store storage.Store) StatsManager {
 	return &mgr{
 		inMemory:        make(map[string]Stats),
 		bucket:          "stats-test",
-		store:           store,
+		repo:            newStatsRepository(store, "stats-test"),
 		CurrentLimit:    10,
 		HistoricalLimit: 10,
 	}
@@ -193,7 +193,7 @@ func TestStatsManagerUpdateRollupSameHour(t *testing.T) {
 	hMgr := &mgr{
 		inMemory:        make(map[string]Stats),
 		bucket:          "health-rollup-test",
-		store:           store,
+		repo:            newStatsRepository(store, "health-rollup-test"),
 		CurrentLimit:    10,
 		HistoricalLimit: 10,
 	}

--- a/controller/telemetry/stats_repository.go
+++ b/controller/telemetry/stats_repository.go
@@ -1,0 +1,33 @@
+package telemetry
+
+import "github.com/reef-pi/reef-pi/controller/storage"
+
+type statsRepository interface {
+	Load(string, interface{}) error
+	Save(string, interface{}) error
+	Delete(string) error
+}
+
+type storeStatsRepository struct {
+	store  storage.Store
+	bucket string
+}
+
+func newStatsRepository(store storage.Store, bucket string) statsRepository {
+	return storeStatsRepository{
+		store:  store,
+		bucket: bucket,
+	}
+}
+
+func (r storeStatsRepository) Load(id string, v interface{}) error {
+	return r.store.Get(r.bucket, id, v)
+}
+
+func (r storeStatsRepository) Save(id string, v interface{}) error {
+	return r.store.Update(r.bucket, id, v)
+}
+
+func (r storeStatsRepository) Delete(id string) error {
+	return r.store.Delete(r.bucket, id)
+}

--- a/controller/telemetry/stats_repository_test.go
+++ b/controller/telemetry/stats_repository_test.go
@@ -1,0 +1,46 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+func TestStoreStatsRepositoryLoadSaveDelete(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.CreateBucket("stats-repository-test"); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := newStatsRepository(store, "stats-repository-test")
+	expected := StatsResponse{
+		Current: []Metric{
+			testMetric{V: 1.2},
+		},
+		Historical: []Metric{
+			testMetric{V: 3.4},
+		},
+	}
+	if err := repo.Save("sensor", expected); err != nil {
+		t.Fatal(err)
+	}
+
+	var got StatsOnDisk
+	if err := repo.Load("sensor", &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Current) != 1 || len(got.Historical) != 1 {
+		t.Fatalf("expected one current and historical metric, got %#v", got)
+	}
+
+	if err := repo.Delete("sensor"); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Load("sensor", &got); err == nil {
+		t.Fatal("expected deleted stats lookup to fail")
+	}
+}

--- a/controller/telemetry/telemetry.go
+++ b/controller/telemetry/telemetry.go
@@ -178,7 +178,7 @@ func (t *telemetry) NewStatsManager(b string) StatsManager {
 	return &mgr{
 		inMemory:        make(map[string]Stats),
 		bucket:          b,
-		store:           t.store,
+		repo:            newStatsRepository(t.store, b),
 		HistoricalLimit: t.config.HistoricalLimit,
 		CurrentLimit:    t.config.CurrentLimit,
 	}


### PR DESCRIPTION
Summary: adds a package-private repository for telemetry stats persistence. Stats load, save, rollover persistence, and delete now route storage through the seam.\n\nScope: Slice 05 backend storage/service seams; focused on controller/telemetry stats storage. No API path, response, bucket name, JSON shape, ring-buffer behavior, rollup behavior, retention limits, or telemetry config behavior changes intended.\n\nValidation: rtk go test ./controller/telemetry; rtk go test ./controller/...; rtk git diff --check; rtk git diff --cached --check.\n\nRollback: isolated to telemetry stats storage indirection and focused tests.