### PR TITLE
Avoid mutating telemetry config state

### DIFF
--- a/front-end/src/telemetry/main.jsx
+++ b/front-end/src/telemetry/main.jsx
@@ -7,6 +7,18 @@ import { updateTelemetry, fetchTelemetry, sendTestMessage } from 'redux/actions/
 import { connect } from 'react-redux'
 import i18n from '../utils/i18n'
 
+const cloneTelemetryConfig = config => ({
+  ...config,
+  adafruitio: config.adafruitio ? { ...config.adafruitio } : config.adafruitio,
+  mailer: config.mailer
+    ? {
+        ...config.mailer,
+        to: Array.isArray(config.mailer.to) ? [...config.mailer.to] : config.mailer.to
+      }
+    : config.mailer,
+  mqtt: config.mqtt ? { ...config.mqtt } : config.mqtt
+})
+
 class telemetry extends React.Component {
   constructor (props) {
     super(props)
@@ -35,8 +47,10 @@ class telemetry extends React.Component {
 
   updateLimit (k) {
     return (e) => {
-      const conf = this.state.config
-      conf[k] = e.target.value
+      const conf = {
+        ...this.state.config,
+        [k]: e.target.value
+      }
       this.setState({ config: conf })
     }
   }
@@ -57,8 +71,10 @@ class telemetry extends React.Component {
   }
 
   handleEnableMailer (ev) {
-    const c = this.state.config
-    c.notify = ev.target.checked
+    const c = {
+      ...this.state.config,
+      notify: ev.target.checked
+    }
     this.setState({
       config: c,
       updated: true
@@ -66,7 +82,7 @@ class telemetry extends React.Component {
   }
 
   handleSave () {
-    const c = this.state.config
+    const c = cloneTelemetryConfig(this.state.config)
     if (c.adafruitio.enable) {
       if (c.adafruitio.user === '') {
         showError('Please set a valid adafruit.io user')
@@ -105,8 +121,10 @@ class telemetry extends React.Component {
   }
 
   updateMailer (mailer) {
-    const c = this.state.config
-    c.mailer = mailer
+    const c = {
+      ...this.state.config,
+      mailer
+    }
     this.setState({
       config: c,
       updated: true
@@ -118,8 +136,10 @@ class telemetry extends React.Component {
   }
 
   updateAio (adafruitio) {
-    const c = this.state.config
-    c.adafruitio = adafruitio
+    const c = {
+      ...this.state.config,
+      adafruitio
+    }
     this.setState({
       config: c,
       updated: true
@@ -127,8 +147,10 @@ class telemetry extends React.Component {
   }
 
   updateMqtt (m) {
-    const c = this.state.config
-    c.mqtt = m
+    const c = {
+      ...this.state.config,
+      mqtt: m
+    }
     this.setState({
       config: c,
       updated: true
@@ -202,8 +224,10 @@ class telemetry extends React.Component {
   }
 
   handleUpdateThrottle (ev) {
-    const c = this.state.config
-    c.throttle = ev.target.value
+    const c = {
+      ...this.state.config,
+      throttle: ev.target.value
+    }
     this.setState({
       config: c,
       updated: true

--- a/front-end/src/telemetry/telmetry.test.js
+++ b/front-end/src/telemetry/telmetry.test.js
@@ -95,6 +95,49 @@ describe('Telemetry UI', () => {
     expect(markup).toContain('updateTelemetry')
   })
 
+  it('<Main /> updates telemetry config without mutating previous state', () => {
+    const m = makeMain()
+    const previousConfig = m.state.config
+
+    m.handleEnableMailer({ target: { checked: false } })
+
+    expect(previousConfig.notify).toBeUndefined()
+    expect(m.state.config.notify).toBe(false)
+    expect(m.state.config).not.toBe(previousConfig)
+  })
+
+  it('<Main /> saves parsed telemetry config without mutating state config', () => {
+    const update = jest.fn()
+    const m = makeMain({ update })
+    const derived = Main.getDerivedStateFromProps({ config: m.props.config }, m.state)
+    m.state = { ...m.state, ...derived }
+    m.state.config = {
+      ...m.state.config,
+      current_limit: '100',
+      historical_limit: '720',
+      throttle: '10',
+      mailer: {
+        ...m.state.config.mailer,
+        port: '546'
+      }
+    }
+    const previousConfig = m.state.config
+    const previousMailer = m.state.config.mailer
+
+    m.handleSave()
+
+    expect(previousConfig.current_limit).toBe('100')
+    expect(previousConfig.mailer.port).toBe('546')
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      current_limit: 100,
+      historical_limit: 720,
+      throttle: 10,
+      mailer: expect.objectContaining({ port: 546 })
+    }))
+    expect(update.mock.calls[0][0]).not.toBe(previousConfig)
+    expect(update.mock.calls[0][0].mailer).not.toBe(previousMailer)
+  })
+
   it('<AdafruitIO />', () => {
     let updated = {}
     const m = new AdafruitIO({


### PR DESCRIPTION
## Summary
- clone telemetry config state for limit, mailer, AIO, MQTT, and notification updates
- clone nested config before save-time parsing so existing state is not rewritten
- add regression coverage for update and save paths

## Tests
- rtk yarn jest front-end/src/telemetry/telmetry.test.js --runInBand
- rtk yarn standard
- rtk git diff --check