### PR TITLE
Avoid mutating chart data during render

### DIFF
--- a/front-end/src/ato/chart.jsx
+++ b/front-end/src/ato/chart.jsx
@@ -34,7 +34,7 @@ export class RawATOChart extends React.Component {
     if (this.props.config === undefined) {
       return <div />
     }
-    const metrics = this.props.usage.historical
+    const metrics = this.props.usage.historical.slice()
       .sort((a, b) => ParseTimestamp(a.time) > ParseTimestamp(b.time) ? 1 : -1)
       .map(m => ({ ...m, ts: timestampToEpoch(m.time) }))
     return (

--- a/front-end/src/ato/chart.test.js
+++ b/front-end/src/ato/chart.test.js
@@ -6,6 +6,12 @@ const usage = { historical: [{ time: 'Jul-01-10:00, 2024', pump: 5 }] }
 
 describe('ATO Chart', () => {
   it('renders without throwing with config and usage present', () => {
+    const usage = {
+      historical: [
+        { time: 'Jul-01-10:10, 2024', pump: 6 },
+        { time: 'Jul-01-10:00, 2024', pump: 5 }
+      ]
+    }
     const chart = new RawATOChart({
       ato_id: '1',
       height: 200,
@@ -14,6 +20,8 @@ describe('ATO Chart', () => {
       fetchATOUsage: jest.fn()
     })
     expect(() => chart.render()).not.toThrow()
+    expect(usage.historical.map(item => item.time)).toEqual(['Jul-01-10:10, 2024', 'Jul-01-10:00, 2024'])
+    expect(usage.historical[0].ts).toBeUndefined()
     expect(Chart).toBeDefined()
   })
 

--- a/front-end/src/doser/chart.jsx
+++ b/front-end/src/doser/chart.jsx
@@ -34,7 +34,7 @@ export class RawDoserChart extends React.Component {
     if (this.props.config === undefined) {
       return <div />
     }
-    const metrics = this.props.usage.historical
+    const metrics = this.props.usage.historical.slice()
       .sort((a, b) => ParseTimestamp(a.time) > ParseTimestamp(b.time) ? 1 : -1)
       .map(m => ({ ...m, ts: timestampToEpoch(m.time) }))
     return (

--- a/front-end/src/doser/chart.test.js
+++ b/front-end/src/doser/chart.test.js
@@ -6,6 +6,12 @@ const usage = { historical: [{ time: 'Jul-01-10:00, 2024', pump: 3 }] }
 
 describe('Doser Chart', () => {
   it('renders without throwing with config and usage present', () => {
+    const usage = {
+      historical: [
+        { time: 'Jul-01-10:10, 2024', pump: 4 },
+        { time: 'Jul-01-10:00, 2024', pump: 3 }
+      ]
+    }
     const chart = new RawDoserChart({
       doser_id: '1',
       height: 200,
@@ -14,6 +20,8 @@ describe('Doser Chart', () => {
       fetchDoserUsage: jest.fn()
     })
     expect(() => chart.render()).not.toThrow()
+    expect(usage.historical.map(item => item.time)).toEqual(['Jul-01-10:10, 2024', 'Jul-01-10:00, 2024'])
+    expect(usage.historical[0].ts).toBeUndefined()
     expect(Chart).toBeDefined()
   })
 

--- a/front-end/src/health_chart.jsx
+++ b/front-end/src/health_chart.jsx
@@ -29,12 +29,11 @@ export class RawHealthChart extends React.Component {
       return (<div />)
     }
     const healthStats = this.props.health_stats[this.state.trend]
-    if (healthStats) {
-      healthStats.sort((a, b) => {
+      ?.slice()
+      .sort((a, b) => {
         return ParseTimestamp(a.time) > ParseTimestamp(b.time) ? 1 : -1
       })
-      healthStats.forEach((m, i) => { healthStats[i] = { ...m, ts: timestampToEpoch(m.time) } })
-    }
+      .map(m => ({ ...m, ts: timestampToEpoch(m.time) }))
     return (
       <div className='container'>
         <span className='h6'>{i18next.t('health_chart:cpu_memory')} ({i18next.t('health_chart:' + this.props.trend)})</span>

--- a/front-end/src/health_chart.test.js
+++ b/front-end/src/health_chart.test.js
@@ -42,4 +42,22 @@ describe('Health', () => {
 
     expect(window.clearInterval).toHaveBeenCalledWith(123)
   })
+
+  it('does not mutate health stats while preparing chart rows', () => {
+    const current = [
+      { time: 'Jul-01-10:10, 2024', cpu: 2, memory: 3, cpu_temp: 4 },
+      { time: 'Jul-01-10:00, 2024', cpu: 1, memory: 2, cpu_temp: 3 }
+    ]
+    const chart = new RawHealthChart({
+      fetchHealth,
+      health_stats: { current },
+      trend: 'current',
+      height: 100
+    })
+
+    chart.render()
+
+    expect(current.map(item => item.time)).toEqual(['Jul-01-10:10, 2024', 'Jul-01-10:00, 2024'])
+    expect(current[0].ts).toBeUndefined()
+  })
 })

--- a/front-end/src/lighting/charts/charts.test.js
+++ b/front-end/src/lighting/charts/charts.test.js
@@ -146,7 +146,12 @@ describe('GenericLightChart', () => {
   })
 
   it('renders chart when light and usage are present', () => {
-    const usage = { current: [{ time: '10:00', channels: { 1: 50 } }] }
+    const usage = {
+      current: [
+        { time: '10:10', channels: { 1: 75 } },
+        { time: '10:00', channels: { 1: 50 } }
+      ]
+    }
     const tree = new RawGenericLightChart({
       light_id: '1',
       light: lightConfig,
@@ -155,6 +160,8 @@ describe('GenericLightChart', () => {
       height: 200
     }).render()
     expect(tree.props.className).toBe('container')
+    expect(usage.current.map(item => item.time)).toEqual(['10:10', '10:00'])
+    expect(usage.current[0][1]).toBeUndefined()
   })
 
   it('clears interval on unmount', () => {

--- a/front-end/src/lighting/charts/generic.jsx
+++ b/front-end/src/lighting/charts/generic.jsx
@@ -42,16 +42,17 @@ export class RawGenericLightChart extends React.Component {
     })
 
     const usage = this.props.usage.current
-
-    usage.sort((a, b) => {
-      return ParseTimestamp(a.time) > ParseTimestamp(b.time) ? 1 : -1
-    })
-
-    usage.forEach((v, i) => {
-      Object.entries(v.channels).forEach(([ch, v]) => {
-        usage[i][ch] = v
+      .slice()
+      .sort((a, b) => {
+        return ParseTimestamp(a.time) > ParseTimestamp(b.time) ? 1 : -1
       })
-    })
+      .map(v => {
+        const row = { ...v }
+        Object.entries(v.channels).forEach(([ch, value]) => {
+          row[ch] = value
+        })
+        return row
+      })
     return (
       <div className='container'>
         <span className='h6'>{l.name}</span>


### PR DESCRIPTION
## Summary
- derive chart rows from copied health, ATO, doser, and light usage arrays
- avoid sorting or flattening caller-owned data during render
- add regression assertions that source usage arrays remain in their original order and shape

## Tests
- rtk yarn jest front-end/src/health_chart.test.js front-end/src/doser/chart.test.js front-end/src/ato/chart.test.js front-end/src/lighting/charts/charts.test.js
- rtk yarn standard front-end/src/health_chart.jsx front-end/src/health_chart.test.js front-end/src/doser/chart.jsx front-end/src/doser/chart.test.js front-end/src/ato/chart.jsx front-end/src/ato/chart.test.js front-end/src/lighting/charts/generic.jsx front-end/src/lighting/charts/charts.test.js
- rtk git diff --check