### PR TITLE
Avoid mutating temperature control chart data

### DIFF
--- a/front-end/src/temperature/control_chart.jsx
+++ b/front-end/src/temperature/control_chart.jsx
@@ -29,15 +29,12 @@ export class RawControlChart extends React.Component {
     if (this.props.usage === undefined) {
       return <div />
     }
-    const usage = []
-    this.props.usage.historical.forEach((v, i) => {
-      v.cooler *= -1
-      usage.push(v)
-    })
-    usage.sort((a, b) => {
-      return ParseTimestamp(a.time) > ParseTimestamp(b.time) ? 1 : -1
-    })
-    usage.forEach((m, i) => { usage[i] = { ...m, ts: timestampToEpoch(m.time) } })
+    const usage = this.props.usage.historical
+      .map(v => ({ ...v, cooler: v.cooler * -1 }))
+      .sort((a, b) => {
+        return ParseTimestamp(a.time) > ParseTimestamp(b.time) ? 1 : -1
+      })
+      .map(m => ({ ...m, ts: timestampToEpoch(m.time) }))
 
     const c = this.props.config.chart
     const unit = this.props.config.fahrenheit ? '°F' : '°C'

--- a/front-end/src/temperature/temperature.test.js
+++ b/front-end/src/temperature/temperature.test.js
@@ -251,9 +251,10 @@ describe('Temperature controller ui', () => {
     expect(new RawControlChart({ config: undefined, usage: { historical: [] }, sensor_id: '1', fetchTCUsage: jest.fn() }).render().type).toBe('div')
     expect(new RawControlChart({ config: { chart: {} }, usage: undefined, sensor_id: '1', fetchTCUsage: jest.fn() }).render().type).toBe('div')
     const fetchTCUsage = jest.fn()
+    const historical = [{ time: '2026-04-27T10:00:00Z', cooler: 1, up: 2, down: 0, value: 72 }]
     const instance = new RawControlChart({
       config: { id: '1', name: 'Water', chart: { color: '#f00', ymin: 70, ymax: 90 }, fahrenheit: true },
-      usage: { historical: [{ time: '2026-04-27T10:00:00Z', cooler: 1, up: 2, down: 0, value: 72 }], current: [] },
+      usage: { historical, current: [] },
       sensor_id: '1',
       fetchTCUsage,
       height: 200
@@ -262,6 +263,8 @@ describe('Temperature controller ui', () => {
     instance.componentDidMount()
     expect(fetchTCUsage).toHaveBeenCalledWith('1')
     expect(instance.render().props.className).toBe('container')
+    expect(historical[0].cooler).toBe(1)
+    expect(historical[0].ts).toBeUndefined()
     instance.componentWillUnmount()
   })
 


### PR DESCRIPTION
## Summary
- derive temperature control chart rows from copied historical usage records
- preserve cooler inversion for rendering without mutating the source usage object
- add a regression assertion that the original record keeps its cooler value and has no ts field added

## Tests
- rtk yarn jest front-end/src/temperature/temperature.test.js
- rtk yarn standard front-end/src/temperature/control_chart.jsx front-end/src/temperature/temperature.test.js
- rtk git diff --check