### PR TITLE
Avoid mutating dashboard config on save

### DIFF
--- a/front-end/src/dashboard/config.jsx
+++ b/front-end/src/dashboard/config.jsx
@@ -36,7 +36,7 @@ export class RawDashboardConfig extends React.Component {
 
   handleSave () {
     let error = false
-    const payload = this.state.config
+    const payload = { ...this.state.config }
     payload.width = parseInt(payload.width)
     payload.height = parseInt(payload.height)
     payload.column = parseInt(payload.column)

--- a/front-end/src/dashboard/dashboard.test.js
+++ b/front-end/src/dashboard/dashboard.test.js
@@ -281,6 +281,45 @@ describe('Dashboard', () => {
     expect(Alert.showUpdateSuccessful).toHaveBeenCalled()
   })
 
+  it('<Config /> saves parsed payload without mutating state config', () => {
+    const updateDashboard = jest.fn()
+    const m = new RawDashboardConfig({
+      config: {},
+      fetchDashboard: jest.fn(),
+      updateDashboard
+    })
+    m.state = {
+      updated: false,
+      config: {
+        row: '2',
+        column: '3',
+        width: '400',
+        height: '200',
+        grid_details: []
+      }
+    }
+    m.setState = update => { m.state = { ...m.state, ...update } }
+    const previousConfig = m.state.config
+
+    m.handleSave()
+
+    expect(previousConfig).toEqual({
+      row: '2',
+      column: '3',
+      width: '400',
+      height: '200',
+      grid_details: []
+    })
+    expect(updateDashboard).toHaveBeenCalledWith({
+      row: 2,
+      column: 3,
+      width: 400,
+      height: 200,
+      grid_details: []
+    })
+    expect(updateDashboard.mock.calls[0][0]).not.toBe(previousConfig)
+  })
+
   it('<Config /> rejects invalid save values and rebuilds grid details', () => {
     const cells = [[{ type: 'ato', id: '1' }]]
     const updateDashboard = jest.fn()


### PR DESCRIPTION
## Summary
- clone dashboard config before parsing numeric save fields
- add regression coverage that handleSave does not rewrite state config while sending a parsed payload

## Tests
- rtk yarn jest front-end/src/dashboard/dashboard.test.js --runInBand
- rtk yarn standard
- rtk git diff --check