### PR TITLE
Avoid mutating health notify state

### DIFF
--- a/front-end/src/configuration/configuration.test.js
+++ b/front-end/src/configuration/configuration.test.js
@@ -296,8 +296,39 @@ describe('Configuration ui', () => {
       update
     })
     patchSetState(m)
+    const previousNotify = m.state.notify
     m.handleUpdateEnable({ target: { checked: true } })
+    expect(previousNotify).toEqual({
+      enable: false,
+      max_memory: 10,
+      max_cpu: 20,
+      max_cpu_temp: 30,
+      report_enable: false,
+      report_schedule: ''
+    })
+    expect(m.state.notify).not.toBe(previousNotify)
+    const previousEnableNotify = m.state.notify
     m.update('max_cpu')({ target: { value: '11' } })
+    expect(previousEnableNotify).toEqual({
+      enable: true,
+      max_memory: 10,
+      max_cpu: 20,
+      max_cpu_temp: 30,
+      report_enable: false,
+      report_schedule: ''
+    })
+    expect(m.state.notify).not.toBe(previousEnableNotify)
+    const previousCpuNotify = m.state.notify
+    m.handleUpdateReportEnable({ target: { checked: true } })
+    expect(previousCpuNotify).toEqual({
+      enable: true,
+      max_memory: 10,
+      max_cpu: 11,
+      max_cpu_temp: 30,
+      report_enable: false,
+      report_schedule: ''
+    })
+    expect(m.state.notify).not.toBe(previousCpuNotify)
     m.setState({ notify: { ...m.state.notify, enable: true } })
     expect(update).toHaveBeenCalled()
   })

--- a/front-end/src/configuration/health_notify.jsx
+++ b/front-end/src/configuration/health_notify.jsx
@@ -20,14 +20,14 @@ export default class HealthNotify extends React.Component {
   }
 
   handleUpdateEnable (ev) {
-    const h = this.state.notify
+    const h = { ...this.state.notify }
     h.enable = ev.target.checked
     this.setState({ notify: h })
     this.props.update(h)
   }
 
   handleUpdateReportEnable (ev) {
-    const h = this.state.notify
+    const h = { ...this.state.notify }
     h.report_enable = ev.target.checked
     this.setState({ notify: h })
     this.props.update(h)
@@ -35,7 +35,7 @@ export default class HealthNotify extends React.Component {
 
   update (key) {
     return function (ev) {
-      const h = this.state.notify
+      const h = { ...this.state.notify }
       h[key] = key === 'report_schedule' ? ev.target.value : Number(ev.target.value)
       this.setState({ notify: h })
       this.props.update(h)


### PR DESCRIPTION
## Summary
- clone HealthNotify notify state before applying checkbox and input changes
- add regression coverage that prior notify state objects are not mutated

## Validation
- rtk yarn jest front-end/src/configuration/configuration.test.js
- rtk yarn standard
- rtk git diff --check