### PR TITLE
Avoid mutating camera config state

### DIFF
--- a/front-end/src/camera/camera.test.js
+++ b/front-end/src/camera/camera.test.js
@@ -109,6 +109,34 @@ describe('Camera module', () => {
     expect(Alert.showError).toHaveBeenCalled()
   })
 
+  it('<Config /> updates local config without mutating previous state', () => {
+    const config = new Config({ config: { tick_interval: 1, enable: false }, update: jest.fn() })
+    config.setState = jest.fn(next => {
+      config.state = { ...config.state, ...next }
+    })
+    const previousConfig = config.state.config
+
+    config.updateBool('enable')({ target: { checked: true } })
+
+    expect(previousConfig).toEqual({ tick_interval: 1, enable: false })
+    expect(config.state.config).toEqual({ tick_interval: 1, enable: true })
+    expect(config.state.config).not.toBe(previousConfig)
+  })
+
+  it('<Config /> saves parsed config without mutating state config', () => {
+    const update = jest.fn()
+    const config = new Config({ config: { tick_interval: '5', enable: true }, update })
+    config.setState = jest.fn(next => {
+      config.state = { ...config.state, ...next }
+    })
+    const previousConfig = config.state.config
+
+    config.handleSave()
+
+    expect(previousConfig).toEqual({ tick_interval: '5', enable: true })
+    expect(update).toHaveBeenCalledWith({ tick_interval: 5, enable: true })
+  })
+
   it('<Gallery />', () => {
     const images = [{ thumbnail: '', src: '' }]
     const gallery = new Gallery({ images })

--- a/front-end/src/camera/config.jsx
+++ b/front-end/src/camera/config.jsx
@@ -16,7 +16,7 @@ export default class Config extends React.Component {
   }
 
   handleSave (ev) {
-    const config = this.state.config
+    const config = { ...this.state.config }
     config.tick_interval = parseInt(config.tick_interval)
     if (isNaN(config.tick_interval)) {
       showError(i18next.t('camera:tick_must_be_positive'))
@@ -28,8 +28,10 @@ export default class Config extends React.Component {
 
   updateBool (k) {
     return (function (ev) {
-      const config = this.state.config
-      config[k] = ev.target.checked
+      const config = {
+        ...this.state.config,
+        [k]: ev.target.checked
+      }
       this.setState({
         config,
         updated: true
@@ -39,8 +41,10 @@ export default class Config extends React.Component {
 
   updateText (k) {
     return (function (ev) {
-      const config = this.state.config
-      config[k] = ev.target.value
+      const config = {
+        ...this.state.config,
+        [k]: ev.target.value
+      }
       this.setState({
         config,
         updated: true


### PR DESCRIPTION
## Summary
- clone camera config state before text/checkbox updates
- clone before parsing tick_interval during save so local state remains unchanged
- add regression coverage for both paths

## Tests
- rtk yarn jest front-end/src/camera/camera.test.js --runInBand
- rtk yarn standard
- rtk git diff --check