### PR TITLE
Slice 05: route driver API get through domain

### DIFF
--- a/controller/device_manager/drivers/api.go
+++ b/controller/device_manager/drivers/api.go
@@ -204,12 +204,8 @@ func (d *Drivers) validate(w http.ResponseWriter, r *http.Request) {
 
 func (d *Drivers) get(w http.ResponseWriter, r *http.Request) {
 
-	var dr Driver
 	fn := func(id string) (interface{}, error) {
-		if err := d.store.Get(DriverBucket, id, &dr); err != nil {
-			return nil, err
-		}
-		return dr, nil
+		return d.Get(id)
 	}
 	utils.JSONGetResponse(fn, w, r)
 }

--- a/controller/device_manager/drivers/repository.go
+++ b/controller/device_manager/drivers/repository.go
@@ -25,13 +25,6 @@ func (r *driverRepository) get(id string) (Driver, error) {
 	return d, nil
 }
 
-func (r *driverRepository) Get(bucket, id string, d interface{}) error {
-	if bucket != DriverBucket {
-		return storage.ErrDoesNotExist
-	}
-	return r.store.Get(DriverBucket, id, d)
-}
-
 func (r *driverRepository) create(d Driver) (Driver, error) {
 	fn := func(id string) interface{} {
 		d.ID = id


### PR DESCRIPTION
Summary: routes GET /api/drivers/{id} through Drivers.Get and removes the now-unused bucket-shaped repository helper.\n\nScope: Slice 05 backend storage/service seams; focused on controller/device_manager/drivers API storage access cleanup. No API path, response shape, DriverBucket, JSON shape, pin-map loading behavior, validation, readonly behavior, or HAL registry behavior changes intended.\n\nValidation: rtk go test ./controller/device_manager/drivers; rtk go test ./controller/...; rtk git diff --check.\n\nRollback: isolated to the driver GET handler and repository helper cleanup.