### PR TITLE
Avoid mutating infrastructure lists during render

### DIFF
--- a/front-end/src/drivers/main.jsx
+++ b/front-end/src/drivers/main.jsx
@@ -24,7 +24,7 @@ export class RawDriversMain extends React.Component {
 
   list () {
     const items = []
-    this.props.drivers.sort((a, b) => SortByName(a, b))
+    this.props.drivers.slice().sort((a, b) => SortByName(a, b))
       .forEach((d, n) => {
         items.push(
           <Driver

--- a/front-end/src/drivers/main.test.js
+++ b/front-end/src/drivers/main.test.js
@@ -72,8 +72,12 @@ describe('Drivers Main', () => {
   })
 
   it('renders drivers including rpi type as read_only', () => {
+    const unsortedDrivers = [
+      { id: '1', name: 'RPI B', type: 'rpi', config: {} },
+      { id: '2', name: 'PCA A', type: 'pca9685', config: {} }
+    ]
     const main = new RawDriversMain({
-      drivers,
+      drivers: unsortedDrivers,
       driverOptions,
       fetch: jest.fn(),
       fetchDriverOptions: jest.fn(),
@@ -89,6 +93,7 @@ describe('Drivers Main', () => {
     const byId = Object.fromEntries(driverNodes.map(node => [node.props.driver.id, node.props]))
     expect(byId['1'].read_only).toBe(true)
     expect(byId['2'].read_only).toBe(false)
+    expect(unsortedDrivers.map(driver => driver.name)).toEqual(['RPI B', 'PCA A'])
   })
 
   it('renders with non-rpi driver', () => {

--- a/front-end/src/equipment/edit_equipment.jsx
+++ b/front-end/src/equipment/edit_equipment.jsx
@@ -69,7 +69,7 @@ const EditEquipment = ({
             value={values.outlet}
           >
             <option value='' className='d-none'>-- {i18next.t('select')} --</option>
-            {outlets.sort((a, b) => SortByName(a, b))
+            {outlets.slice().sort((a, b) => SortByName(a, b))
               .map((item) => {
                 return (
                   <option

--- a/front-end/src/equipment/equipment.test.js
+++ b/front-end/src/equipment/equipment.test.js
@@ -187,6 +187,10 @@ describe('Equipment ui', () => {
   })
 
   it('<EditEquipment />', () => {
+    const unsortedOutlets = [
+      { id: '1', name: 'Outlet B' },
+      { id: '2', name: 'Outlet A' }
+    ]
     const tree = EditEquipment({
       actionLabel: 'save',
       values: { id: 1, name: '', outlet: '', stay_off_on_boot: false, boot_delay: 0 },
@@ -194,12 +198,13 @@ describe('Equipment ui', () => {
       touched: {},
       update: () => true,
       delete: () => true,
-      outlets: [{ id: '1', name: 'O1' }],
+      outlets: unsortedOutlets,
       handleBlur: () => true,
       submitForm: () => true,
       handleChange: () => true
     })
     expect(tree.type).toBe('form')
+    expect(unsortedOutlets.map(outlet => outlet.name)).toEqual(['Outlet B', 'Outlet A'])
   })
 
   it('<EditEquipment /> New Item', () => {

--- a/front-end/src/instances/instances.test.js
+++ b/front-end/src/instances/instances.test.js
@@ -60,8 +60,12 @@ describe('Instances Main', () => {
     const create = jest.fn()
     const update = jest.fn()
     const remove = jest.fn()
+    const instances = [
+      { ...instanceData, id: '2', name: 'Remote Tank B' },
+      { ...instanceData, id: '1', name: 'Remote Tank A' }
+    ]
     const main = new RawInstancesMain({
-      instances: [instanceData],
+      instances,
       fetch,
       create,
       update,
@@ -72,7 +76,8 @@ describe('Instances Main', () => {
     expect(fetch).toHaveBeenCalled()
 
     const rendered = main.render()
-    expect(countByType(rendered, node => node.type === Instance)).toBe(1)
+    expect(countByType(rendered, node => node.type === Instance)).toBe(2)
+    expect(instances.map(instance => instance.name)).toEqual(['Remote Tank B', 'Remote Tank A'])
   })
 
   it('renders with empty instance list', () => {

--- a/front-end/src/instances/main.jsx
+++ b/front-end/src/instances/main.jsx
@@ -45,7 +45,7 @@ export class RawInstancesMain extends React.Component {
     }
     return (
       <ul className='list-group list-group-flush'>
-        {this.props.instances.sort((a, b) => { return parseInt(a.id) < parseInt(b.id) }).map(item => {
+        {this.props.instances.slice().sort((a, b) => { return parseInt(a.id) < parseInt(b.id) }).map(item => {
           return (
             <Instance
               key={item.id}


### PR DESCRIPTION
## Summary
- sort shallow copies in drivers, instances, and equipment outlet selection before rendering
- preserve rendered ordering while avoiding in-place mutation of caller-provided arrays
- add regression assertions that input arrays keep their original order after render/list generation

## Tests
- rtk yarn jest front-end/src/drivers/main.test.js front-end/src/instances/instances.test.js front-end/src/equipment/equipment.test.js
- rtk yarn standard front-end/src/drivers/main.jsx front-end/src/drivers/main.test.js front-end/src/instances/main.jsx front-end/src/instances/instances.test.js front-end/src/equipment/edit_equipment.jsx front-end/src/equipment/equipment.test.js
- rtk git diff --check