### PR TITLE
Avoid mutating display derived state

### DIFF
--- a/front-end/src/configuration/configuration.test.js
+++ b/front-end/src/configuration/configuration.test.js
@@ -130,6 +130,17 @@ describe('Configuration ui', () => {
     expect(RawDisplay.getDerivedStateFromProps({ config: undefined }, {})).toBeNull()
   })
 
+  it('<Display /> derives config state without mutating previous state', () => {
+    const previousState = { brightness: 25, on: false, local: true }
+    const derived = RawDisplay.getDerivedStateFromProps({
+      config: { brightness: 80, on: true }
+    }, previousState)
+
+    expect(previousState).toEqual({ brightness: 25, on: false, local: true })
+    expect(derived).toEqual({ brightness: 80, on: true, local: true })
+    expect(derived).not.toBe(previousState)
+  })
+
   it('<Capabilities />', () => {
     const update = jest.fn()
     const m = new Capabilities({

--- a/front-end/src/configuration/display.jsx
+++ b/front-end/src/configuration/display.jsx
@@ -22,9 +22,11 @@ export class RawDisplay extends React.Component {
     if (Object.keys(props.config).length === 0) {
       return null
     }
-    state.on = props.config.on
-    state.brightness = props.config.brightness
-    return state
+    return {
+      ...state,
+      on: props.config.on,
+      brightness: props.config.brightness
+    }
   }
 
   componentDidMount () {


### PR DESCRIPTION
## Summary
- return a fresh state object from RawDisplay.getDerivedStateFromProps
- add regression coverage that previous display state is not mutated

## Tests
- rtk yarn jest front-end/src/configuration/configuration.test.js --runInBand
- rtk yarn standard
- rtk git diff --check