### PR TITLE
Pass mapped camera images to gallery

### DIFF
--- a/front-end/src/camera/camera.test.js
+++ b/front-end/src/camera/camera.test.js
@@ -23,6 +23,21 @@ const countByType = (node, predicate) => {
   return count
 }
 
+const findByType = (node, type) => {
+  if (!node || typeof node !== 'object') {
+    return undefined
+  }
+  if (node.type === type) {
+    return node
+  }
+  for (const child of React.Children.toArray(node.props?.children)) {
+    const found = findByType(child, type)
+    if (found) {
+      return found
+    }
+  }
+}
+
 describe('Camera module', () => {
   afterEach(() => {
     fetchMock.reset()
@@ -49,6 +64,10 @@ describe('Camera module', () => {
 
     const rendered = camera.render()
     expect(rendered.type).toBe('div')
+    expect(findByType(rendered, Gallery).props.images).toEqual([
+      { src: '/images/foo.jpg', thumbnail: '/images/thumbnail-foo.jpg' },
+      { src: '/images/bar.jpg', thumbnail: '/images/thumbnail-bar.jpg' }
+    ])
   })
 
   it('<Main /> mounts with empty state', () => {

--- a/front-end/src/camera/main.jsx
+++ b/front-end/src/camera/main.jsx
@@ -68,7 +68,7 @@ export class RawCamera extends React.Component {
           {config}
         </div>
         <div className='row'>
-          <Gallery images={this.state.images} />
+          <Gallery images={images} />
         </div>
         <div className='row'>
           <Capture />


### PR DESCRIPTION
## Summary
- pass the mapped camera image URLs into Gallery instead of the empty local state list
- add focused coverage for generated gallery image and thumbnail paths

## Tests
- rtk yarn jest front-end/src/camera/camera.test.js --runInBand
- rtk yarn standard
- rtk git diff --check