### PR TITLE
Slice 06: fix ATO subsystem log spelling

### DIFF
--- a/controller/modules/ato/controller.go
+++ b/controller/modules/ato/controller.go
@@ -108,7 +108,7 @@ func (c *Controller) Stop() {
 		if err := c.statsMgr.Save(id); err != nil {
 			log.Println("ERROR: ato controller. Failed to save usage. Error:", err)
 		}
-		log.Println("ato sub-system: Saved usage data of sensor:", id)
+		log.Println("ato subsystem: Saved usage data of sensor:", id)
 	}
 	c.wg.Wait()
 }


### PR DESCRIPTION
## Summary
- normalize ATO controller log text from sub-system to subsystem

## Validation
- rtk go test ./controller/modules/ato
- rtk git diff --check

## Risk
- Log-message-only cleanup; no runtime behavior change.