### PR TITLE
Slice 08: use API helper for journal and macro actions

### DIFF
--- a/front-end/src/redux/actions/journal.js
+++ b/front-end/src/redux/actions/journal.js
@@ -1,4 +1,4 @@
-import { reduxPut, reduxDelete, reduxGet, reduxPost } from 'utils/ajax'
+import { deleteAction, getAction, postAction, putAction } from './api'
 
 export const journalUpdated = () => {
   return ({
@@ -14,10 +14,7 @@ export const journalsLoaded = (s) => {
 }
 
 export const fetchJournals = () => {
-  return (reduxGet({
-    url: '/api/journal',
-    success: journalsLoaded
-  }))
+  return getAction('journal', journalsLoaded)
 }
 
 export const journalLoaded = (s) => {
@@ -28,10 +25,7 @@ export const journalLoaded = (s) => {
 }
 
 export const fetchJournal = (id) => {
-  return (reduxGet({
-    url: '/api/journal/' + id,
-    success: journalLoaded
-  }))
+  return getAction(['journal', id], journalLoaded)
 }
 
 export const journalUsageLoaded = (id) => {
@@ -44,41 +38,23 @@ export const journalUsageLoaded = (id) => {
 }
 
 export const fetchJournalUsage = (id) => {
-  return (reduxGet({
-    url: '/api/journal/' + id + '/usage',
-    success: journalUsageLoaded(id)
-  }))
+  return getAction(['journal', id, 'usage'], journalUsageLoaded(id))
 }
 
 export const createJournal = (a) => {
-  return (reduxPut({
-    url: '/api/journal',
-    data: a,
-    success: fetchJournals
-  }))
+  return putAction('journal', a, fetchJournals)
 }
 
 export const updateJournal = (id, a) => {
-  return (reduxPost({
-    url: '/api/journal/' + id,
-    data: a,
-    success: fetchJournals
-  }))
+  return postAction(['journal', id], a, fetchJournals)
 }
 
 export const deleteJournal = (id) => {
-  return (reduxDelete({
-    url: '/api/journal/' + id,
-    success: fetchJournals
-  }))
+  return deleteAction(['journal', id], fetchJournals)
 }
 
 export const recordJournal = (id, j) => {
-  return (reduxPost({
-    url: '/api/journal/' + id + '/record',
-    data: j,
-    success: journalRecorded(id)
-  }))
+  return postAction(['journal', id, 'record'], j, journalRecorded(id))
 }
 
 export const journalRecorded = (id) => {

--- a/front-end/src/redux/actions/macro.js
+++ b/front-end/src/redux/actions/macro.js
@@ -1,4 +1,4 @@
-import { reduxPut, reduxDelete, reduxGet, reduxPost } from '../../utils/ajax'
+import { deleteAction, getAction, postAction, putAction } from './api'
 
 export const macroUpdated = () => {
   return ({
@@ -25,10 +25,7 @@ export const macrosLoaded = (s) => {
 }
 
 export const fetchMacros = () => {
-  return (reduxGet({
-    url: '/api/macros',
-    success: macrosLoaded
-  }))
+  return getAction('macros', macrosLoaded)
 }
 
 export const macroUsageLoaded = (id) => {
@@ -41,44 +38,24 @@ export const macroUsageLoaded = (id) => {
 }
 
 export const fetchMacroUsage = (id) => {
-  return (reduxGet({
-    url: '/api/macros/' + id + '/usage',
-    success: macroUsageLoaded(id)
-  }))
+  return getAction(['macros', id, 'usage'], macroUsageLoaded(id))
 }
 
 export const createMacro = (a) => {
-  return (reduxPut({
-    url: '/api/macros',
-    data: a,
-    success: fetchMacros
-  }))
+  return putAction('macros', a, fetchMacros)
 }
 
 export const updateMacro = (id, a) => {
-  return (reduxPost({
-    url: '/api/macros/' + id,
-    data: a,
-    success: fetchMacros
-  }))
+  return postAction(['macros', id], a, fetchMacros)
 }
 
 export const deleteMacro = (id) => {
-  return (reduxDelete({
-    url: '/api/macros/' + id,
-    success: fetchMacros
-  }))
+  return deleteAction(['macros', id], fetchMacros)
 }
 
 export const runMacro = (id) => {
-  return (reduxPost({
-    url: '/api/macros/' + id + '/run',
-    success: macroRun
-  }))
+  return postAction(['macros', id, 'run'], undefined, macroRun)
 }
 export const revertMacro = (id) => {
-  return (reduxPost({
-    url: '/api/macros/' + id + '/revert',
-    success: macroRevert
-  }))
+  return postAction(['macros', id, 'revert'], undefined, macroRevert)
 }


### PR DESCRIPTION
## Summary
- route journal Redux action requests through the shared API action helper
- route macro Redux action requests through the shared API action helper
- preserve existing usage, record, run, revert, CRUD URLs and action behavior

## Validation
- rtk yarn jest front-end/src/redux/actions/journal.test.js front-end/src/redux/actions/macro.test.js
- rtk yarn standard front-end/src/redux/actions/journal.js front-end/src/redux/actions/macro.js
- rtk git diff --check

## Risk
- Request construction refactor only; no API path or UI behavior changes intended.