### PR TITLE
Avoid mutating subsystem lists during render

### DIFF
--- a/front-end/src/ato/main.jsx
+++ b/front-end/src/ato/main.jsx
@@ -80,7 +80,7 @@ export class RawATOMain extends React.Component {
   }
 
   probeList () {
-    return this.props.atos.sort((a, b) => SortByName(a, b))
+    return this.props.atos.slice().sort((a, b) => SortByName(a, b))
       .map(probe => {
         const handleToggleState = () => {
           probe.enable = !probe.enable

--- a/front-end/src/ato/main.test.js
+++ b/front-end/src/ato/main.test.js
@@ -47,11 +47,16 @@ describe('ATO Main', () => {
   })
 
   it('renders a collapsible entry for each ATO', () => {
-    const component = new RawATOMain(makeProps())
+    const atos = [
+      { ...ato, id: '1', name: 'Top-off B' },
+      { ...ato, id: '2', name: 'Top-off A' }
+    ]
+    const component = new RawATOMain(makeProps({ atos }))
     const panels = component.probeList()
 
-    expect(panels).toHaveLength(1)
-    expect(panels[0].props.name).toBe('panel-ato-1')
+    expect(panels).toHaveLength(2)
+    expect(panels[0].props.name).toBe('panel-ato-2')
+    expect(atos.map(item => item.name)).toEqual(['Top-off B', 'Top-off A'])
   })
 
   it('renders with an empty ATO list', () => {

--- a/front-end/src/doser/doser.test.js
+++ b/front-end/src/doser/doser.test.js
@@ -153,10 +153,15 @@ describe('Doser ui', () => {
   }
 
   it('<Main /> doserList renders one entry per doser', () => {
-    const component = makeComponent()
+    const dosers = [
+      makeDoser({ id: '1', name: 'doser B' }),
+      makeDoser({ id: '2', name: 'doser A' })
+    ]
+    const component = makeComponent({ dosers })
     const items = component.doserList()
-    expect(items).toHaveLength(1)
-    expect(items[0].props.name).toBe('panel-doser-1')
+    expect(items).toHaveLength(2)
+    expect(items[0].props.name).toBe('panel-doser-2')
+    expect(dosers.map(item => item.name)).toEqual(['doser B', 'doser A'])
   })
 
   it('<Main /> doserList toggle enable calls update', () => {

--- a/front-end/src/doser/main.jsx
+++ b/front-end/src/doser/main.jsx
@@ -32,7 +32,7 @@ export class RawDoser extends React.Component {
 
   doserList () {
     return (
-      this.props.dosers.sort((a, b) => SortByName(a, b))
+      this.props.dosers.slice().sort((a, b) => SortByName(a, b))
         .map(doser => {
           const calibrationButton = (
             <button

--- a/front-end/src/journal/main.jsx
+++ b/front-end/src/journal/main.jsx
@@ -32,7 +32,7 @@ export class RawJournalMain extends React.Component {
   }
 
   list () {
-    return this.props.journals.sort((a, b) => SortByName(a, b))
+    return this.props.journals.slice().sort((a, b) => SortByName(a, b))
       .map(j => {
         return (
           <Collapsible

--- a/front-end/src/journal/main.test.js
+++ b/front-end/src/journal/main.test.js
@@ -40,6 +40,7 @@ describe('<Main />', () => {
     const rendered = main.render()
 
     expect(countByType(rendered, node => node.type === Collapsible)).toBe(2)
+    expect(journals.map(journal => journal.name)).toEqual(['pH Log', 'Alkalinity'])
   })
 
   it('renders with empty journal list', () => {

--- a/front-end/src/timers/main.jsx
+++ b/front-end/src/timers/main.jsx
@@ -26,7 +26,7 @@ export class RawTimersMain extends React.Component {
   }
 
   timerList () {
-    return this.props.timers.sort((a, b) => SortByName(a, b))
+    return this.props.timers.slice().sort((a, b) => SortByName(a, b))
       .map(timer => {
         const handleToggleState = () => {
           timer.enable = !timer.enable

--- a/front-end/src/timers/timers.test.js
+++ b/front-end/src/timers/timers.test.js
@@ -66,11 +66,16 @@ describe('Timer ui', () => {
   })
 
   it('<Main /> renders timers when present', () => {
-    const component = new RawTimersMain(makeProps())
+    const timers = [
+      { ...timerData, id: '1', name: 'timer B' },
+      { ...timerData, id: '2', name: 'timer A' }
+    ]
+    const component = new RawTimersMain(makeProps({ timers }))
     const items = component.timerList()
 
-    expect(items).toHaveLength(1)
-    expect(items[0].props.name).toBe('panel-timer-1')
+    expect(items).toHaveLength(2)
+    expect(items[0].props.name).toBe('panel-timer-2')
+    expect(timers.map(item => item.name)).toEqual(['timer B', 'timer A'])
   })
 
   it('<Main /> toggles add timer form', () => {


### PR DESCRIPTION
## Summary
- sort shallow copies of ATO, doser, timer, and journal prop arrays before rendering
- preserve displayed sorted order while avoiding in-place mutation of Redux-provided lists
- add regression assertions that source arrays keep their original order after list rendering

## Tests
- rtk yarn jest front-end/src/ato/main.test.js front-end/src/doser/doser.test.js front-end/src/timers/timers.test.js front-end/src/journal/main.test.js
- rtk yarn standard front-end/src/ato/main.jsx front-end/src/ato/main.test.js front-end/src/doser/main.jsx front-end/src/doser/doser.test.js front-end/src/timers/main.jsx front-end/src/timers/timers.test.js front-end/src/journal/main.jsx front-end/src/journal/main.test.js
- rtk git diff --check