### PR TITLE
Use API helpers for temperature and pH actions

### DIFF
--- a/front-end/src/redux/actions/phprobes.js
+++ b/front-end/src/redux/actions/phprobes.js
@@ -1,4 +1,4 @@
-import { reduxPut, reduxDelete, reduxGet, reduxPost } from '../../utils/ajax'
+import { deleteAction, getAction, postAction, putAction } from './api'
 
 export const phProbesLoaded = (s) => {
   return ({
@@ -28,17 +28,11 @@ export const probeCalibrated = () => {
 }
 
 export const fetchPhProbes = () => {
-  return (reduxGet({
-    url: '/api/phprobes',
-    success: phProbesLoaded
-  }))
+  return getAction('phprobes', phProbesLoaded)
 }
 
 export const readProbe = (id) => {
-  return (reduxGet({
-    url: '/api/phprobes/' + id + '/read',
-    success: probeReadComplete(id)
-  }))
+  return getAction(['phprobes', id, 'read'], probeReadComplete(id))
 }
 
 export const probeReadComplete = (id) => {
@@ -51,39 +45,21 @@ export const probeReadComplete = (id) => {
 }
 
 export const fetchProbeReadings = (id) => {
-  return (reduxGet({
-    url: '/api/phprobes/' + id + '/readings',
-    success: probeReadingsLoaded(id)
-  }))
+  return getAction(['phprobes', id, 'readings'], probeReadingsLoaded(id))
 }
 
 export const updateProbe = (id, a) => {
-  return (reduxPost({
-    url: '/api/phprobes/' + id,
-    data: a,
-    success: fetchPhProbes
-  }))
+  return postAction(['phprobes', id], a, fetchPhProbes)
 }
 
 export const createProbe = (a) => {
-  return (reduxPut({
-    url: '/api/phprobes',
-    data: a,
-    success: fetchPhProbes
-  }))
+  return putAction('phprobes', a, fetchPhProbes)
 }
 
 export const deleteProbe = (id) => {
-  return (reduxDelete({
-    url: '/api/phprobes/' + id,
-    success: fetchPhProbes
-  }))
+  return deleteAction(['phprobes', id], fetchPhProbes)
 }
 
 export const calibrateProbe = (id, a) => {
-  return (reduxPost({
-    url: '/api/phprobes/' + id + '/calibratepoint',
-    data: a,
-    success: probeCalibrated
-  }))
+  return postAction(['phprobes', id, 'calibratepoint'], a, probeCalibrated)
 }

--- a/front-end/src/redux/actions/tcs.js
+++ b/front-end/src/redux/actions/tcs.js
@@ -1,4 +1,4 @@
-import { reduxGet, reduxPut, reduxDelete, reduxPost } from '../../utils/ajax'
+import { deleteAction, getAction, postAction, putAction } from './api'
 
 export const tcsLoaded = (s) => {
   return ({
@@ -24,54 +24,31 @@ export const tcUsageLoaded = (id) => {
 }
 
 export const fetchTCs = () => {
-  return (reduxGet({
-    url: '/api/tcs',
-    success: tcsLoaded
-  }))
+  return getAction('tcs', tcsLoaded)
 }
 
 export const createTC = (t) => {
-  return (reduxPut({
-    url: '/api/tcs',
-    data: t,
-    success: fetchTCs
-  }))
+  return putAction('tcs', t, fetchTCs)
 }
 
 export const updateTC = (id, t) => {
-  return (reduxPost({
-    url: '/api/tcs/' + id,
-    data: t,
-    success: fetchTCs
-  }))
+  return postAction(['tcs', id], t, fetchTCs)
 }
 
 export const deleteTC = (id) => {
-  return (reduxDelete({
-    url: '/api/tcs/' + id,
-    success: fetchTCs
-  }))
+  return deleteAction(['tcs', id], fetchTCs)
 }
 
 export const fetchSensors = () => {
-  return (reduxGet({
-    url: '/api/tcs/sensors',
-    success: sensorsLoaded
-  }))
+  return getAction(['tcs', 'sensors'], sensorsLoaded)
 }
 
 export const fetchTCUsage = (id) => {
-  return (reduxGet({
-    url: '/api/tcs/' + id + '/usage',
-    success: tcUsageLoaded(id)
-  }))
+  return getAction(['tcs', id, 'usage'], tcUsageLoaded(id))
 }
 
 export const readTC = (id) => {
-  return (reduxGet({
-    url: '/api/tcs/' + id + '/read',
-    success: tcReadComplete(id)
-  }))
+  return getAction(['tcs', id, 'read'], tcReadComplete(id))
 }
 
 export const tcReadComplete = (id) => {
@@ -84,11 +61,7 @@ export const tcReadComplete = (id) => {
 }
 
 export const calibrateTemperature = (id, c) => {
-  return (reduxPost({
-    url: '/api/tcs/' + id + '/calibrate',
-    data: c,
-    success: tcCalibrated
-  }))
+  return postAction(['tcs', id, 'calibrate'], c, tcCalibrated)
 }
 
 export const tcCalibrated = () => {


### PR DESCRIPTION
Summary:
- Replace direct ajax helper usage in temperature controller actions with ./api helpers while preserving existing endpoints and callbacks.
- Replace direct ajax helper usage in pH probe actions with ./api helpers while preserving read, readings, and calibration routes.

Validation:
- rtk yarn install
- rtk yarn jest front-end/src/redux/actions/tcs.test.js front-end/src/redux/actions/phprobes.test.js (2 suites, 19 tests passed; Node punycode deprecation warning only)
- rtk ./node_modules/.bin/standard front-end/src/redux/actions/tcs.js front-end/src/redux/actions/phprobes.js