### PR TITLE
Centralize percentage input validation

### DIFF
--- a/front-end/src/lighting/auto_profile.jsx
+++ b/front-end/src/lighting/auto_profile.jsx
@@ -4,6 +4,7 @@ import { ErrorFor, NameFor, ShowError } from 'utils/validation_helper'
 import classNames from 'classnames'
 import { Field } from 'formik'
 import i18next from 'i18next'
+import { IsPercentageInput } from '../utils/percentage_input'
 
 export default class AutoProfile extends React.Component {
   constructor (props) {
@@ -44,8 +45,7 @@ export default class AutoProfile extends React.Component {
 
   curry (i) {
     return (ev) => {
-      // TODO: [ML] Allow decimal in regex
-      if (/^([0-9]{0,2}$)|(100)$|^([0-9]{1,2}.[0-9]+$)/.test(ev.target.value)) {
+      if (IsPercentageInput(ev.target.value)) {
         const val = parseFloat(ev.target.value)
 
         const values = [...this.state.values]

--- a/front-end/src/lighting/fixed_profile.jsx
+++ b/front-end/src/lighting/fixed_profile.jsx
@@ -4,6 +4,7 @@ import { ErrorFor, NameFor, ShowError } from 'utils/validation_helper'
 import classNames from 'classnames'
 import { Field } from 'formik'
 import i18next from 'i18next'
+import { IsPercentageInput } from '../utils/percentage_input'
 
 export default class FixedProfile extends React.Component {
   constructor (props) {
@@ -16,8 +17,7 @@ export default class FixedProfile extends React.Component {
   }
 
   handleChange (e) {
-    // TODO: [ML] Allow decimal in regex
-    if (/^([0-9]{0,2}$)|(100)$|^([0-9]{1,2}.[0-9]+$)/.test(e.target.value)) {
+    if (IsPercentageInput(e.target.value)) {
       let value = parseFloat(e.target.value)
       if (isNaN(value)) {
         value = ''

--- a/front-end/src/lighting/manual_light.jsx
+++ b/front-end/src/lighting/manual_light.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import debounce from 'lodash/debounce'
+import { IsPercentageInput } from '../utils/percentage_input'
 
 export default class ManualLight extends React.Component {
   constructor (props) {
@@ -36,8 +37,7 @@ export default class ManualLight extends React.Component {
   }
 
   handleValueChange (e) {
-    // TODO: [ML] Allow decimal in regex
-    if (/^([0-9]{0,2}$)|(100)$|^([0-9]{1,2}.[0-9]+$)/.test(e.target.value)) {
+    if (IsPercentageInput(e.target.value)) {
       const channels = {
         ...this.state.channels,
         [e.target.name]: {

--- a/front-end/src/ui_components/percent.jsx
+++ b/front-end/src/ui_components/percent.jsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { IsPercentageInput } from '../utils/percentage_input'
 
 const Percent = props => {
   const { value, ...other } = props
 
   const handleChange = e => {
-    // TODO: [ML] Allow decimal in regex
-    if (/^([0-9]{0,2}$)|(100)$|^([0-9]{1,2}.[0-9]+$)/.test(e.target.value)) {
+    if (IsPercentageInput(e.target.value)) {
       let val = parseFloat(e.target.value)
       if (isNaN(e.target.value)) { val = '' }
       const event = {

--- a/front-end/src/ui_components/percent.test.js
+++ b/front-end/src/ui_components/percent.test.js
@@ -43,6 +43,14 @@ describe('Percent', () => {
     expect(called).toBe(false)
   })
 
+  it('does not treat non-dot separators as decimals', () => {
+    let called = false
+    const onChange = () => { called = true }
+    const input = renderInput({ value: 0, onChange, name: 'pct' })
+    input.props.onChange({ target: { name: 'pct', value: '99x5' } })
+    expect(called).toBe(false)
+  })
+
   it('calls onChange with NaN for empty input', () => {
     let received
     const onChange = e => { received = e.target.value }

--- a/front-end/src/utils/percentage_input.js
+++ b/front-end/src/utils/percentage_input.js
@@ -1,0 +1,1 @@
+export const IsPercentageInput = value => /^([0-9]{0,2}|100|[0-9]{1,2}\.[0-9]+)$/.test(value)

--- a/front-end/src/utils/percentage_input.test.js
+++ b/front-end/src/utils/percentage_input.test.js
@@ -1,0 +1,25 @@
+import { IsPercentageInput } from './percentage_input'
+
+describe('IsPercentageInput', () => {
+  it('accepts empty input while editing', () => {
+    expect(IsPercentageInput('')).toBe(true)
+  })
+
+  it('accepts whole percentage values', () => {
+    expect(IsPercentageInput('0')).toBe(true)
+    expect(IsPercentageInput('99')).toBe(true)
+    expect(IsPercentageInput('100')).toBe(true)
+  })
+
+  it('accepts decimal percentage values under 100', () => {
+    expect(IsPercentageInput('0.5')).toBe(true)
+    expect(IsPercentageInput('99.5')).toBe(true)
+  })
+
+  it('rejects non-numeric separators and out-of-range values', () => {
+    expect(IsPercentageInput('99x5')).toBe(false)
+    expect(IsPercentageInput('100.5')).toBe(false)
+    expect(IsPercentageInput('101')).toBe(false)
+    expect(IsPercentageInput('abc')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add a shared percentage input validator for UI percentage fields
- replace duplicated lighting/percent regex checks with the shared helper
- cover valid decimal input and reject non-dot separators such as 99x5

## Tests
- rtk yarn jest front-end/src/utils/percentage_input.test.js front-end/src/ui_components/percent.test.js front-end/src/lighting/manual_light.test.js front-end/src/lighting/auto_profile.test.js --runInBand
- rtk yarn jest front-end/src/lighting/profile.test.js --runInBand
- rtk yarn standard
- rtk git diff --check