### PR TITLE
Fix temperature subsystem log spelling

### DIFF
--- a/controller/modules/temperature/control.go
+++ b/controller/modules/temperature/control.go
@@ -16,16 +16,16 @@ func (c *Controller) Check(tc *TC) (float64, error) {
 
 	reading, err := c.Read(tc)
 	if err != nil {
-		log.Println("ERROR: temperature sub-system. Failed to read  sensor. Error:", err)
-		c.c.LogError("tc-"+tc.ID, "temperature sub-system. Failed to read  sensor "+tc.Name+". Error:"+err.Error())
+		log.Println("ERROR: temperature subsystem. Failed to read  sensor. Error:", err)
+		c.c.LogError("tc-"+tc.ID, "temperature subsystem. Failed to read  sensor "+tc.Name+". Error:"+err.Error())
 		subject := fmt.Sprintf("Temperature sensor '%s' failed", tc.Name)
 		c.c.Telemetry().Alert(subject, "Error:"+err.Error())
 		if tc.FailSafe && tc.Control && tc.Heater != "" {
 			if sub, sErr := c.c.Subsystem("equipment"); sErr == nil {
 				if oErr := sub.On(tc.Heater, false); oErr != nil {
-					log.Println("ERROR: temperature sub-system: failsafe: failed to turn off heater:", oErr)
+					log.Println("ERROR: temperature subsystem: failsafe: failed to turn off heater:", oErr)
 				} else {
-					log.Println("temperature sub-system: failsafe: turned off heater due to sensor read failure:", tc.Name)
+					log.Println("temperature subsystem: failsafe: turned off heater due to sensor read failure:", tc.Name)
 				}
 			}
 		}
@@ -38,7 +38,7 @@ func (c *Controller) Check(tc *TC) (float64, error) {
 	}
 
 	tc.currentValue = reading
-	log.Println("temperature sub-system:  sensor", tc.Name, "value:", reading)
+	log.Println("temperature subsystem:  sensor", tc.Name, "value:", reading)
 	c.c.Telemetry().EmitMetric(tc.Name, "reading", reading)
 	u := controller.Observation{
 		Time:  telemetry.TeleTime(time.Now()),
@@ -46,7 +46,7 @@ func (c *Controller) Check(tc *TC) (float64, error) {
 	}
 	if tc.Control {
 		if err := tc.h.Sync(&u); err != nil {
-			log.Println("temperature sub-system: ERROR: Failed to execute:", err)
+			log.Println("temperature subsystem: ERROR: Failed to execute:", err)
 			c.c.LogError("tc-"+tc.ID, "Failed to execute temperature control logic for:"+tc.Name+". Error:"+err.Error())
 		}
 	}

--- a/controller/modules/temperature/controller.go
+++ b/controller/modules/temperature/controller.go
@@ -110,7 +110,7 @@ func (c *Controller) Stop() {
 		if err := c.statsMgr.Save(id); err != nil {
 			log.Println("ERROR: temperature controller. Failed to save usage. Error:", err)
 		}
-		log.Println("temperature sub-system: Saved usage data of sensor:", id)
+		log.Println("temperature subsystem: Saved usage data of sensor:", id)
 	}
 	c.wg.Wait()
 }

--- a/controller/modules/temperature/tc.go
+++ b/controller/modules/temperature/tc.go
@@ -163,7 +163,7 @@ func (c *Controller) Delete(id string) error {
 		return err
 	}
 	if err := c.repo.DeleteUsage(id); err != nil {
-		log.Println("ERROR:  temperature sub-system: Failed to delete usage details for sensor:", id)
+		log.Println("ERROR:  temperature subsystem: Failed to delete usage details for sensor:", id)
 	}
 
 	quit, ok := c.quitters[id]
@@ -196,14 +196,14 @@ func (c *Controller) IsEquipmentInUse(id string) (bool, error) {
 func (c *Controller) Run(t *TC, quit chan struct{}) error {
 	t.CreateFeed(c.c.Telemetry())
 	if t.Period <= 0 {
-		log.Printf("ERROR: temperature sub-system. Invalid period set for sensor:%s. Expected positive, found:%d\n", t.Name, t.Period)
+		log.Printf("ERROR: temperature subsystem. Invalid period set for sensor:%s. Expected positive, found:%d\n", t.Name, t.Period)
 		return nil
 	}
 	t.loadHomeostasis(c.c)
 	ticker := time.NewTicker(t.Period * time.Second)
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("ERROR: temperature sub-system. Panic in Run goroutine for sensor:%s: %v\n", t.Name, r)
+			log.Printf("ERROR: temperature subsystem. Panic in Run goroutine for sensor:%s: %v\n", t.Name, r)
 			c.c.LogError("tc-"+t.ID, fmt.Sprintf("temperature controller goroutine panicked: %v", r))
 		}
 	}()


### PR DESCRIPTION
Summary:
- Change temperature log text from 'temperature sub-system' to 'temperature subsystem' in owned temperature module files only.

Validation:
- gofmt -w controller/modules/temperature/control.go controller/modules/temperature/tc.go controller/modules/temperature/controller.go
- go test ./controller/modules/temperature
- git diff --check -- controller/modules/temperature/control.go controller/modules/temperature/tc.go controller/modules/temperature/controller.go