### PR TITLE
Use immutable auto profile point removal

### DIFF
--- a/front-end/src/lighting/auto_profile.jsx
+++ b/front-end/src/lighting/auto_profile.jsx
@@ -33,8 +33,7 @@ export default class AutoProfile extends React.Component {
   }
 
   handleRemovePoint (x) {
-    const values = [...this.state.values]
-    values.splice(x, 1)
+    const values = this.state.values.filter((_, i) => i !== x)
     this.props.onChangeHandler({
       start: this.props.config.start,
       end: this.props.config.end,

--- a/front-end/src/lighting/auto_profile.test.js
+++ b/front-end/src/lighting/auto_profile.test.js
@@ -129,6 +129,26 @@ describe('Lighting ui - Auto Profile', () => {
     expect(textContent(labels[1])).toBe('15:00')
   })
 
+  it('<AutoProfile /> removes a point without mutating the original values', () => {
+    const onChangeHandler = jest.fn()
+    const config = {
+      start: '14:00:00',
+      end: '15:00:00',
+      values: [10, 20, 30]
+    }
+
+    const m = renderProfile(config, { onChangeHandler })
+    m.handleRemovePoint(1)
+
+    expect(onChangeHandler).toHaveBeenCalledWith({
+      start: '14:00:00',
+      end: '15:00:00',
+      values: [10, 30]
+    })
+    expect(m.state.values).toEqual([10, 30])
+    expect(config.values).toEqual([10, 20, 30])
+  })
+
   it('<AutoProfile /> Should allow end time before start time to represent overnight', () => {
     const config = {
       start: '23:00:00',


### PR DESCRIPTION
## Summary
- Replace AutoProfile point removal copy/splice with an immutable filter expression
- Add regression coverage for removing a point without mutating the original values array

## Validation
- rtk yarn jest front-end/src/lighting/auto_profile.test.js
- rtk yarn standard
- rtk git diff --check