### PR TITLE
Avoid mutating error boundary derived state

### DIFF
--- a/front-end/src/ui_components/error_boundary.jsx
+++ b/front-end/src/ui_components/error_boundary.jsx
@@ -10,10 +10,12 @@ class ErrorBoundary extends React.Component {
     if (props.tab === state.currentTab) {
       return null
     }
-    state.error = null
-    state.errorInfo = null
-    state.currentTab = props.tab
-    return state
+    return {
+      ...state,
+      error: null,
+      errorInfo: null,
+      currentTab: props.tab
+    }
   }
 
   componentDidCatch (error, errorInfo) {

--- a/front-end/src/ui_components/error_boundary.test.js
+++ b/front-end/src/ui_components/error_boundary.test.js
@@ -19,10 +19,14 @@ describe('ErrorBoundary', () => {
   it('resets state when the tab prop changes', () => {
     const instance = mountClassComponent(ErrorBoundary, { tab: 'tab1', children: 'Child' })
     instance.componentDidCatch(new Error('error'), { componentStack: 'stackTrace' })
+    const previousState = instance.state
 
     const nextState = ErrorBoundary.getDerivedStateFromProps({ tab: 'tab2' }, instance.state)
     instance.state = nextState
 
+    expect(previousState.error).toEqual(new Error('error'))
+    expect(previousState.errorInfo).toEqual({ componentStack: 'stackTrace' })
+    expect(nextState).not.toBe(previousState)
     expect(instance.state.error).toBeNull()
     expect(instance.state.errorInfo).toBeNull()
     expect(instance.render()).toBe('Child')


### PR DESCRIPTION
## Summary
- return a fresh reset state from ErrorBoundary.getDerivedStateFromProps when tabs change
- add regression coverage that the previous error state is not mutated

## Tests
- rtk yarn jest front-end/src/ui_components/error_boundary.test.js --runInBand
- rtk yarn standard
- rtk git diff --check