### PR TITLE
Remove Redux store singleton

### DIFF
--- a/front-end/src/entry.js
+++ b/front-end/src/entry.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { Provider } from 'react-redux'
-import { configureStore, setStore } from 'redux/store'
+import { configureStore } from 'redux/store'
 import { setAlertDispatcher } from 'utils/alert'
 import App from 'app'
 
-const store = setStore(configureStore())
+const store = configureStore()
 setAlertDispatcher(store.dispatch)
 const root = createRoot(document.getElementById('main-panel'))
 

--- a/front-end/src/redux/store.js
+++ b/front-end/src/redux/store.js
@@ -6,14 +6,3 @@ import { createInitialState } from './state'
 export const configureStore = (preloadedState = createInitialState()) => {
   return createStore(rootReducer, preloadedState, applyMiddleware(thunk))
 }
-
-let appStore
-
-export const setStore = (store) => {
-  appStore = store
-  return appStore
-}
-
-export const getStore = () => {
-  return appStore
-}

--- a/front-end/src/redux/store.test.js
+++ b/front-end/src/redux/store.test.js
@@ -1,19 +1,14 @@
+import { configureStore } from './store'
+
 describe('redux store ownership', () => {
-  beforeEach(() => {
-    jest.resetModules()
-  })
+  it('creates a Redux store with the initial app state', () => {
+    const store = configureStore()
 
-  it('does not create a store before one is registered', () => {
-    const { getStore } = require('./store')
-
-    expect(getStore()).toBeUndefined()
-  })
-
-  it('returns the registered store', () => {
-    const { getStore, setStore } = require('./store')
-    const store = { dispatch: jest.fn(), getState: jest.fn() }
-
-    expect(setStore(store)).toBe(store)
-    expect(getStore()).toBe(store)
+    expect(store.dispatch).toEqual(expect.any(Function))
+    expect(store.getState()).toEqual(expect.objectContaining({
+      info: expect.any(Object),
+      errors: expect.any(Array),
+      capabilities: expect.any(Object)
+    }))
   })
 })


### PR DESCRIPTION
## Summary
- remove the unused setStore/getStore singleton from the Redux store module
- let entry.js own the configured store directly
- update store coverage to assert configureStore creates a usable app-state store

## Tests
- rtk yarn jest front-end/src/redux/store.test.js
- rtk yarn standard front-end/src/redux/store.js front-end/src/redux/store.test.js front-end/src/entry.js
- rtk rg -n "\b(getStore|setStore)\b" front-end/src front-end/test -g '*.js' -g '*.jsx'
- rtk git diff --check