### PR TITLE
Name default light channel color

### DIFF
--- a/front-end/src/lighting/lighting.test.js
+++ b/front-end/src/lighting/lighting.test.js
@@ -16,6 +16,7 @@ import LunarProfile from './lunar_profile'
 import CircadianProfile from './circadian_profile'
 import CyclicProfile from './cyclic_profile'
 import Profile from './profile'
+import { DEFAULT_CHANNEL_COLOR } from './main'
 import Percent from '../ui_components/percent'
 import * as Alert from 'utils/alert'
 import 'isomorphic-fetch'
@@ -373,6 +374,10 @@ describe('Lighting ui', () => {
         expect(setTouched).toHaveBeenCalledWith(touched)
       }
     })
+  })
+
+  it('<Main /> defines a default color for new light channels', () => {
+    expect(DEFAULT_CHANNEL_COLOR).toBe('#000000')
   })
 
   it('<Profile /> fixed', () => {

--- a/front-end/src/lighting/main.jsx
+++ b/front-end/src/lighting/main.jsx
@@ -13,6 +13,8 @@ import ManualLight from './manual_light'
 import { SortByName } from 'utils/sort_by_name'
 import i18n from 'utils/i18n'
 
+export const DEFAULT_CHANNEL_COLOR = '#000000'
+
 class main extends React.Component {
   constructor (props) {
     super(props)
@@ -106,7 +108,7 @@ class main extends React.Component {
     const channels = {}
     jack.pins.map((pin, idx) => (
       channels[pin] = {
-        color: '#000000', // FIXME this avoids undefined color
+        color: DEFAULT_CHANNEL_COLOR,
         manual: false,
         min: 0,
         max: 100,


### PR DESCRIPTION
## Summary
- replace the inline default light channel color with a named constant
- add focused coverage for the fallback color value used for new light channels

## Tests
- rtk yarn jest front-end/src/lighting/lighting.test.js --runInBand
- rtk yarn standard
- rtk git diff --check