### PR TITLE
Fix usage delete log grammar

### DIFF
--- a/controller/modules/ato/ato.go
+++ b/controller/modules/ato/ato.go
@@ -115,10 +115,10 @@ func (c *Controller) Reset(id string) error {
 		delete(c.quitters, id)
 	}
 	if err := c.statsMgr.Delete(id); err != nil {
-		log.Println("ERROR:  ato-subsystem: Failed to deleted usage details for ato:", id, "error:", err)
+		log.Println("ERROR:  ato-subsystem: Failed to delete usage details for ato:", id, "error:", err)
 	}
 	if err := c.repo.DeleteUsage(id); err != nil {
-		log.Println("ERROR:  ato-subsystem: Failed to deleted usage details for ato:", id, "error:", err)
+		log.Println("ERROR:  ato-subsystem: Failed to delete usage details for ato:", id, "error:", err)
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/controller/modules/ato/repository.go
+++ b/controller/modules/ato/repository.go
@@ -69,7 +69,7 @@ func (r storeRepository) Delete(id string) error {
 		return err
 	}
 	if err := r.DeleteUsage(id); err != nil {
-		log.Println("ERROR:  ato-subsystem: Failed to deleted usage details for ato:", id)
+		log.Println("ERROR:  ato-subsystem: Failed to delete usage details for ato:", id)
 	}
 	return nil
 }

--- a/controller/modules/journal/repository.go
+++ b/controller/modules/journal/repository.go
@@ -68,7 +68,7 @@ func (r storeRepository) Delete(id string) error {
 		return err
 	}
 	if err := r.store.Delete(UsageBucket, id); err != nil {
-		log.Println("ERROR: journal-subsystem: Failed to deleted usage details for journal:", id)
+		log.Println("ERROR: journal-subsystem: Failed to delete usage details for journal:", id)
 	}
 	return nil
 }

--- a/controller/modules/macro/repository.go
+++ b/controller/modules/macro/repository.go
@@ -64,7 +64,7 @@ func (r storeRepository) Delete(id string) error {
 		return err
 	}
 	if err := r.store.Delete(UsageBucket, id); err != nil {
-		log.Println("ERROR:  macro-subsystem: Failed to deleted usage details for macro:", id)
+		log.Println("ERROR:  macro-subsystem: Failed to delete usage details for macro:", id)
 	}
 	return nil
 }

--- a/controller/modules/ph/probe.go
+++ b/controller/modules/ph/probe.go
@@ -153,7 +153,7 @@ func (c *Controller) Delete(id string) error {
 		return err
 	}
 	if err := c.statsMgr.Delete(id); err != nil {
-		log.Println("ERROR: ph sub-system: Failed to deleted readings for probe:", id)
+		log.Println("ERROR: ph sub-system: Failed to delete readings for probe:", id)
 	}
 
 	delete(c.calibrators, id)


### PR DESCRIPTION
## Summary
- Correct usage-delete log grammar from 'Failed to deleted' to 'Failed to delete' in journal, macro, ato, and ph owned files.
- No behavior, API, storage, or test changes.

## Validation
- gofmt -w controller/modules/journal/repository.go controller/modules/macro/repository.go controller/modules/ato/repository.go controller/modules/ato/ato.go controller/modules/ph/probe.go
- go test ./controller/modules/journal ./controller/modules/macro ./controller/modules/ato ./controller/modules/ph
- git diff --cached --check