### PR TITLE
Avoid mutating driver config values

### DIFF
--- a/front-end/src/drivers/edit_driver.jsx
+++ b/front-end/src/drivers/edit_driver.jsx
@@ -12,6 +12,7 @@ const EditDriver = ({
   touched,
   submitForm,
   handleChange,
+  setValues,
   mode,
   isValid,
   dirty,
@@ -30,10 +31,15 @@ const EditDriver = ({
   }
 
   const driverTypeChangeHandler = (e) => {
-    values.config = {}
-    driverOptions[e.target.value].forEach(item => {
-      values.config[item.name.toLowerCase()] = item.default.toString()
+    const type = e.target.value
+    const config = {}
+    driverOptions[type].forEach(item => {
+      config[item.name.toLowerCase()] = item.default.toString()
     })
+    if (setValues) {
+      setValues({ ...values, type, config })
+      return
+    }
     handleChange(e)
   }
 
@@ -146,6 +152,7 @@ EditDriver.propTypes = {
   submitForm: PropTypes.func.isRequired,
   onDelete: PropTypes.func,
   handleChange: PropTypes.func,
+  setValues: PropTypes.func,
   driverOptions: PropTypes.object
 }
 

--- a/front-end/src/drivers/edit_driver.test.js
+++ b/front-end/src/drivers/edit_driver.test.js
@@ -74,12 +74,35 @@ describe('<EditDriver />', () => {
 
   it('driverTypeChangeHandler sets config defaults and calls handleChange', () => {
     const handleChange = jest.fn()
+    const setValues = jest.fn()
+    const values = { type: '', config: { old: 'value' } }
+    const form = EditDriver(baseProps({ handleChange, setValues, values }))
+    const typeField = findNode(form, n => n.props?.name === 'type' && n.props?.onChange)
+
+    typeField.props.onChange({ target: { value: 'ezo' } })
+
+    expect(values.config).toEqual({ old: 'value' })
+    expect(setValues).toHaveBeenCalledWith({
+      type: 'ezo',
+      config: {
+        address: '99',
+        enabled: 'true'
+      }
+    })
+    expect(handleChange).not.toHaveBeenCalled()
+  })
+
+  it('driverTypeChangeHandler falls back to handleChange when setValues is missing', () => {
+    const handleChange = jest.fn()
     const values = { type: '', config: {} }
+    const event = { target: { value: 'ezo' } }
     const form = EditDriver(baseProps({ handleChange, values }))
     const typeField = findNode(form, n => n.props?.name === 'type' && n.props?.onChange)
-    typeField.props.onChange({ target: { value: 'ezo' } })
-    expect(values.config.address).toBe('99')
-    expect(handleChange).toHaveBeenCalled()
+
+    typeField.props.onChange(event)
+
+    expect(values.config).toEqual({})
+    expect(handleChange).toHaveBeenCalledWith(event)
   })
 
   it('driverConfig renders param fields when type has options', () => {


### PR DESCRIPTION
## Summary
- build driver config defaults as a new object when the driver type changes
- update Formik values through setValues instead of mutating values.config
- add tests for immutable config updates and the legacy handleChange fallback

## Tests
- rtk yarn jest front-end/src/drivers/edit_driver.test.js --runInBand
- rtk yarn standard
- rtk git diff --check