### PR TITLE
Avoid mutating telemetry child config state

### DIFF
--- a/front-end/src/telemetry/adafruit_io.jsx
+++ b/front-end/src/telemetry/adafruit_io.jsx
@@ -13,18 +13,22 @@ export default class AdafruitIO extends React.Component {
 
   onChange (label) {
     return function (ev) {
-      const adafruitio = this.state.adafruitio
-      adafruitio[label] = ev.target.value
+      const adafruitio = {
+        ...this.state.adafruitio,
+        [label]: ev.target.value
+      }
       this.setState({ adafruitio })
-      this.props.update(this.state.adafruitio)
+      this.props.update(adafruitio)
     }.bind(this)
   }
 
   handleUpdateEnable (ev) {
-    const adafruitio = this.state.adafruitio
-    adafruitio.enable = ev.target.checked
+    const adafruitio = {
+      ...this.state.adafruitio,
+      enable: ev.target.checked
+    }
     this.setState({ adafruitio })
-    this.props.update(this.state.adafruitio)
+    this.props.update(adafruitio)
   }
 
   toRow (label, text) {

--- a/front-end/src/telemetry/mqtt.jsx
+++ b/front-end/src/telemetry/mqtt.jsx
@@ -13,19 +13,23 @@ export default class Mqtt extends React.Component {
 
   onChange (label) {
     return function (ev) {
-      const config = this.state.config
-      config[label] = ev.target.type === 'checkbox' ? ev.target.checked : ev.target.value
+      const config = {
+        ...this.state.config,
+        [label]: ev.target.type === 'checkbox' ? ev.target.checked : ev.target.value
+      }
       config.qos = parseInt(config.qos)
       this.setState({ config })
-      this.props.update(this.state.config)
+      this.props.update(config)
     }.bind(this)
   }
 
   handleUpdateEnable (ev) {
-    const config = this.state.config
-    config.enable = ev.target.checked
+    const config = {
+      ...this.state.config,
+      enable: ev.target.checked
+    }
     this.setState({ config })
-    this.props.update(this.state.config)
+    this.props.update(config)
   }
 
   toRow (label, text, iType) {

--- a/front-end/src/telemetry/notification.jsx
+++ b/front-end/src/telemetry/notification.jsx
@@ -16,8 +16,10 @@ export default class NotificationSettings extends React.Component {
 
   update (key) {
     return function (ev) {
-      const config = this.state.config
-      config[key] = ev.target.value
+      const config = {
+        ...this.state.config,
+        [key]: ev.target.value
+      }
       this.setState({
         config
       })
@@ -27,9 +29,11 @@ export default class NotificationSettings extends React.Component {
 
   updateTo () {
     return function (ev) {
-      const config = this.state.config
       const recipients = ev.target.value.split(',')
-      config.to = recipients.map(s => s.trim())
+      const config = {
+        ...this.state.config,
+        to: recipients.map(s => s.trim())
+      }
       this.setState({
         config
       })

--- a/front-end/src/telemetry/telmetry.test.js
+++ b/front-end/src/telemetry/telmetry.test.js
@@ -156,6 +156,26 @@ describe('Telemetry UI', () => {
     expect(updated.foo).toBe(1)
   })
 
+  it('<AdafruitIO /> updates without mutating previous state', () => {
+    const adafruitio = { enable: true, user: 'u', token: 'foo', prefix: 'reef' }
+    let updated = {}
+    const m = new AdafruitIO({
+      adafruitio,
+      update: c => { updated = c }
+    })
+    m.setState = update => {
+      const next = typeof update === 'function' ? update(m.state, m.props) : update
+      m.state = { ...m.state, ...next }
+    }
+    const previous = m.state.adafruitio
+
+    m.onChange('user')({ target: { value: 'u2' } })
+
+    expect(previous.user).toBe('u')
+    expect(m.state.adafruitio).not.toBe(previous)
+    expect(updated.user).toBe('u2')
+  })
+
   it('<Mqtt /> onChange sends boolean for checkbox, string for text', () => {
     const mqttConfig = {
       enable: true,
@@ -185,6 +205,32 @@ describe('Telemetry UI', () => {
     expect(updated.retained).toBe(false)
   })
 
+  it('<Mqtt /> updates without mutating previous state', () => {
+    const mqttConfig = {
+      enable: true,
+      server: 'mqtt.example.com',
+      username: '',
+      client_id: '',
+      password: '',
+      qos: 0,
+      prefix: '',
+      retained: false
+    }
+    let updated = {}
+    const m = new Mqtt({ config: mqttConfig, update: (c) => { updated = c } })
+    m.setState = update => {
+      const next = typeof update === 'function' ? update(m.state, m.props) : update
+      m.state = { ...m.state, ...next }
+    }
+    const previous = m.state.config
+
+    m.onChange('server')({ target: { type: 'text', value: 'broker.local' } })
+
+    expect(previous.server).toBe('mqtt.example.com')
+    expect(m.state.config).not.toBe(previous)
+    expect(updated.server).toBe('broker.local')
+  })
+
   it('<Notification />', () => {
     let updated = {}
     const m = new Notification({
@@ -199,5 +245,22 @@ describe('Telemetry UI', () => {
     expect(updated[1]).toBe('foo')
     m.updateTo()({ target: { value: 'a@example.com, b@example.com' } })
     expect(updated.to).toEqual(['a@example.com', 'b@example.com'])
+  })
+
+  it('<Notification /> updates without mutating previous state', () => {
+    const mailer = { server: 'smtp.example.com', port: 25, from: 'reef@example.com', to: ['old@example.com'] }
+    let updated = {}
+    const m = new Notification({ mailer, update: (c) => { updated = c } })
+    m.setState = update => {
+      const next = typeof update === 'function' ? update(m.state, m.props) : update
+      m.state = { ...m.state, ...next }
+    }
+    const previous = m.state.config
+
+    m.update('server')({ target: { value: 'smtp.local' } })
+
+    expect(previous.server).toBe('smtp.example.com')
+    expect(m.state.config).not.toBe(previous)
+    expect(updated.server).toBe('smtp.local')
   })
 })


### PR DESCRIPTION
## Summary
- clone NotificationSettings mailer config before field and recipient updates
- clone Adafruit.IO and MQTT config before local updates
- add regression coverage for each telemetry child component

## Tests
- rtk yarn jest front-end/src/telemetry/telmetry.test.js --runInBand
- rtk yarn standard
- rtk git diff --check