### PR TITLE
Slice 08: use API helper for admin and error actions

### DIFF
--- a/front-end/src/redux/actions/admin.js
+++ b/front-end/src/redux/actions/admin.js
@@ -1,4 +1,4 @@
-import { reduxPost } from '../../utils/ajax'
+import { postAction } from './api'
 
 export const reloaded = () => {
   return ({
@@ -8,11 +8,7 @@ export const reloaded = () => {
 
 export const reload = () => {
   return (
-    reduxPost({
-      url: '/api/admin/reload',
-      success: reloaded,
-      failure: () => {}
-    }))
+    postAction(['admin', 'reload'], undefined, reloaded, { failure: () => {} }))
 }
 
 export const rebooted = () => {
@@ -23,10 +19,7 @@ export const rebooted = () => {
 
 export const reboot = () => {
   return (
-    reduxPost({
-      url: '/api/admin/reboot',
-      success: rebooted
-    }))
+    postAction(['admin', 'reboot'], undefined, rebooted))
 }
 
 export const powerOffed = () => {
@@ -37,11 +30,7 @@ export const powerOffed = () => {
 
 export const powerOff = () => {
   return (
-    reduxPost({
-      url: '/api/admin/poweroff',
-      success: powerOffed,
-      data: {}
-    }))
+    postAction(['admin', 'poweroff'], {}, powerOffed))
 }
 
 export const dbImported = () => {
@@ -52,11 +41,7 @@ export const dbImported = () => {
 
 export const dbImport = (formData) => {
   return (
-    reduxPost({
-      url: '/api/admin/reef-pi.db',
-      success: dbImported,
-      raw: formData
-    }))
+    postAction(['admin', 'reef-pi.db'], undefined, dbImported, { raw: formData }))
 }
 
 export const upgraded = () => {
@@ -67,9 +52,5 @@ export const upgraded = () => {
 
 export const upgrade = (version) => {
   return (
-    reduxPost({
-      url: '/api/admin/upgrade',
-      success: upgraded,
-      data: { version }
-    }))
+    postAction(['admin', 'upgrade'], { version }, upgraded))
 }

--- a/front-end/src/redux/actions/admin.test.js
+++ b/front-end/src/redux/actions/admin.test.js
@@ -1,4 +1,4 @@
-import { reboot, powerOff, reload, reloaded, rebooted, powerOffed } from './admin'
+import { reboot, powerOff, reload, reloaded, rebooted, powerOffed, dbImport, dbImported, upgrade, upgraded } from './admin'
 import { thunk } from 'redux-thunk'
 import fetchMock from 'fetch-mock'
 import configureMockStore from 'redux-mock-store'
@@ -56,6 +56,32 @@ describe('admin actions', () => {
     const store = mockStore()
     return store.dispatch(powerOff()).then(() => {
       expect(store.getActions()).toEqual([powerOffed()])
+    })
+  })
+
+  it('dbImported', () => {
+    expect(dbImported().type).toEqual('DB_IMPORTED')
+  })
+
+  it('dbImport', () => {
+    const formData = new window.FormData()
+    fetchMock.postOnce('/api/admin/reef-pi.db', {})
+    const store = mockStore()
+    return store.dispatch(dbImport(formData)).then(() => {
+      expect(store.getActions()).toEqual([dbImported()])
+      expect(fetchMock.lastOptions('/api/admin/reef-pi.db').body).toBe(formData)
+    })
+  })
+
+  it('upgraded', () => {
+    expect(upgraded().type).toEqual('UPGRADED')
+  })
+
+  it('upgrade', () => {
+    fetchMock.postOnce('/api/admin/upgrade', {})
+    const store = mockStore()
+    return store.dispatch(upgrade('1.2.3')).then(() => {
+      expect(store.getActions()).toEqual([upgraded()])
     })
   })
 })

--- a/front-end/src/redux/actions/errors.js
+++ b/front-end/src/redux/actions/errors.js
@@ -1,4 +1,4 @@
-import { reduxDelete, reduxGet } from 'utils/ajax'
+import { deleteAction, getAction } from './api'
 
 export const errorsLoaded = (s) => {
   return ({
@@ -8,22 +8,13 @@ export const errorsLoaded = (s) => {
 }
 
 export const fetchErrors = () => {
-  return (reduxGet({
-    url: '/api/errors',
-    success: errorsLoaded
-  }))
+  return (getAction('errors', errorsLoaded))
 }
 
 export const deleteError = (id) => {
-  return (reduxDelete({
-    url: '/api/errors/' + id,
-    success: fetchErrors
-  }))
+  return (deleteAction(['errors', id], fetchErrors))
 }
 
 export const deleteErrors = () => {
-  return (reduxDelete({
-    url: '/api/errors/clear',
-    success: fetchErrors
-  }))
+  return (deleteAction(['errors', 'clear'], fetchErrors))
 }


### PR DESCRIPTION
## Summary
- route admin Redux action requests through the shared API action helper
- route error Redux action requests through the shared API action helper
- preserve reload, reboot, poweroff, DB import, upgrade, error fetch/delete/clear URLs and behavior
- add missing admin action coverage for DB import and upgrade while preserving existing assertions

## Validation
- rtk yarn install
- rtk yarn jest front-end/src/redux/actions/admin.test.js front-end/src/redux/actions/errors.test.js
- rtk yarn standard front-end/src/redux/actions/admin.js front-end/src/redux/actions/admin.test.js front-end/src/redux/actions/errors.js
- rtk git diff --check

## Risk
- Request construction refactor only; no API path or UI behavior changes intended.