### PR TITLE
Avoid mutating control lists during render

### DIFF
--- a/front-end/src/lighting/lighting.test.js
+++ b/front-end/src/lighting/lighting.test.js
@@ -127,8 +127,15 @@ describe('Lighting ui', () => {
   })
 
   it('<Main />', () => {
-    const m = createMain()
-    expect(m.lightsList()).toHaveLength(2)
+    const lights = [
+      { ...light, id: '1', name: 'light B' },
+      { ...light, id: '2', name: 'light A' }
+    ]
+    const m = createMain({ lights })
+    const items = m.lightsList()
+    expect(items).toHaveLength(2)
+    expect(items[0].props.name).toBe('light-2')
+    expect(lights.map(item => item.name)).toEqual(['light B', 'light A'])
   })
 
   it('<Main /> should change mode from auto to manual', () => {

--- a/front-end/src/lighting/main.jsx
+++ b/front-end/src/lighting/main.jsx
@@ -140,7 +140,7 @@ class main extends React.Component {
 
   lightsList () {
     return (
-      this.props.lights.sort((a, b) => SortByName(a, b))
+      this.props.lights.slice().sort((a, b) => SortByName(a, b))
         .map(light => {
           let panelContent = (
             <Light

--- a/front-end/src/macro/main.jsx
+++ b/front-end/src/macro/main.jsx
@@ -52,7 +52,7 @@ export class RawMacroMain extends React.Component {
 
   macroList () {
     return (
-      this.props.macros.sort((a, b) => SortByName(a, b))
+      this.props.macros.slice().sort((a, b) => SortByName(a, b))
         .map(macro => {
           const buttons = []
           buttons.push(

--- a/front-end/src/macro/main.test.js
+++ b/front-end/src/macro/main.test.js
@@ -47,8 +47,12 @@ describe('Macro UI', () => {
   })
 
   it('<Main /> mounts with macros', () => {
+    const macros = [
+      { ...macro, id: '1', name: 'Macro B' },
+      { ...macro, id: '2', name: 'Macro A' }
+    ]
     const main = new RawMacroMain({
-      macros: [macro],
+      macros,
       fetch: jest.fn(),
       create: jest.fn(),
       update: jest.fn(),
@@ -57,6 +61,7 @@ describe('Macro UI', () => {
       revert: jest.fn()
     })
     expect(main.render().type).toBe('ul')
+    expect(macros.map(item => item.name)).toEqual(['Macro B', 'Macro A'])
   })
 
   it('<Main /> toggles add macro form', () => {

--- a/front-end/src/ph/main.jsx
+++ b/front-end/src/ph/main.jsx
@@ -32,7 +32,7 @@ class ph extends React.Component {
   }
 
   probeList () {
-    return this.props.probes
+    return this.props.probes.slice()
       .sort((a, b) => SortByName(a, b))
       .map(probe => {
         const handleToggleState = () => {

--- a/front-end/src/ph/ph.test.js
+++ b/front-end/src/ph/ph.test.js
@@ -87,10 +87,17 @@ describe('Ph ui', () => {
   })
 
   it('<Main /> mounts with probes', () => {
-    const props = createProps({ probes: phState.phprobes })
+    const probes = [
+      { id: '1', name: 'probe B', enable: false, notify: { enable: false }, control: false },
+      { id: '2', name: 'probe A', enable: false, notify: { enable: false }, control: false }
+    ]
+    const props = createProps({ probes })
     const component = new RawPhMain(props)
     component.componentDidMount()
-    expect(component.probeList()).toHaveLength(1)
+    const items = component.probeList()
+    expect(items).toHaveLength(2)
+    expect(items[0].props.name).toBe('panel-ph-2')
+    expect(probes.map(probe => probe.name)).toEqual(['probe B', 'probe A'])
   })
 
   it('<Main /> toggles add probe form', () => {

--- a/front-end/src/temperature/main.jsx
+++ b/front-end/src/temperature/main.jsx
@@ -79,7 +79,7 @@ export class RawTemperatureMain extends React.Component {
   }
 
   probeList () {
-    return this.props.probes
+    return this.props.probes.slice()
       .sort((a, b) => SortByName(a, b))
       .map(probe => {
         const calibrationButton = (

--- a/front-end/src/temperature/temperature.test.js
+++ b/front-end/src/temperature/temperature.test.js
@@ -77,8 +77,12 @@ describe('Temperature controller ui', () => {
   })
 
   it('<Main /> mounts with tcs', () => {
+    const probes = [
+      { id: '1', name: 'Water B', chart: {}, enable: false, notify: { enable: false } },
+      { id: '2', name: 'Water A', chart: {}, enable: false, notify: { enable: false } }
+    ]
     const props = {
-      probes: tcState.tcs,
+      probes,
       currentReading: [],
       sensors: [],
       analogInputs: [],
@@ -97,7 +101,10 @@ describe('Temperature controller ui', () => {
     const component = new RawTemperatureMain(props)
     component.componentDidMount()
     expect(props.readTC).toHaveBeenCalledWith('1')
-    expect(component.probeList()).toHaveLength(1)
+    const items = component.probeList()
+    expect(items).toHaveLength(2)
+    expect(items[0].props.name).toBe('panel-temperature-2')
+    expect(probes.map(probe => probe.name)).toEqual(['Water B', 'Water A'])
   })
 
   it('<Main /> toggles add probe form', () => {


### PR DESCRIPTION
## Summary
- sort shallow copies of pH, temperature, lighting, and macro prop arrays before rendering
- preserve displayed sorted order while avoiding in-place mutation of Redux-provided lists
- add regression assertions that source arrays keep their original order after list rendering

## Tests
- rtk yarn jest front-end/src/ph/ph.test.js front-end/src/temperature/temperature.test.js front-end/src/lighting/lighting.test.js front-end/src/macro/main.test.js
- rtk yarn standard front-end/src/ph/main.jsx front-end/src/ph/ph.test.js front-end/src/temperature/main.jsx front-end/src/temperature/temperature.test.js front-end/src/lighting/main.jsx front-end/src/lighting/lighting.test.js front-end/src/macro/main.jsx front-end/src/macro/main.test.js
- rtk git diff --check