### PR TITLE
Avoid mutating collapsible list derived state

### DIFF
--- a/front-end/src/ui_components/collapsible_list.jsx
+++ b/front-end/src/ui_components/collapsible_list.jsx
@@ -62,9 +62,11 @@ export default class CollapsibleList extends React.Component {
         readOnly[child.props.name] = true
       }
     })
-    state.expanded = expanded
-    state.readOnly = readOnly
-    return state
+    return {
+      ...state,
+      expanded,
+      readOnly
+    }
   }
 
   render () {

--- a/front-end/src/ui_components/collapsible_list.test.js
+++ b/front-end/src/ui_components/collapsible_list.test.js
@@ -79,6 +79,33 @@ describe('CollapsibleList', () => {
     expect(derived.readOnly.new).toBe(true)
   })
 
+  it('getDerivedStateFromProps does not mutate previous state', () => {
+    const state = {
+      expanded: { first: true },
+      readOnly: { first: false },
+      other: 'value'
+    }
+
+    const derived = CollapsibleList.getDerivedStateFromProps(
+      { children: [<Item key='new' name='new' />] },
+      state
+    )
+
+    expect(derived).not.toBe(state)
+    expect(derived.expanded).not.toBe(state.expanded)
+    expect(derived.readOnly).not.toBe(state.readOnly)
+    expect(state).toEqual({
+      expanded: { first: true },
+      readOnly: { first: false },
+      other: 'value'
+    })
+    expect(derived).toEqual({
+      expanded: { first: true, new: false },
+      readOnly: { first: false, new: true },
+      other: 'value'
+    })
+  })
+
   it('passes expanded, readOnly, onToggle, onEdit, onSubmit to children', () => {
     const list = makeList(<Item name='p' />)
     const child = renderedChildren(list)[0]


### PR DESCRIPTION
## Summary
- return a fresh state object from CollapsibleList.getDerivedStateFromProps
- keep expanded and readOnly maps copied before adding new child state
- add regression coverage proving the previous state and maps are not mutated

## Validation
- rtk yarn jest front-end/src/ui_components/collapsible_list.test.js front-end/src/ui_components/collapsible.test.js
- rtk yarn standard
- rtk git diff --check