### PR TITLE
Slice 06: fix test message typos

### DIFF
--- a/controller/daemon/settings_test.go
+++ b/controller/daemon/settings_test.go
@@ -22,7 +22,7 @@ func TestDevModeDetection(t *testing.T) {
 			t.Error(err)
 		}
 		if s.Capabilities.DevMode {
-			t.Error("Devmode is turned on, expected off")
+			t.Error("Dev mode is turned on, expected off")
 		}
 		os.Setenv("DEV_MODE", "1")
 		s, err = initializeSettings(store)
@@ -30,7 +30,7 @@ func TestDevModeDetection(t *testing.T) {
 			t.Error(err)
 		}
 		if !s.Capabilities.DevMode {
-			t.Error("Devmode is turned off, expected on")
+			t.Error("Dev mode is turned off, expected on")
 		}
 		os.Unsetenv("DEV_MODE")
 	}

--- a/controller/storage/store_test.go
+++ b/controller/storage/store_test.go
@@ -17,7 +17,7 @@ func TestStore(t *testing.T) {
 	testBucket := "test"
 	store, err := TestDB()
 	if err != nil {
-		t.Fatal("Failed to create test databse")
+		t.Fatal("Failed to create test database")
 	}
 	if err := store.CreateBucket(testBucket); err != nil {
 		t.Fatal("Failed to create test bucket. Error:", err)
@@ -37,7 +37,7 @@ func TestStore(t *testing.T) {
 		t.Fatal("Failed to fetch test object. Error:", err)
 	}
 	if nData.Name != "fake" {
-		t.Fatal("Fetched data is inconsitent with stored data. Expected: 'fake', Found: ", nData.Name)
+		t.Fatal("Fetched data is inconsistent with stored data. Expected: 'fake', Found: ", nData.Name)
 	}
 	var ls []testData
 	lsFn := func(_ string, bs []byte) error {


### PR DESCRIPTION
## Summary
- fix spelling in storage test failure messages
- normalize Dev mode wording in daemon settings test assertions

## Validation
- rtk go test ./controller/storage ./controller/daemon
- rtk git diff --check

## Risk
- Test-only assertion/fatal message cleanup; no runtime behavior change.