### PR TITLE
Use setState in telemetry save test

### DIFF
--- a/front-end/src/telemetry/telmetry.test.js
+++ b/front-end/src/telemetry/telmetry.test.js
@@ -111,7 +111,8 @@ describe('Telemetry UI', () => {
     const m = makeMain({ update })
     const derived = Main.getDerivedStateFromProps({ config: m.props.config }, m.state)
     m.state = { ...m.state, ...derived }
-    m.state.config = {
+    m.setState({
+      config: {
       ...m.state.config,
       current_limit: '100',
       historical_limit: '720',
@@ -120,7 +121,8 @@ describe('Telemetry UI', () => {
         ...m.state.config.mailer,
         port: '546'
       }
-    }
+      }
+    })
     const previousConfig = m.state.config
     const previousMailer = m.state.config.mailer
 


### PR DESCRIPTION
## Summary
- replace direct telemetry test state assignment with the existing patched setState helper
- keep the save-path immutability regression behavior unchanged

## Tests
- rtk yarn jest front-end/src/telemetry/telmetry.test.js --runInBand
- rtk yarn standard
- rtk git diff --check