### PR TITLE
Adopt API helpers for connector actions

### DIFF
--- a/front-end/src/redux/actions/analog_inputs.js
+++ b/front-end/src/redux/actions/analog_inputs.js
@@ -1,9 +1,4 @@
-import {
-  reduxPut,
-  reduxDelete,
-  reduxGet,
-  reduxPost
-} from '../../utils/ajax'
+import { deleteAction, getAction, postAction, putAction } from './api'
 
 export const analogInputsLoaded = (ais) => {
   return ({
@@ -13,35 +8,17 @@ export const analogInputsLoaded = (ais) => {
 }
 
 export const fetchAnalogInputs = () => {
-  return (
-    reduxGet({
-      url: '/api/analog_inputs',
-      success: analogInputsLoaded
-    }))
+  return getAction('analog_inputs', analogInputsLoaded)
 }
 
 export const deleteAnalogInput = (id) => {
-  return (
-    reduxDelete({
-      url: '/api/analog_inputs/' + id,
-      success: fetchAnalogInputs
-    }))
+  return deleteAction(['analog_inputs', id], fetchAnalogInputs)
 }
 
 export const createAnalogInput = (ai) => {
-  return (
-    reduxPut({
-      url: '/api/analog_inputs',
-      data: ai,
-      success: fetchAnalogInputs
-    }))
+  return putAction('analog_inputs', ai, fetchAnalogInputs)
 }
 
 export const updateAnalogInput = (id, ai) => {
-  return (
-    reduxPost({
-      url: '/api/analog_inputs/' + id,
-      data: ai,
-      success: fetchAnalogInputs
-    }))
+  return postAction(['analog_inputs', id], ai, fetchAnalogInputs)
 }

--- a/front-end/src/redux/actions/inlets.js
+++ b/front-end/src/redux/actions/inlets.js
@@ -1,4 +1,4 @@
-import { reduxGet, reduxPost, reduxPut, reduxDelete } from '../../utils/ajax'
+import { deleteAction, getAction, postAction, putAction } from './api'
 
 export const inletsLoaded = (inlets) => {
   return ({
@@ -8,35 +8,17 @@ export const inletsLoaded = (inlets) => {
 }
 
 export const fetchInlets = () => {
-  return (
-    reduxGet({
-      url: '/api/inlets',
-      success: inletsLoaded
-    }))
+  return getAction('inlets', inletsLoaded)
 }
 
 export const deleteInlet = (id) => {
-  return (
-    reduxDelete({
-      url: '/api/inlets/' + id,
-      success: fetchInlets
-    }))
+  return deleteAction(['inlets', id], fetchInlets)
 }
 
 export const createInlet = (inlet) => {
-  return (
-    reduxPut({
-      url: '/api/inlets',
-      data: inlet,
-      success: fetchInlets
-    }))
+  return putAction('inlets', inlet, fetchInlets)
 }
 
 export const updateInlet = (id, inlet) => {
-  return (
-    reduxPost({
-      url: '/api/inlets/' + id,
-      data: inlet,
-      success: fetchInlets
-    }))
+  return postAction(['inlets', id], inlet, fetchInlets)
 }

--- a/front-end/src/redux/actions/jacks.js
+++ b/front-end/src/redux/actions/jacks.js
@@ -1,4 +1,4 @@
-import { reduxPut, reduxDelete, reduxGet, reduxPost } from '../../utils/ajax'
+import { deleteAction, getAction, postAction, putAction } from './api'
 
 export const jacksLoaded = (jacks) => {
   return ({
@@ -8,35 +8,17 @@ export const jacksLoaded = (jacks) => {
 }
 
 export const fetchJacks = () => {
-  return (
-    reduxGet({
-      url: '/api/jacks',
-      success: jacksLoaded
-    }))
+  return getAction('jacks', jacksLoaded)
 }
 
 export const deleteJack = (id) => {
-  return (
-    reduxDelete({
-      url: '/api/jacks/' + id,
-      success: fetchJacks
-    }))
+  return deleteAction(['jacks', id], fetchJacks)
 }
 
 export const createJack = (jack) => {
-  return (
-    reduxPut({
-      url: '/api/jacks',
-      data: jack,
-      success: fetchJacks
-    }))
+  return putAction('jacks', jack, fetchJacks)
 }
 
 export const updateJack = (id, jack) => {
-  return (
-    reduxPost({
-      url: '/api/jacks/' + id,
-      data: jack,
-      success: fetchJacks
-    }))
+  return postAction(['jacks', id], jack, fetchJacks)
 }

--- a/front-end/src/redux/actions/outlets.js
+++ b/front-end/src/redux/actions/outlets.js
@@ -1,4 +1,4 @@
-import { reduxGet, reduxPost, reduxPut, reduxDelete } from '../../utils/ajax'
+import { deleteAction, getAction, postAction, putAction } from './api'
 
 export const outletsLoaded = (outlets) => {
   return ({
@@ -8,35 +8,17 @@ export const outletsLoaded = (outlets) => {
 }
 
 export const fetchOutlets = () => {
-  return (
-    reduxGet({
-      url: '/api/outlets',
-      success: outletsLoaded
-    }))
+  return getAction('outlets', outletsLoaded)
 }
 
 export const deleteOutlet = (id) => {
-  return (
-    reduxDelete({
-      url: '/api/outlets/' + id,
-      success: fetchOutlets
-    }))
+  return deleteAction(['outlets', id], fetchOutlets)
 }
 
 export const createOutlet = (outlet) => {
-  return (
-    reduxPut({
-      url: '/api/outlets',
-      data: outlet,
-      success: fetchOutlets
-    }))
+  return putAction('outlets', outlet, fetchOutlets)
 }
 
 export const updateOutlet = (id, outlet) => {
-  return (
-    reduxPost({
-      url: '/api/outlets/' + id,
-      data: outlet,
-      success: fetchOutlets
-    }))
+  return postAction(['outlets', id], outlet, fetchOutlets)
 }


### PR DESCRIPTION
## Summary
- Replace direct redux ajax calls with shared API action helpers in connector CRUD actions
- Preserve connector API paths, including analog_inputs spelling

## Validation
- rtk yarn jest front-end/src/redux/actions/jacks.test.js front-end/src/redux/actions/inlets.test.js front-end/src/redux/actions/outlets.test.js front-end/src/redux/actions/analog_inputs.test.js
- rtk ./node_modules/.bin/standard front-end/src/redux/actions/jacks.js front-end/src/redux/actions/inlets.js front-end/src/redux/actions/outlets.js front-end/src/redux/actions/analog_inputs.js