### PR TITLE
Avoid direct gallery state mutation in camera test

### DIFF
--- a/front-end/src/camera/camera.test.js
+++ b/front-end/src/camera/camera.test.js
@@ -124,8 +124,9 @@ describe('Camera module', () => {
     gallery.handleGotoNext()
     gallery.handleGotoImage(0)
     gallery.handleOnClick()
-    gallery.state.current = -1
+    gallery.setState({ current: -1 })
     gallery.handleOnClick()
+    expect(gallery.state.current).toBe(0)
     expect(() => new Gallery({}).render()).not.toThrow()
   })
 


### PR DESCRIPTION
## Summary
- replace direct Gallery test state assignment with the test's patched setState
- assert the click handler advances the artificial pre-first state back to the first image

## Validation
- rtk yarn jest front-end/src/camera/camera.test.js
- rtk yarn standard
- rtk git diff --check