### PR TITLE
Document journal timestamp schema semantics

### DIFF
--- a/front-end/src/journal/entry_schema.jsx
+++ b/front-end/src/journal/entry_schema.jsx
@@ -6,7 +6,7 @@ const EntrySchema = Yup.object().shape({
     .required(i18next.t('validation:entry_required')),
   comment: Yup.string(),
   timestamp: Yup.string()
-    // TODO: date strings don't sort well, differ by locale, and implicit cast may fail
+    // Journal timestamps are persisted as display strings; parsing and sorting happen outside this schema.
     .required(i18next.t('validation:date_required'))
 })
 

--- a/front-end/src/journal/entry_schema.test.js
+++ b/front-end/src/journal/entry_schema.test.js
@@ -17,6 +17,23 @@ describe('EntrySchema', () => {
       })
   })
 
+  it('accepts timestamp strings without date parsing', () => {
+    expect.assertions(2)
+    return EntrySchema.validate({ value: 8.1, timestamp: 'not a date' })
+      .then(value => {
+        expect(value.value).toBe(8.1)
+        expect(value.timestamp).toBe('not a date')
+      })
+  })
+
+  it('preserves yup string casting for timestamp', () => {
+    expect.assertions(1)
+    return EntrySchema.validate({ value: 8.1, timestamp: 1234 })
+      .then(value => {
+        expect(value.timestamp).toBe('1234')
+      })
+  })
+
   it('rejects when value is missing', () => {
     expect.assertions(1)
     return EntrySchema.validate({ comment: 'test', timestamp: 'Jul-08-23:38, 2022' })
@@ -28,6 +45,14 @@ describe('EntrySchema', () => {
   it('rejects when timestamp is missing', () => {
     expect.assertions(1)
     return EntrySchema.validate({ value: 7.2, comment: 'test' })
+      .catch(err => {
+        expect(err.message).toBeTruthy()
+      })
+  })
+
+  it('rejects when timestamp is empty', () => {
+    expect.assertions(1)
+    return EntrySchema.validate({ value: 7.2, timestamp: '' })
       .catch(err => {
         expect(err.message).toBeTruthy()
       })


### PR DESCRIPTION
## Summary
- remove the journal entry timestamp TODO by documenting current schema behavior
- add tests that make the required display-string semantics explicit
- cover current Yup string casting and empty timestamp rejection

## Validation
- rtk yarn jest front-end/src/journal/entry_schema.test.js
- rtk yarn standard
- rtk git diff --check