### PR TITLE
Make journal unit requirement explicit

### DIFF
--- a/front-end/src/journal/schema.js
+++ b/front-end/src/journal/schema.js
@@ -1,13 +1,16 @@
 import * as Yup from 'yup'
 import i18n from 'utils/i18n'
 
+const entryRequiredMessage = i18n.t('validation:entry_required')
+const unitRequiredMessage = entryRequiredMessage
+
 const JournalSchema = Yup.object().shape({
   name: Yup.string()
     .required(i18n.t('validation:name_required')),
   description: Yup.string()
-    .required(i18n.t('validation:entry_required')),
+    .required(entryRequiredMessage),
   unit: Yup.string()
-    .required(i18n.t('validation:entry_required')) // TODO: really required?
+    .required(unitRequiredMessage)
 })
 
 export default JournalSchema

--- a/front-end/src/journal/schema.test.js
+++ b/front-end/src/journal/schema.test.js
@@ -1,4 +1,5 @@
 import JournalSchema from './schema'
+import i18n from 'utils/i18n'
 
 describe('JournalSchema', () => {
   it('accepts a valid journal', () => {
@@ -25,11 +26,11 @@ describe('JournalSchema', () => {
       })
   })
 
-  it('rejects when unit is missing', () => {
+  it('requires unit with the entry required validation message', () => {
     expect.assertions(1)
     return JournalSchema.validate({ name: 'pH Log', description: 'Daily readings' })
       .catch(err => {
-        expect(err.message).toBeTruthy()
+        expect(err.message).toBe(i18n.t('validation:entry_required'))
       })
   })
 


### PR DESCRIPTION
## Summary
- replace the journal unit TODO with named required-message constants
- assert the unit-required validation message in the journal schema test

## Validation
- rtk yarn jest front-end/src/journal/schema.test.js
- rtk yarn standard
- rtk git diff --check