### PR TITLE
Use spread updates for lightning profile

### DIFF
--- a/front-end/src/lighting/lightning_profile.jsx
+++ b/front-end/src/lighting/lightning_profile.jsx
@@ -12,7 +12,7 @@ const LightningProfile = ({
   onChangeHandler
 }) => {
   const handleChange = e => {
-    const updated = Object.assign({}, config, { [e.target.name]: e.target.value })
+    const updated = { ...config, [e.target.name]: e.target.value }
     onChangeHandler(updated)
   }
 

--- a/front-end/src/lighting/lightning_profile.test.js
+++ b/front-end/src/lighting/lightning_profile.test.js
@@ -63,6 +63,8 @@ describe('LightningProfile', () => {
       target: { name: 'start', value: '09:00:00' }
     })
     expect(handler).toHaveBeenCalledWith({ ...config, start: '09:00:00' })
+    expect(config.start).toBe('08:00:00')
+    expect(handler.mock.calls[0][0]).not.toBe(config)
   })
 
   it('renders in readOnly mode without throwing', () => {


### PR DESCRIPTION
## Summary
- replace the lightning profile Object.assign update with object spread
- assert field changes do not reuse or mutate the original config object

## Tests
- rtk yarn jest front-end/src/lighting/lightning_profile.test.js --runInBand
- rtk yarn standard
- rtk git diff --check