### PR TITLE
Slice 05: add credentials repository seam

### DIFF
--- a/controller/utils/credentials_manager.go
+++ b/controller/utils/credentials_manager.go
@@ -13,20 +13,17 @@ type Credentials struct {
 }
 
 type CredentialsManager struct {
-	store  storage.Store
-	bucket string
+	repo credentialsRepository
 }
 
 func NewCredentialsManager(store storage.Store, bucket string) *CredentialsManager {
 	return &CredentialsManager{
-		store:  store,
-		bucket: bucket,
+		repo: newCredentialsRepository(store, bucket),
 	}
 }
 
 func (cs *CredentialsManager) Get() (Credentials, error) {
-	var c Credentials
-	return c, cs.store.Get(cs.bucket, "credentials", &c)
+	return cs.repo.Get()
 }
 
 func (cs *CredentialsManager) Update(credentials Credentials) error {
@@ -34,7 +31,7 @@ func (cs *CredentialsManager) Update(credentials Credentials) error {
 	if err != nil {
 		return err
 	}
-	return cs.store.Update(cs.bucket, "credentials", Credentials{
+	return cs.repo.Update(Credentials{
 		User:     credentials.User,
 		Password: string(hash),
 	})

--- a/controller/utils/credentials_repository.go
+++ b/controller/utils/credentials_repository.go
@@ -1,0 +1,31 @@
+package utils
+
+import "github.com/reef-pi/reef-pi/controller/storage"
+
+const credentialsKey = "credentials"
+
+type credentialsRepository interface {
+	Get() (Credentials, error)
+	Update(Credentials) error
+}
+
+type storeCredentialsRepository struct {
+	store  storage.Store
+	bucket string
+}
+
+func newCredentialsRepository(store storage.Store, bucket string) credentialsRepository {
+	return storeCredentialsRepository{
+		store:  store,
+		bucket: bucket,
+	}
+}
+
+func (r storeCredentialsRepository) Get() (Credentials, error) {
+	var c Credentials
+	return c, r.store.Get(r.bucket, credentialsKey, &c)
+}
+
+func (r storeCredentialsRepository) Update(c Credentials) error {
+	return r.store.Update(r.bucket, credentialsKey, c)
+}

--- a/controller/utils/credentials_repository_test.go
+++ b/controller/utils/credentials_repository_test.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/reef-pi/reef-pi/controller/storage"
+)
+
+func TestStoreCredentialsRepositoryGetAndUpdate(t *testing.T) {
+	store, err := storage.TestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.CreateBucket("reef-pi"); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := newCredentialsRepository(store, "reef-pi")
+	expected := Credentials{User: "reef-pi", Password: "secret"}
+	if err := repo.Update(expected); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := repo.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.User != expected.User || got.Password != expected.Password {
+		t.Fatalf("expected credentials %#v, got %#v", expected, got)
+	}
+}


### PR DESCRIPTION
Summary: adds a package-private repository for credentials persistence and routes CredentialsManager get/update through it.\n\nScope: Slice 05 backend storage/service seams; focused on controller/utils credentials persistence. No API path, payload shape, bucket name, credentials key, bcrypt hashing, default credentials, or validation behavior changes intended.\n\nValidation: rtk go test ./controller/utils; rtk go test ./controller/...; rtk git diff --check; rtk git diff --cached --check.\n\nRollback: isolated to credentials storage indirection and focused tests.