### PR TITLE
Avoid mutating manual light updates

### DIFF
--- a/front-end/src/lighting/manual_light.jsx
+++ b/front-end/src/lighting/manual_light.jsx
@@ -22,15 +22,29 @@ export default class ManualLight extends React.Component {
   }
 
   updateLight (name, value) {
-    this.props.light.channels[name].value = parseFloat(value)
-    this.props.handleChange(this.props.light.id, this.props.light)
+    const light = {
+      ...this.props.light,
+      channels: {
+        ...this.props.light.channels,
+        [name]: {
+          ...this.props.light.channels[name],
+          value: parseFloat(value)
+        }
+      }
+    }
+    this.props.handleChange(this.props.light.id, light)
   }
 
   handleValueChange (e) {
     // TODO: [ML] Allow decimal in regex
     if (/^([0-9]{0,2}$)|(100)$|^([0-9]{1,2}.[0-9]+$)/.test(e.target.value)) {
-      const channels = Object.assign({}, this.state.channels)
-      channels[e.target.name].value = e.target.value
+      const channels = {
+        ...this.state.channels,
+        [e.target.name]: {
+          ...this.state.channels[e.target.name],
+          value: e.target.value
+        }
+      }
       this.setState({ channels })
 
       if (isNaN(parseFloat(e.target.value)) === false) {

--- a/front-end/src/lighting/manual_light.test.js
+++ b/front-end/src/lighting/manual_light.test.js
@@ -71,4 +71,54 @@ describe('Lighting ui - Manual Control', () => {
     expect(component.state.channels[0].value).toBe('44.5')
     expect(component.debouncedChange).toHaveBeenCalledWith('0', 44.5)
   })
+
+  it('<ManualLight /> should update channel state without mutating existing channel objects', () => {
+    const handleChange = jest.fn()
+    const component = new ManualLight({
+      light: JSON.parse(JSON.stringify(light)),
+      handleChange
+    })
+    component.setState = jest.fn(next => {
+      component.state = { ...component.state, ...next }
+    })
+    component.debouncedChange = jest.fn()
+    const previousChannel = component.state.channels[0]
+
+    component.handleValueChange({
+      target: {
+        name: '0',
+        value: '44.5'
+      }
+    })
+
+    expect(previousChannel.value).toBe(10)
+    expect(component.state.channels[0]).not.toBe(previousChannel)
+    expect(component.state.channels[0].value).toBe('44.5')
+  })
+
+  it('<ManualLight /> should emit updated light values without mutating props', () => {
+    const handleChange = jest.fn()
+    const originalLight = JSON.parse(JSON.stringify(light))
+    const component = new ManualLight({
+      light: originalLight,
+      handleChange
+    })
+    const previousChannel = originalLight.channels[0]
+
+    component.updateLight('0', '44.5')
+
+    expect(originalLight.channels[0].value).toBe(10)
+    expect(handleChange).toHaveBeenCalledWith('1', {
+      ...originalLight,
+      channels: {
+        ...originalLight.channels,
+        0: {
+          ...originalLight.channels[0],
+          value: 44.5
+        }
+      }
+    })
+    expect(handleChange.mock.calls[0][1]).not.toBe(originalLight)
+    expect(handleChange.mock.calls[0][1].channels[0]).not.toBe(previousChannel)
+  })
 })


### PR DESCRIPTION
## Summary
- clone updated ManualLight channel state instead of mutating nested state objects
- emit cloned light payloads from manual light changes instead of mutating props
- add regression coverage for both immutability paths

## Tests
- rtk yarn jest front-end/src/lighting/manual_light.test.js --runInBand
- rtk yarn standard
- rtk git diff --check