### PR TITLE
Slice 08: use API helper for light actions

### DIFF
--- a/front-end/src/redux/actions/lights.js
+++ b/front-end/src/redux/actions/lights.js
@@ -1,4 +1,4 @@
-import { reduxDelete, reduxPut, reduxGet, reduxPost } from '../../utils/ajax'
+import { deleteAction, getAction, postAction, putAction } from './api'
 
 export const lightsLoaded = (s) => {
   for (const i in s) {
@@ -34,45 +34,25 @@ export const lightUsageLoaded = (id) => {
 }
 
 export const fetchLights = () => {
-  return (reduxGet({
-    url: '/api/lights',
-    success: lightsLoaded
-  }))
+  return getAction('lights', lightsLoaded)
 }
 
 export const fetchLight = (id) => {
-  return (reduxGet({
-    url: '/api/lights/' + id,
-    success: lightLoaded(id)
-  }))
+  return getAction(['lights', id], lightLoaded(id))
 }
 
 export const createLight = (s) => {
-  return (reduxPut({
-    url: '/api/lights',
-    success: fetchLights,
-    data: s
-  }))
+  return putAction('lights', s, fetchLights)
 }
 
 export const updateLight = (id, l) => {
-  return (reduxPost({
-    url: '/api/lights/' + id,
-    success: fetchLights,
-    data: l
-  }))
+  return postAction(['lights', id], l, fetchLights)
 }
 
 export const deleteLight = (s) => {
-  return (reduxDelete({
-    url: '/api/lights/' + s,
-    success: fetchLights
-  }))
+  return deleteAction(['lights', s], fetchLights)
 }
 
 export const fetchLightUsage = (id) => {
-  return (reduxGet({
-    url: '/api/lights/' + id + '/usage',
-    success: lightUsageLoaded(id)
-  }))
+  return getAction(['lights', id, 'usage'], lightUsageLoaded(id))
 }


### PR DESCRIPTION
## Summary
- route light Redux action requests through the shared API action helper
- preserve existing light CRUD and usage URLs, action types, payloads, and refresh behavior

## Validation
- rtk yarn jest front-end/src/redux/actions/lights.test.js
- rtk yarn standard front-end/src/redux/actions/lights.js
- rtk git diff --check

## Risk
- Request construction refactor only; no API path or UI behavior changes intended.