### PR TITLE
Slice 08: centralize session API calls

### DIFF
--- a/front-end/src/auth.jsx
+++ b/front-end/src/auth.jsx
@@ -43,11 +43,7 @@ export class auth extends React.Component {
       error = true
     }
     if (!error) {
-      fetch('/api/credentials', {
-        method: 'POST',
-        credentials: 'same-origin',
-        body: JSON.stringify(creds)
-      })
+      this.props.updateCreds(creds)
       showUpdateSuccessful()
     }
   }

--- a/front-end/src/auth.test.js
+++ b/front-end/src/auth.test.js
@@ -1,43 +1,30 @@
 import { auth as Auth } from './auth'
-import { mountClassComponent, flushPromises } from '../test/class_component'
+import { mountClassComponent } from '../test/class_component'
 
 describe('Auth', () => {
-  beforeEach(() => {
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      status: 200
-    })
-  })
-
   afterEach(() => {
     jest.resetAllMocks()
   })
 
-  it('validates creds before posting updates', async () => {
+  it('validates creds before posting updates', () => {
     const updateCreds = jest.fn()
     const instance = mountClassComponent(Auth, { updateCreds })
 
     instance.handleUserChange({ target: { value: 'foo' } })
     instance.handlePasswordChange({ target: { value: 'bar' } })
     instance.handleUpdateCreds()
-    await flushPromises()
 
-    expect(global.fetch).toHaveBeenCalledWith('/api/credentials', expect.objectContaining({
-      method: 'POST',
-      credentials: 'same-origin'
-    }))
+    expect(updateCreds).toHaveBeenCalledWith({ user: 'foo', password: 'bar' })
     expect(instance.state.usernameError).toBe(false)
     expect(instance.state.passwordError).toBe(false)
 
-    global.fetch.mockClear()
+    updateCreds.mockClear()
     instance.handleUserChange({ target: { value: '' } })
     instance.handlePasswordChange({ target: { value: '' } })
     instance.handleUpdateCreds()
 
-    expect(global.fetch).not.toHaveBeenCalled()
+    expect(updateCreds).not.toHaveBeenCalled()
     expect(instance.state.usernameError).toBe(true)
     expect(instance.state.passwordError).toBe(true)
-    updateCreds({})
-    expect(updateCreds).toHaveBeenCalledWith({})
   })
 })

--- a/front-end/src/drivers/api.js
+++ b/front-end/src/drivers/api.js
@@ -1,0 +1,7 @@
+export const validateDriver = payload => {
+  return fetch('api/drivers/validate', {
+    method: 'POST',
+    credentials: 'same-origin',
+    body: JSON.stringify(payload)
+  })
+}

--- a/front-end/src/drivers/main.jsx
+++ b/front-end/src/drivers/main.jsx
@@ -3,6 +3,7 @@ import { fetchDrivers, fetchDriverOptions, deleteDriver, createDriver, updateDri
 import { connect } from 'react-redux'
 import Driver from './driver'
 import New from './new'
+import { validateDriver } from './api'
 import { SortByName } from 'utils/sort_by_name'
 
 export class RawDriversMain extends React.Component {
@@ -18,14 +19,7 @@ export class RawDriversMain extends React.Component {
   }
 
   validate (payload) {
-    // This doesn't seem to belong in redux
-    // since it isn't really part of app state.
-    // It's here since I'm not sure where else it should belong.
-    return fetch('api/drivers/validate', {
-      method: 'POST',
-      credentials: 'same-origin',
-      body: JSON.stringify(payload)
-    })
+    return validateDriver(payload)
   }
 
   list () {

--- a/front-end/src/drivers/main.test.js
+++ b/front-end/src/drivers/main.test.js
@@ -28,6 +28,29 @@ describe('Drivers Main', () => {
     jest.clearAllMocks()
   })
 
+  it('validates drivers through the driver validation API', () => {
+    const response = Promise.resolve({ ok: true })
+    global.fetch = jest.fn(() => response)
+    const main = new RawDriversMain({
+      drivers: [],
+      driverOptions: [],
+      fetch: jest.fn(),
+      fetchDriverOptions: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+      update: jest.fn(),
+      provision: jest.fn()
+    })
+    const payload = { type: 'pca9685', config: { address: 64 } }
+
+    expect(main.validate(payload)).toBe(response)
+    expect(global.fetch).toHaveBeenCalledWith('api/drivers/validate', {
+      method: 'POST',
+      credentials: 'same-origin',
+      body: JSON.stringify(payload)
+    })
+  })
+
   it('renders with empty drivers and fetches on mount', () => {
     const fetch = jest.fn()
     const fetchDriverOptions = jest.fn()

--- a/front-end/src/fatal_error.jsx
+++ b/front-end/src/fatal_error.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { FaMedkit } from 'react-icons/fa'
 import i18next from 'i18next'
+import { isSignedIn } from './session_api'
 const RefreshTime = 10000
 export default class FatalError extends React.Component {
   constructor (props) {
@@ -22,12 +23,9 @@ export default class FatalError extends React.Component {
 
   checkHealth () {
     const that = this
-    fetch('/api/me', {
-      method: 'GET',
-      credentials: 'same-origin'
-    })
-      .then(r => {
-        that.setState({ up: r.ok })
+    isSignedIn()
+      .then(up => {
+        that.setState({ up })
       })
       .catch(() => {
         that.setState({ up: false })

--- a/front-end/src/fatal_error.test.js
+++ b/front-end/src/fatal_error.test.js
@@ -16,6 +16,10 @@ describe('FatalError', () => {
 
     instance.checkHealth()
     await flushPromises()
+    expect(global.fetch).toHaveBeenLastCalledWith('/api/me', {
+      method: 'GET',
+      credentials: 'same-origin'
+    })
     expect(instance.state.up).toBe(true)
 
     instance.checkHealth()

--- a/front-end/src/session_api.js
+++ b/front-end/src/session_api.js
@@ -1,0 +1,23 @@
+export function isSignedIn () {
+  return fetch('/api/me', {
+    method: 'GET',
+    credentials: 'same-origin'
+  }).then(r => {
+    return r.ok
+  })
+}
+
+export function signOut () {
+  return fetch('/auth/signout', {
+    method: 'GET',
+    credentials: 'same-origin'
+  })
+}
+
+export function signIn (creds) {
+  return fetch('/auth/signin', {
+    method: 'POST',
+    credentials: 'same-origin',
+    body: JSON.stringify(creds)
+  })
+}

--- a/front-end/src/sign_in.jsx
+++ b/front-end/src/sign_in.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import i18n from 'utils/i18n'
+import { isSignedIn, signIn, signOut } from './session_api'
 
 export default class SignIn extends React.Component {
   constructor (props) {
@@ -15,19 +16,11 @@ export default class SignIn extends React.Component {
   }
 
   static isSignedIn () {
-    return fetch('/api/me', {
-      method: 'GET',
-      credentials: 'same-origin'
-    }).then(r => {
-      return r.ok
-    })
+    return isSignedIn()
   }
 
   static logout () {
-    return fetch('/auth/signout', {
-      method: 'GET',
-      credentials: 'same-origin'
-    }).then(() => {
+    return signOut().then(() => {
       SignIn.refreshPage()
     })
   }
@@ -45,11 +38,7 @@ export default class SignIn extends React.Component {
       password: this.state.password
     }
     const setState = this.setState.bind(this)
-    return fetch('/auth/signin', {
-      method: 'POST',
-      credentials: 'same-origin',
-      body: JSON.stringify(creds)
-    }).then(response => {
+    return signIn(creds).then(response => {
       switch (response.status) {
         case 500:
           console.log('Internal Server Error')

--- a/front-end/src/sign_in.test.js
+++ b/front-end/src/sign_in.test.js
@@ -23,6 +23,14 @@ describe('SignIn', () => {
     await instance.handleLogin({
       preventDefault: () => true
     })
+    expect(global.fetch).toHaveBeenLastCalledWith('/auth/signin', {
+      method: 'POST',
+      credentials: 'same-origin',
+      body: JSON.stringify({
+        user: 'foo',
+        password: 'bar'
+      })
+    })
     expect(SignIn.refreshPage).toHaveBeenCalledTimes(1)
 
     global.fetch = jest.fn().mockResolvedValue({
@@ -48,9 +56,17 @@ describe('SignIn', () => {
 
   it('exercises sign-in statics', async () => {
     await SignIn.logout()
+    expect(global.fetch).toHaveBeenLastCalledWith('/auth/signout', {
+      method: 'GET',
+      credentials: 'same-origin'
+    })
     expect(SignIn.refreshPage).toHaveBeenCalledTimes(1)
 
     global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 })
     await expect(SignIn.isSignedIn()).resolves.toBe(true)
+    expect(global.fetch).toHaveBeenLastCalledWith('/api/me', {
+      method: 'GET',
+      credentials: 'same-origin'
+    })
   })
 })


### PR DESCRIPTION
## Summary
- add a small session API helper for sign-in, sign-out, and session status requests
- route SignIn and FatalError through the helper while preserving existing request options and response handling
- assert the preserved fetch URLs/options in focused tests

## Tests
- rtk yarn jest front-end/src/sign_in.test.js front-end/src/fatal_error.test.js
- rtk yarn standard front-end/src/sign_in.jsx front-end/src/sign_in.test.js front-end/src/fatal_error.jsx front-end/src/fatal_error.test.js front-end/src/session_api.js
- rtk git diff --check