### PR TITLE
Avoid mutating inlet selector state

### DIFF
--- a/front-end/src/connectors/connectors.test.js
+++ b/front-end/src/connectors/connectors.test.js
@@ -68,6 +68,20 @@ describe('Connectors', () => {
     expect(renderToStaticMarkup(component.inlets())).toContain('foo')
   })
 
+  it('<InletSelector /> getDerivedStateFromProps does not mutate previous state', () => {
+    const previousInlet = { id: '1', name: 'foo', pin: 1 }
+    const activeInlet = { id: '2', name: 'bar', pin: 2 }
+    const previousState = { inlet: previousInlet }
+    const nextState = RawInletSelector.getDerivedStateFromProps({
+      inlets: [previousInlet, activeInlet],
+      active: '2'
+    }, previousState)
+
+    expect(previousState.inlet).toBe(previousInlet)
+    expect(nextState).not.toBe(previousState)
+    expect(nextState.inlet).toBe(activeInlet)
+  })
+
   it('<Inlets />', () => {
     const create = jest.fn()
     const inlets = [

--- a/front-end/src/connectors/inlet_selector.jsx
+++ b/front-end/src/connectors/inlet_selector.jsx
@@ -30,12 +30,19 @@ class inletSelector extends React.Component {
     if (Object.keys(props.inlets).length === 0) {
       return null
     }
+    let inlet
     props.inlets.forEach((v, k) => {
       if (v.id === props.active) {
-        state.inlet = v
+        inlet = v
       }
     })
-    return state
+    if (inlet === undefined) {
+      return state
+    }
+    return {
+      ...state,
+      inlet
+    }
   }
 
   inlets () {


### PR DESCRIPTION
## Summary
- avoid mutating the previous state object in RawInletSelector.getDerivedStateFromProps
- add regression coverage for preserving previous inlet state while returning a new active inlet state

## Validation
- rtk yarn jest front-end/src/connectors/connectors.test.js
- rtk yarn standard
- rtk git diff --check