### PR TITLE
Fix doser subsystem log spelling

### DIFF
--- a/controller/modules/doser/controller.go
+++ b/controller/modules/doser/controller.go
@@ -55,7 +55,7 @@ func (c *Controller) Stop() {
 		delete(c.quitters, id)
 	}
 	c.mu.Unlock()
-	log.Println("Stopped dosing sub-system")
+	log.Println("Stopped dosing subsystem")
 }
 
 func (c *Controller) Setup() error {

--- a/controller/modules/doser/pump.go
+++ b/controller/modules/doser/pump.go
@@ -149,7 +149,7 @@ func (c *Controller) Update(id string, p Pump) error {
 	}
 	c.mu.Lock()
 	if cID, ok := c.cronIDs[id]; ok {
-		log.Printf("doser sub-system. Removing cron entry %d for pump id: %s.\n", cID, id)
+		log.Printf("doser subsystem. Removing cron entry %d for pump id: %s.\n", cID, id)
 		c.runner.Remove(cID)
 		delete(c.cronIDs, id)
 	}
@@ -177,7 +177,7 @@ func (c *Controller) Schedule(id string, r DosingRegiment) error {
 func (c *Controller) Delete(id string) error {
 	c.mu.Lock()
 	if cID, ok := c.cronIDs[id]; ok {
-		log.Printf("doser sub-system. Removing cron entry %d for pump id: %s.\n", cID, id)
+		log.Printf("doser subsystem. Removing cron entry %d for pump id: %s.\n", cID, id)
 		c.runner.Remove(cID)
 		delete(c.cronIDs, id)
 	}

--- a/controller/modules/doser/runner.go
+++ b/controller/modules/doser/runner.go
@@ -24,7 +24,7 @@ func (r *Runner) Run() {
 	if r.pump.Type == "stepper" && r.pump.Stepper != nil {
 		log.Println("doser sub system: running doser(stepper)", r.pump.Name, "for", r.pump.Regiment.Volume, "(ml)")
 		if err := r.pump.Stepper.Dose(r.dm.Outlets(), r.pump.Regiment.Volume); err != nil {
-			log.Println("ERROR: dosing sub-system. Failed to run stepper. Error:", err)
+			log.Println("ERROR: dosing subsystem. Failed to run stepper. Error:", err)
 			return
 		}
 		usage.Pump = int(r.pump.Regiment.Duration)
@@ -35,7 +35,7 @@ func (r *Runner) Run() {
 		}
 		log.Println("doser sub system: running doser(dcmotor)", r.pump.Name, "at", r.pump.Regiment.Speed, "%speed for", duration, "(s)")
 		if err := r.PWMDose(r.pump.Regiment.Speed, duration); err != nil {
-			log.Println("ERROR: dosing sub-system. Failed to control jack. Error:", err)
+			log.Println("ERROR: dosing subsystem. Failed to control jack. Error:", err)
 			return
 		}
 		usage.Pump = int(duration)


### PR DESCRIPTION
## Summary
- Change doser/dosing log text from sub-system to subsystem in owned doser files only.

## Validation
- gofmt -w controller/modules/doser/controller.go controller/modules/doser/pump.go controller/modules/doser/runner.go
- go test ./controller/modules/doser
- git diff --check