### PR TITLE
Avoid mutating dashboard grid cells

### DIFF
--- a/front-end/src/dashboard/dashboard.test.js
+++ b/front-end/src/dashboard/dashboard.test.js
@@ -105,6 +105,68 @@ describe('Dashboard', () => {
     m.render()
   })
 
+  it('<Grid /> setType does not mutate previous cells', () => {
+    const cells = [
+      [{ id: '1', type: 'light' }, { id: '2', type: 'light' }],
+      [{ id: '1', type: 'equipment' }, { id: '2', type: 'ato' }]
+    ]
+    const hook = jest.fn()
+    const m = new Grid({ rows: 2, columns: 2, cells, hook })
+    m.setState = update => { m.state = { ...m.state, ...update } }
+
+    const previousCells = m.state.cells
+    const previousRow = previousCells[0]
+    const previousCell = previousRow[0]
+    Object.freeze(previousCell)
+    Object.freeze(previousRow)
+    Object.freeze(previousCells)
+
+    m.setType(0, 0, 'equipment')()
+
+    expect(previousCells[0]).toBe(previousRow)
+    expect(previousRow[0]).toBe(previousCell)
+    expect(previousCell).toEqual({ id: '1', type: 'light' })
+    expect(m.state.cells).not.toBe(previousCells)
+    expect(m.state.cells[0]).not.toBe(previousRow)
+    expect(m.state.cells[0][0]).not.toBe(previousCell)
+    expect(hook).toHaveBeenCalledWith(m.state.cells)
+    expect(hook).toHaveBeenCalledWith([
+      [{ id: '1', type: 'equipment' }, { id: '2', type: 'light' }],
+      [{ id: '1', type: 'equipment' }, { id: '2', type: 'ato' }]
+    ])
+  })
+
+  it('<Grid /> setID does not mutate previous cells', () => {
+    const cells = [
+      [{ id: '1', type: 'light' }, { id: '2', type: 'light' }],
+      [{ id: '1', type: 'equipment' }, { id: '2', type: 'ato' }]
+    ]
+    const hook = jest.fn()
+    const m = new Grid({ rows: 2, columns: 2, cells, hook })
+    m.setState = update => { m.state = { ...m.state, ...update } }
+
+    const previousCells = m.state.cells
+    const previousRow = previousCells[0]
+    const previousCell = previousRow[0]
+    Object.freeze(previousCell)
+    Object.freeze(previousRow)
+    Object.freeze(previousCells)
+
+    m.setID(0, 0)('3')
+
+    expect(previousCells[0]).toBe(previousRow)
+    expect(previousRow[0]).toBe(previousCell)
+    expect(previousCell).toEqual({ id: '1', type: 'light' })
+    expect(m.state.cells).not.toBe(previousCells)
+    expect(m.state.cells[0]).not.toBe(previousRow)
+    expect(m.state.cells[0][0]).not.toBe(previousCell)
+    expect(hook).toHaveBeenCalledWith(m.state.cells)
+    expect(hook).toHaveBeenCalledWith([
+      [{ id: '3', type: 'light' }, { id: '2', type: 'light' }],
+      [{ id: '1', type: 'equipment' }, { id: '2', type: 'ato' }]
+    ])
+  })
+
   it('<ComponentSelector />', () => {
     const comps = {
       c1: { id: '1', name: 'foo' },

--- a/front-end/src/dashboard/grid.jsx
+++ b/front-end/src/dashboard/grid.jsx
@@ -72,9 +72,9 @@ export default class Grid extends React.Component {
 
   setID (i, j) {
     return (function (id) {
-      const cells = this.state.cells
-      const row = cells[i] ? cells[i] : []
-      const cell = row[j] ? row[j] : {}
+      const cells = this.state.cells.slice()
+      const row = cells[i] ? cells[i].slice() : []
+      const cell = row[j] ? { ...row[j] } : {}
       cell.id = id
       row[j] = cell
       cells[i] = row
@@ -85,9 +85,9 @@ export default class Grid extends React.Component {
 
   setType (i, j, type) {
     return (function () {
-      const cells = this.state.cells
-      const row = cells[i] ? cells[i] : []
-      const cell = row[j] ? row[j] : {}
+      const cells = this.state.cells.slice()
+      const row = cells[i] ? cells[i].slice() : []
+      const cell = row[j] ? { ...row[j] } : {}
       cell.type = type
       row[j] = cell
       cells[i] = row


### PR DESCRIPTION
## Summary
- copy the dashboard grid array, target row, and target cell before applying setID/setType updates
- add regression tests proving previous grid state references are not mutated while hook payload shape is preserved

## Validation
- rtk yarn jest front-end/src/dashboard/dashboard.test.js
- rtk yarn standard
- rtk git diff --check