### PR TITLE
Slice 06: fix validation message spelling

### DIFF
--- a/commands/reset_password.go
+++ b/commands/reset_password.go
@@ -12,11 +12,11 @@ import (
 func resetPassword(db, u, p string) {
 	store, err := storage.NewStore(db)
 	if u == "" {
-		fmt.Println("username can not be empty")
+		fmt.Println("username cannot be empty")
 		os.Exit(1)
 	}
 	if p == "" {
-		fmt.Println("password can not be empty")
+		fmt.Println("password cannot be empty")
 		os.Exit(1)
 	}
 	if err != nil {

--- a/controller/device_manager/connectors/analog_input.go
+++ b/controller/device_manager/connectors/analog_input.go
@@ -39,7 +39,7 @@ func (j AnalogInput) channel(drvrs *drivers.Drivers) (hal.AnalogInputPin, error)
 
 func (j AnalogInput) IsValid(drvrs *drivers.Drivers) error {
 	if j.Name == "" {
-		return fmt.Errorf("AnalogInput name can not be empty")
+		return fmt.Errorf("AnalogInput name cannot be empty")
 	}
 	_, err := j.channel(drvrs)
 	if err != nil {

--- a/controller/device_manager/connectors/inlet.go
+++ b/controller/device_manager/connectors/inlet.go
@@ -150,7 +150,7 @@ func (i Inlet) inputPin(drivers *drivers.Drivers) (hal.DigitalInputPin, error) {
 
 func (i Inlet) IsValid(drivers *drivers.Drivers) error {
 	if i.Name == "" {
-		return errors.New("Inlet name can not be empty")
+		return errors.New("Inlet name cannot be empty")
 	}
 	if _, err := i.inputPin(drivers); err != nil {
 		return fmt.Errorf("inlet %s did not get associated with a driver pin: %v", i.Name, err)

--- a/controller/device_manager/connectors/jack.go
+++ b/controller/device_manager/connectors/jack.go
@@ -41,7 +41,7 @@ func (j Jack) pwmChannel(channel int, drvrs *drivers.Drivers) (hal.PWMChannel, e
 
 func (j Jack) IsValid(drvrs *drivers.Drivers) error {
 	if j.Name == "" {
-		return fmt.Errorf("Jack name can not be empty")
+		return fmt.Errorf("Jack name cannot be empty")
 	}
 	if len(j.Pins) == 0 {
 		return fmt.Errorf("Jack should have pins associated with it")

--- a/controller/device_manager/connectors/outlet.go
+++ b/controller/device_manager/connectors/outlet.go
@@ -48,7 +48,7 @@ func (o Outlet) outputPin(drivers *drivers.Drivers) (hal.DigitalOutputPin, error
 
 func (o Outlet) IsValid(drivers *drivers.Drivers) error {
 	if o.Name == "" {
-		return fmt.Errorf("Outlet name can not be empty")
+		return fmt.Errorf("Outlet name cannot be empty")
 	}
 	_, err := o.outputPin(drivers)
 	return err

--- a/controller/modules/doser/controller.go
+++ b/controller/modules/doser/controller.go
@@ -144,7 +144,7 @@ func (c *Controller) On(id string, b bool) error {
 		return err
 	}
 	if p.Regiment.Enable {
-		return errors.New("enabled doser can not be On/Off -ed")
+		return errors.New("enabled doser cannot be On/Off -ed")
 	}
 	log.Println("doser-subsystem: Switching doser :", p.Name, "to", b)
 	v := make(map[int]float64)

--- a/controller/modules/doser/pump.go
+++ b/controller/modules/doser/pump.go
@@ -35,7 +35,7 @@ type Pump struct {
 
 func (p *Pump) IsValid() error {
 	if p.Name == "" {
-		return fmt.Errorf("name can not be empty")
+		return fmt.Errorf("name cannot be empty")
 	}
 	if p.Regiment.SoftStart < 0 {
 		return fmt.Errorf("soft start must be non-negative")

--- a/controller/modules/lighting/light.go
+++ b/controller/modules/lighting/light.go
@@ -51,7 +51,7 @@ func (c *Controller) List() ([]Light, error) {
 
 func (c *Controller) validate(l *Light) error {
 	if l.Name == "" {
-		return fmt.Errorf("Light name can not be empty")
+		return fmt.Errorf("Light name cannot be empty")
 	}
 	existing, err := c.List()
 	if err != nil {


### PR DESCRIPTION
Summary: fixes user-facing validation/error strings from 'can not' to 'cannot'.\n\nScope: Slice 06 backend naming cleanup; focused on validation message spelling only. No API paths, payloads, validation conditions, storage keys, or runtime logic changes intended.\n\nValidation: rtk go test ./controller/device_manager/connectors ./controller/modules/lighting ./controller/modules/doser; rtk go test ./controller/...; rtk git diff --check.\n\nRollback: isolated to validation/error string spelling.