### PR TITLE
Avoid mutating form option arrays

### DIFF
--- a/front-end/src/connectors/connectors.test.js
+++ b/front-end/src/connectors/connectors.test.js
@@ -294,10 +294,12 @@ describe('Connectors', () => {
   })
 
   it('<Pin /> renders select with options for driver pins', () => {
-    const driver = { id: 'rpi', pinmap: { 'digital-output': [1, 2, 3] } }
+    const pins = [3, 1, 2]
+    const driver = { id: 'rpi', pinmap: { 'digital-output': pins } }
     const html = renderToStaticMarkup(<Pin driver={driver} update={() => {}} type='digital-output' current={1} />)
     expect(html).toContain('<select')
     expect((html.match(/<option/g) || []).length).toBe(3)
+    expect(pins).toEqual([3, 1, 2])
   })
 
   it('<Pin /> calls update on change', () => {

--- a/front-end/src/connectors/pin.jsx
+++ b/front-end/src/connectors/pin.jsx
@@ -25,7 +25,7 @@ export default class Pin extends React.Component {
       return
     }
 
-    return pins.sort((a, b) => { return a - b }).map(item => {
+    return pins.slice().sort((a, b) => { return a - b }).map(item => {
       return (
         <option key={'pin-' + item} value={item}>
           {item}

--- a/front-end/src/drivers/edit_driver.jsx
+++ b/front-end/src/drivers/edit_driver.jsx
@@ -42,7 +42,7 @@ const EditDriver = ({
     if (selectedType == null) { return null }
     const params = []
 
-    selectedType.sort((a, b) => { return parseInt(a.order) > parseInt(b.order) })
+    selectedType.slice().sort((a, b) => { return parseInt(a.order) > parseInt(b.order) })
       .forEach((item) => {
         const param = (
           <div key={item.name} className='col col-sm-6 col-md-3'>

--- a/front-end/src/drivers/edit_driver.test.js
+++ b/front-end/src/drivers/edit_driver.test.js
@@ -83,9 +83,18 @@ describe('<EditDriver />', () => {
   })
 
   it('driverConfig renders param fields when type has options', () => {
+    const selectedType = [
+      { name: 'Enabled', default: 'true', type: 4, order: 1 },
+      { name: 'Address', default: '99', type: 1, order: 0 }
+    ]
+    const driverOptions = {
+      ...options,
+      ezo: selectedType
+    }
     const values = { type: 'ezo', config: { address: '99', enabled: 'true' } }
-    const form = EditDriver(baseProps({ values }))
+    const form = EditDriver(baseProps({ values, driverOptions }))
     expect(form).not.toBeNull()
+    expect(selectedType.map(item => item.name)).toEqual(['Enabled', 'Address'])
   })
 
   it('renders in readOnly mode with disabled inputs', () => {


### PR DESCRIPTION
## Summary
- sort connector pin options from a copy instead of mutating the driver pinmap array
- sort driver config field definitions from a copy instead of mutating driverOptions
- add regression assertions that source arrays keep their input order after rendering

## Tests
- rtk yarn jest front-end/src/connectors/connectors.test.js front-end/src/drivers/edit_driver.test.js
- rtk yarn standard front-end/src/connectors/pin.jsx front-end/src/connectors/connectors.test.js front-end/src/drivers/edit_driver.jsx front-end/src/drivers/edit_driver.test.js
- rtk git diff --check