### PR TITLE
Slice 06: fix camera and timer log spelling

### DIFF
--- a/controller/modules/camera/camera.go
+++ b/controller/modules/camera/camera.go
@@ -59,7 +59,7 @@ func (c *Controller) run() {
 		return
 	}
 	if err := c.Process(img); err != nil {
-		log.Println("ERROR: camera sub-system : Failed to process image. Error:", err)
+		log.Println("ERROR: camera subsystem: Failed to process image. Error:", err)
 		c.c.LogError("camera-process", "Failed to process image. Error:"+err.Error())
 	}
 	if c.config.Upload {

--- a/controller/modules/timer/runner.go
+++ b/controller/modules/timer/runner.go
@@ -43,13 +43,13 @@ func NewSubSystemRunner(j Job, c controller.Controller) (cron.Job, error) {
 func (m *SubSystemRunner) Run() {
 	log.Println("timer subsystem. Executing module ", m.Type, "element", m.trigger.ID)
 	if err := m.sub.On(m.trigger.ID, m.trigger.On); err != nil {
-		log.Println("ERROR:", m.Type, "sub-system, Failed to trigger. Error:", err)
+		log.Println("ERROR:", m.Type, "subsystem, Failed to trigger. Error:", err)
 	}
 	if m.trigger.Revert {
 		select {
 		case <-time.After(m.trigger.Duration * time.Second):
 			if err := m.sub.On(m.trigger.ID, !m.trigger.On); err != nil {
-				log.Println("ERROR:", m.Type, "sub-system, Failed to revert. Error:", err)
+				log.Println("ERROR:", m.Type, "subsystem, Failed to revert. Error:", err)
 			}
 			log.Println("timer subsystem. Executing module ", m.Type, "element", m.trigger.ID, "reversed")
 		}


### PR DESCRIPTION
## Summary
- normalize camera log text from sub-system to subsystem
- normalize timer subsystem error log text

## Validation
- rtk go test ./controller/modules/camera ./controller/modules/timer
- rtk git diff --check

## Risk
- Log-message-only cleanup; no runtime behavior change.