### PR TITLE
Fix pH subsystem log spelling

### DIFF
--- a/controller/modules/ph/controller.go
+++ b/controller/modules/ph/controller.go
@@ -100,7 +100,7 @@ func (c *Controller) Stop() {
 		if err := c.statsMgr.Save(id); err != nil {
 			log.Println("ERROR: ph controller. Failed to save usage. Error:", err)
 		}
-		log.Println("ph sub-system: Saved usaged data of sensor:", id)
+		log.Println("ph subsystem: Saved usage data of sensor:", id)
 		delete(c.quitters, id)
 	}
 }

--- a/controller/modules/ph/probe.go
+++ b/controller/modules/ph/probe.go
@@ -153,7 +153,7 @@ func (c *Controller) Delete(id string) error {
 		return err
 	}
 	if err := c.statsMgr.Delete(id); err != nil {
-		log.Println("ERROR: ph sub-system: Failed to delete readings for probe:", id)
+		log.Println("ERROR: ph subsystem: Failed to delete readings for probe:", id)
 	}
 
 	delete(c.calibrators, id)
@@ -197,7 +197,7 @@ func (c *Controller) Read(p Probe) (float64, error) {
 
 func (c *Controller) Run(p Probe, quit chan struct{}) error {
 	if p.Period <= 0 {
-		log.Printf("ERROR:ph sub-system. Invalid period set for probe:%s. Expected positive, found:%d\n", p.Name, p.Period)
+		log.Printf("ERROR: ph subsystem. Invalid period set for probe:%s. Expected positive, found:%d\n", p.Name, p.Period)
 		return fmt.Errorf("invalid period: %d for probe: %s", p.Period, p.Name)
 	}
 	if p.Control {
@@ -228,7 +228,7 @@ func (c *Controller) Run(p Probe, quit chan struct{}) error {
 func (c *Controller) checkAndControl(p Probe) (float64, error) {
 	reading, err := c.Read(p)
 	if err != nil {
-		log.Println("ph sub-system: ERROR: Failed to read probe:", p.Name, ". Error:", err)
+		log.Println("ph subsystem: ERROR: Failed to read probe:", p.Name, ". Error:", err)
 		c.c.LogError("ph-"+p.ID, "ph subsystem: Failed read probe:"+p.Name+"Error:"+err.Error())
 		return 0, err
 	}
@@ -240,7 +240,7 @@ func (c *Controller) checkAndControl(p Probe) (float64, error) {
 		reading = calibrator.Calibrate(reading)
 	}
 
-	log.Println("ph sub-system: Probe:", p.Name, "Reading:", reading)
+	log.Println("ph subsystem: Probe:", p.Name, "Reading:", reading)
 	notifyIfNeeded(c.c.Telemetry(), p, reading)
 	u := controller.NewObservation(reading)
 	if p.Control {


### PR DESCRIPTION
## Summary
- update pH module log text from "ph sub-system" to "ph subsystem"
- normalize the pH invalid-period error prefix to "ERROR: ph subsystem"
- fix "Saved usaged data" to "Saved usage data"

## Validation
- gofmt -w controller/modules/ph/controller.go controller/modules/ph/probe.go
- rtk go test ./controller/modules/ph
- rtk rg -n "ph sub-system|ERROR:ph sub-system|Saved usaged data" controller/modules/ph/controller.go controller/modules/ph/probe.go (no matches)