### PR TITLE
Slice 06: fix daemon loader subsystem wording

### DIFF
--- a/controller/daemon/loader.go
+++ b/controller/daemon/loader.go
@@ -76,7 +76,7 @@ func (r *ReefPi) loadATOSubsystem(eqs *equipment.Controller) error {
 	}
 	if eqs == nil {
 		r.settings.Capabilities.ATO = false
-		return fmt.Errorf("equipment sub-system is not initialized")
+		return fmt.Errorf("equipment subsystem is not initialized")
 	}
 	a, err := ato.New(r.settings.Capabilities.DevMode, r)
 	if err != nil {


### PR DESCRIPTION
## Summary
- fix daemon ATO dependency error wording from sub-system to subsystem
- leave the existing LogError key unchanged to preserve stored error identity

## Validation
- rtk go test ./controller/daemon
- rtk git diff --check

## Risk
- Error-message-only cleanup; no runtime behavior change.