### PR TITLE
Use spread props for confirm modal

### DIFF
--- a/front-end/src/utils/confirm.js
+++ b/front-end/src/utils/confirm.js
@@ -4,7 +4,7 @@ import { flushSync } from 'react-dom'
 import { createRoot } from 'react-dom/client'
 
 export function confirm (message, options = {}) {
-  const props = Object.assign({ message }, options)
+  const props = { message, ...options }
   return showModal(<Confirm {...props} />)
 }
 

--- a/front-end/src/utils/confirm.test.js
+++ b/front-end/src/utils/confirm.test.js
@@ -47,6 +47,19 @@ describe('confirm utils', () => {
     expect(typeof showModal).toBe('function')
   })
 
+  it('confirm merges message and options for the modal props', () => {
+    confirm('Delete item?', { confirmLabel: 'Delete', message: 'Override message' })
+
+    expect(mockRender).toHaveBeenCalledWith(
+      expect.objectContaining({
+        props: expect.objectContaining({
+          confirmLabel: 'Delete',
+          message: 'Override message'
+        })
+      })
+    )
+  })
+
   it('showModal appends a div and renders into it', () => {
     const React = require('react')
     return showModal(React.createElement(require('confirm')))


### PR DESCRIPTION
## Summary
- replace confirm modal Object.assign props merge with object spread
- add focused coverage for message/options merge behavior

## Tests
- rtk yarn jest front-end/src/utils/confirm.test.js --runInBand
- rtk yarn standard
- rtk git diff --check