### PR TITLE
Use background context in vcgencmd test

### DIFF
--- a/controller/telemetry/vcgencmd_test.go
+++ b/controller/telemetry/vcgencmd_test.go
@@ -20,7 +20,7 @@ func TestGetThrottles(t *testing.T) {
 		}
 	}
 	bytes = []byte("throttled=0x1")
-	issues, err := GetThrottled(context.TODO(), stubFactory)
+	issues, err := GetThrottled(context.Background(), stubFactory)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
## Summary
- Replace context.TODO() with context.Background() in the vcgencmd telemetry test.

## Validation
- rtk gofmt -w controller/telemetry/vcgencmd_test.go
- rtk go test ./controller/telemetry