### PR TITLE
Name camera image route helper

### DIFF
--- a/front-end/src/camera/camera.test.js
+++ b/front-end/src/camera/camera.test.js
@@ -46,7 +46,7 @@ describe('Camera module', () => {
     jest.clearAllMocks()
   })
 
-  it('<Main /> mounts with images', () => {
+  it('<Main /> passes image route URLs to <Gallery />', () => {
     const fetchConfig = jest.fn()
     const listImages = jest.fn()
     const updateConfig = jest.fn()
@@ -64,7 +64,8 @@ describe('Camera module', () => {
 
     const rendered = camera.render()
     expect(rendered.type).toBe('div')
-    expect(findByType(rendered, Gallery).props.images).toEqual([
+    const galleryImages = findByType(rendered, Gallery).props.images
+    expect(galleryImages).toEqual([
       { src: '/images/foo.jpg', thumbnail: '/images/thumbnail-foo.jpg' },
       { src: '/images/bar.jpg', thumbnail: '/images/thumbnail-bar.jpg' }
     ])
@@ -89,6 +90,18 @@ describe('Camera module', () => {
     capture.componentDidMount()
     expect(getLatestImage).toHaveBeenCalled()
     expect(capture.render().type).toBe('div')
+  })
+
+  it('<Capture /> renders the latest image route URL', () => {
+    const capture = new RawCapture({
+      latest: { image: 'latest.jpg' },
+      getLatestImage: jest.fn(),
+      takeImage: jest.fn()
+    })
+
+    const image = findByType(capture.render(), 'img')
+
+    expect(image.props.src).toBe('/images/latest.jpg')
   })
 
   it('<Config />', () => {

--- a/front-end/src/camera/capture.jsx
+++ b/front-end/src/camera/capture.jsx
@@ -3,6 +3,10 @@ import { takeImage, getLatestImage } from '../redux/actions/camera'
 import { connect } from 'react-redux'
 import i18next from 'i18next'
 
+export const cameraImageRoute = '/images/'
+
+export const cameraImageURL = image => cameraImageRoute + image
+
 export class RawCapture extends React.Component {
   componentDidMount () {
     this.props.getLatestImage()
@@ -20,8 +24,7 @@ export class RawCapture extends React.Component {
     }
     let img = <div className='container' />
     if (this.props.latest !== undefined) {
-      // FIXME: very likely '/images/' should be this.props.config.image_path
-      img = <img src={'/images/' + this.props.latest.image} style={imgStyle} />
+      img = <img src={cameraImageURL(this.props.latest.image)} style={imgStyle} />
     }
     return (
       <div className='container'>

--- a/front-end/src/camera/main.jsx
+++ b/front-end/src/camera/main.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Gallery from './gallery'
 import Config from './config'
-import Capture from './capture'
+import Capture, { cameraImageURL } from './capture'
 import { fetchConfig, updateConfig, listImages } from 'redux/actions/camera'
 import { connect } from 'react-redux'
 import Motion from './motion'
@@ -46,9 +46,8 @@ export class RawCamera extends React.Component {
     const images = []
     this.props.images.forEach((d, i) => {
       images.push({
-        // FIXME: very likely '/images/' should be this.props.config.image_path
-        src: '/images/' + d.name,
-        thumbnail: '/images/thumbnail-' + d.name
+        src: cameraImageURL(d.name),
+        thumbnail: cameraImageURL('thumbnail-' + d.name)
       })
     })
     let config = <div />


### PR DESCRIPTION
## Summary
- name the camera UI image route as a shared exported helper local to the camera module
- use the helper for gallery image/thumbnail URLs and latest capture image URLs
- add focused assertions that URLs remain under /images/

## Validation
- rtk yarn jest front-end/src/camera/camera.test.js
- rtk yarn standard
- rtk git diff --check