### PR TITLE
Avoid mutating capabilities state

### DIFF
--- a/front-end/src/configuration/capabilities.jsx
+++ b/front-end/src/configuration/capabilities.jsx
@@ -13,10 +13,12 @@ export default class Capabilities extends React.Component {
 
   updateCapability (cap) {
     return function (ev) {
-      const capabilities = this.state.capabilities
-      capabilities[cap] = ev.target.checked
+      const capabilities = {
+        ...this.state.capabilities,
+        [cap]: ev.target.checked
+      }
       this.setState({ capabilities })
-      this.props.update(this.state.capabilities)
+      this.props.update(capabilities)
     }.bind(this)
   }
 

--- a/front-end/src/configuration/configuration.test.js
+++ b/front-end/src/configuration/configuration.test.js
@@ -156,6 +156,23 @@ describe('Configuration ui', () => {
     expect(update).toHaveBeenCalledWith(expect.objectContaining({ dashboard: true }))
   })
 
+  it('<Capabilities /> updates without mutating previous state', () => {
+    const update = jest.fn()
+    const capabilities = {
+      equipment: true,
+      dashboard: false
+    }
+    const m = new Capabilities({ capabilities, update })
+    patchSetState(m)
+    const previous = m.state.capabilities
+
+    m.updateCapability('dashboard')({ target: { checked: true } })
+
+    expect(previous.dashboard).toBe(false)
+    expect(m.state.capabilities).not.toBe(previous)
+    expect(update).toHaveBeenCalledWith({ equipment: true, dashboard: true })
+  })
+
   it('<Settings /> renders loading when settings/capabilities missing', () => {
     const component = new RawSettings({
       settings: {},


### PR DESCRIPTION
## Summary
- clone capabilities state before checkbox updates
- pass the cloned capabilities payload to the parent update callback
- add regression coverage for the non-mutating toggle path

## Tests
- rtk yarn jest front-end/src/configuration/configuration.test.js --runInBand
- rtk yarn standard
- rtk git diff --check