### PR TITLE
Avoid mutating settings state

### DIFF
--- a/front-end/src/configuration/configuration.test.js
+++ b/front-end/src/configuration/configuration.test.js
@@ -231,6 +231,23 @@ describe('Configuration ui', () => {
     expect(component.state.settings.address).toBe('localhost:9090')
   })
 
+  it('<Settings /> handleSetAddress updates without mutating previous settings', () => {
+    const component = new RawSettings({
+      settings: { ...fullSettings },
+      capabilities: fullCapabilities,
+      fetchSettings: jest.fn(),
+      updateSettings: jest.fn()
+    })
+    patchSetState(component)
+    const previousSettings = component.state.settings
+
+    component.handleSetAddress({ target: { value: 'localhost:9090' } })
+
+    expect(previousSettings.address).toBe('localhost:8080')
+    expect(component.state.settings).not.toBe(previousSettings)
+    expect(component.state.settings.address).toBe('localhost:9090')
+  })
+
   it('<Settings /> toRow (name) input updates settings', () => {
     const component = new RawSettings({
       settings: { ...fullSettings },
@@ -244,6 +261,24 @@ describe('Configuration ui', () => {
     expect(component.state.settings.name).toBe('new-name')
   })
 
+  it('<Settings /> toRow input updates without mutating previous settings', () => {
+    const component = new RawSettings({
+      settings: { ...fullSettings },
+      capabilities: fullCapabilities,
+      fetchSettings: jest.fn(),
+      updateSettings: jest.fn()
+    })
+    patchSetState(component)
+    const previousSettings = component.state.settings
+    const row = component.toRow('name')
+
+    row.props.children[1].props.onChange({ target: { value: 'new-name' } })
+
+    expect(previousSettings.name).toBe('reef-pi')
+    expect(component.state.settings).not.toBe(previousSettings)
+    expect(component.state.settings.name).toBe('new-name')
+  })
+
   it('<Settings /> handleSetProtocolHttps removes port 80', () => {
     const s = { ...fullSettings, address: 'localhost:80', https: false }
     const component = new RawSettings({
@@ -254,6 +289,26 @@ describe('Configuration ui', () => {
     })
     patchSetState(component)
     component.handleSetProtocolHttps()
+    expect(component.state.settings.address).toBe('localhost')
+    expect(component.state.settings.https).toBe(true)
+  })
+
+  it('<Settings /> handleSetProtocolHttps updates without mutating previous settings', () => {
+    const s = { ...fullSettings, address: 'localhost:80', https: false }
+    const component = new RawSettings({
+      settings: s,
+      capabilities: fullCapabilities,
+      fetchSettings: jest.fn(),
+      updateSettings: jest.fn()
+    })
+    patchSetState(component)
+    const previousSettings = component.state.settings
+
+    component.handleSetProtocolHttps()
+
+    expect(previousSettings.address).toBe('localhost:80')
+    expect(previousSettings.https).toBe(false)
+    expect(component.state.settings).not.toBe(previousSettings)
     expect(component.state.settings.address).toBe('localhost')
     expect(component.state.settings.https).toBe(true)
   })
@@ -297,6 +352,60 @@ describe('Configuration ui', () => {
     const checkbox = component.checkBoxComponent('notification')
     checkbox.props.children.props.children[0].props.onChange({ target: { checked: true } })
     expect(component.state.settings.notification).toBe(true)
+  })
+
+  it('<Settings /> checkbox updates without mutating previous settings', () => {
+    const component = new RawSettings({
+      settings: { ...fullSettings },
+      capabilities: fullCapabilities,
+      fetchSettings: jest.fn(),
+      updateSettings: jest.fn()
+    })
+    patchSetState(component)
+    const previousSettings = component.state.settings
+    const checkbox = component.checkBoxComponent('notification')
+
+    checkbox.props.children.props.children[0].props.onChange({ target: { checked: true } })
+
+    expect(previousSettings.notification).toBe(false)
+    expect(component.state.settings).not.toBe(previousSettings)
+    expect(component.state.settings.notification).toBe(true)
+  })
+
+  it('<Settings /> updateCapabilities updates without mutating previous settings', () => {
+    const component = new RawSettings({
+      settings: { ...fullSettings },
+      capabilities: fullCapabilities,
+      fetchSettings: jest.fn(),
+      updateSettings: jest.fn()
+    })
+    patchSetState(component)
+    const previousSettings = component.state.settings
+    const capabilities = { ...previousSettings.capabilities, dashboard: true }
+
+    component.updateCapabilities(capabilities)
+
+    expect(previousSettings.capabilities).toEqual({ health_check: true })
+    expect(component.state.settings).not.toBe(previousSettings)
+    expect(component.state.settings.capabilities).toEqual({ health_check: true, dashboard: true })
+  })
+
+  it('<Settings /> updateHealthNotify updates without mutating previous settings', () => {
+    const component = new RawSettings({
+      settings: { ...fullSettings },
+      capabilities: fullCapabilities,
+      fetchSettings: jest.fn(),
+      updateSettings: jest.fn()
+    })
+    patchSetState(component)
+    const previousSettings = component.state.settings
+    const healthCheck = { ...previousSettings.health_check, enable: true }
+
+    component.updateHealthNotify(healthCheck)
+
+    expect(previousSettings.health_check.enable).toBe(false)
+    expect(component.state.settings).not.toBe(previousSettings)
+    expect(component.state.settings.health_check.enable).toBe(true)
   })
 
   it('<HealthNotify />', () => {

--- a/front-end/src/configuration/settings.jsx
+++ b/front-end/src/configuration/settings.jsx
@@ -82,8 +82,10 @@ export class RawSettings extends React.Component {
 
   updateHealthNotify (notify) {
     if (notify !== undefined) {
-      const settings = this.state.settings
-      settings.health_check = notify
+      const settings = {
+        ...this.state.settings,
+        health_check: notify
+      }
       this.setState({ settings, updated: true })
     }
     return this.state
@@ -91,8 +93,10 @@ export class RawSettings extends React.Component {
 
   updateCheckbox (key) {
     return function (ev) {
-      const settings = this.state.settings
-      settings[key] = ev.target.checked
+      const settings = {
+        ...this.state.settings,
+        [key]: ev.target.checked
+      }
       this.setState({
         settings,
         updated: true
@@ -101,8 +105,10 @@ export class RawSettings extends React.Component {
   }
 
   handleSetAddress (ev) {
-    const settings = this.state.settings
-    settings.address = ev.target.value
+    const settings = {
+      ...this.state.settings,
+      address: ev.target.value
+    }
     this.setState({
       settings,
       updated: true
@@ -118,21 +124,24 @@ export class RawSettings extends React.Component {
   }
 
   handleSetProtocol (value) {
-    const settings = this.state.settings
-    const port = settings.address.split(':')[1]
+    const current = this.state.settings
+    const port = current.address.split(':')[1]
+    let address = current.address
 
     // Technically redundant, but improves readability
     // Remove the port if https and port 80
     // Also remove the port if http and port 443
     if (port === '80' && value === true) {
-      const address = settings.address.split(':')[0]
-      settings.address = address // Remove port
+      address = current.address.split(':')[0]
     } else if (port === '443' && value === false) {
-      const address = settings.address.split(':')[0]
-      settings.address = address // Remove port
+      address = current.address.split(':')[0]
     }
 
-    settings.https = value
+    const settings = {
+      ...current,
+      address,
+      https: value
+    }
     this.setState({
       settings,
       updated: true
@@ -155,8 +164,10 @@ export class RawSettings extends React.Component {
   }
 
   updateCapabilities (capabilities) {
-    const settings = this.state.settings
-    settings.capabilities = capabilities
+    const settings = {
+      ...this.state.settings,
+      capabilities
+    }
     this.setState({
       settings,
       updated: true
@@ -183,8 +194,10 @@ export class RawSettings extends React.Component {
 
   toRow (label) {
     const fn = function (ev) {
-      const settings = this.state.settings
-      settings[label] = ev.target.value
+      const settings = {
+        ...this.state.settings,
+        [label]: ev.target.value
+      }
       this.setState({
         settings,
         updated: true


### PR DESCRIPTION
## Summary
- clone settings state before updating address, protocol, checkboxes, capabilities, health notifications, and text rows
- add configuration tests that assert previous settings objects are not mutated

## Tests
- rtk yarn jest front-end/src/configuration/configuration.test.js --runInBand
- rtk yarn standard
- rtk git diff --check