### PR TITLE
Use API helpers for equipment and drivers actions

### DIFF
--- a/front-end/src/redux/actions/drivers.js
+++ b/front-end/src/redux/actions/drivers.js
@@ -1,4 +1,4 @@
-import { reduxGet, reduxPost, reduxPut, reduxDelete } from 'utils/ajax'
+import { deleteAction, getAction, postAction, putAction } from './api'
 
 export const driversLoaded = (drivers) => {
   return ({
@@ -8,46 +8,23 @@ export const driversLoaded = (drivers) => {
 }
 
 export const fetchDrivers = () => {
-  return (
-    reduxGet({
-      url: '/api/drivers',
-      success: driversLoaded
-    }))
+  return getAction('drivers', driversLoaded)
 }
 
 export const fetchDriverOptions = () => {
-  return (
-    reduxGet({
-      url: '/api/drivers/options',
-      success: driverOptionsLoaded
-    })
-  )
+  return getAction(['drivers', 'options'], driverOptionsLoaded)
 }
 
 export const deleteDriver = (id) => {
-  return (
-    reduxDelete({
-      url: '/api/drivers/' + id,
-      success: fetchDrivers
-    }))
+  return deleteAction(['drivers', id], fetchDrivers)
 }
 
 export const createDriver = (driver) => {
-  return (
-    reduxPut({
-      url: '/api/drivers',
-      data: driver,
-      success: fetchDrivers
-    }))
+  return putAction('drivers', driver, fetchDrivers)
 }
 
 export const updateDriver = (id, driver) => {
-  return (
-    reduxPost({
-      url: '/api/drivers/' + id,
-      data: driver,
-      success: fetchDrivers
-    }))
+  return postAction(['drivers', id], driver, fetchDrivers)
 }
 
 export const driverOptionsLoaded = (options) => {
@@ -58,10 +35,5 @@ export const driverOptionsLoaded = (options) => {
 }
 
 export const provisionDriver = (id) => {
-  return (
-    reduxPost({
-      url: '/api/drivers/' + id + '/provision',
-      data: {},
-      success: fetchDrivers
-    }))
+  return postAction(['drivers', id, 'provision'], {}, fetchDrivers)
 }

--- a/front-end/src/redux/actions/equipment.js
+++ b/front-end/src/redux/actions/equipment.js
@@ -1,4 +1,4 @@
-import { reduxGet, reduxPost, reduxPut, reduxDelete } from '../../utils/ajax'
+import { deleteAction, getAction, postAction, putAction } from './api'
 
 export const equipmentUpdated = () => {
   return ({
@@ -13,34 +13,16 @@ export const equipmentLoaded = (equipment) => {
 }
 
 export const fetchEquipment = () => {
-  return (
-    reduxGet({
-      url: '/api/equipment',
-      success: equipmentLoaded
-    }))
+  return getAction('equipment', equipmentLoaded)
 }
 export const deleteEquipment = (id) => {
-  return (
-    reduxDelete({
-      url: '/api/equipment/' + id,
-      success: fetchEquipment
-    }))
+  return deleteAction(['equipment', id], fetchEquipment)
 }
 
 export const createEquipment = (e) => {
-  return (
-    reduxPut({
-      url: '/api/equipment',
-      data: e,
-      success: fetchEquipment
-    }))
+  return putAction('equipment', e, fetchEquipment)
 }
 
 export const updateEquipment = (id, e) => {
-  return (
-    reduxPost({
-      url: '/api/equipment/' + id,
-      data: e,
-      success: fetchEquipment
-    }))
+  return postAction(['equipment', id], e, fetchEquipment)
 }


### PR DESCRIPTION
## Summary
- switch equipment actions from direct redux ajax calls to shared API action helpers
- switch drivers actions, including options and provision routes, to shared API action helpers

## Validation
- rtk yarn jest front-end/src/redux/actions/equipment.test.js front-end/src/redux/actions/drivers.test.js
- rtk ./node_modules/.bin/standard front-end/src/redux/actions/equipment.js front-end/src/redux/actions/drivers.js