### PR TITLE
Avoid mutating capabilities payload

### DIFF
--- a/front-end/src/redux/actions/capabilities.js
+++ b/front-end/src/redux/actions/capabilities.js
@@ -1,12 +1,15 @@
 import { getAction } from './api'
 
 export const capabilitiesLoaded = (capabilities) => {
-  const MandatoryCapabilities = {
+  const mandatoryCapabilities = {
     log: true
   }
   return ({
     type: 'CAPABILITIES_LOADED',
-    payload: Object.assign(capabilities, MandatoryCapabilities)
+    payload: {
+      ...capabilities,
+      ...mandatoryCapabilities
+    }
   })
 }
 

--- a/front-end/src/redux/actions/capabilities.test.js
+++ b/front-end/src/redux/actions/capabilities.test.js
@@ -14,7 +14,16 @@ describe('capabilities actions', () => {
   })
 
   it('capabilitiesLoaded', () => {
-    expect(capabilitiesLoaded({}).type).toEqual('CAPABILITIES_LOADED')
+    const capabilities = { equipment: true }
+
+    expect(capabilitiesLoaded(capabilities)).toEqual({
+      type: 'CAPABILITIES_LOADED',
+      payload: {
+        equipment: true,
+        log: true
+      }
+    })
+    expect(capabilities).toEqual({ equipment: true })
   })
 
   it('fetchCapabilities', () => {


### PR DESCRIPTION
## Summary
- build the capabilities-loaded payload with object spread instead of mutating the input object
- preserve the mandatory log capability behavior
- add a regression assertion that the original capabilities object is unchanged

## Tests
- rtk yarn jest front-end/src/redux/actions/capabilities.test.js front-end/src/redux/actions/ui.test.js
- rtk yarn standard front-end/src/redux/actions/capabilities.js front-end/src/redux/actions/capabilities.test.js
- rtk git diff --check