### PR TITLE
Make UI data fetch a thunk

### DIFF
--- a/front-end/src/main_panel.jsx
+++ b/front-end/src/main_panel.jsx
@@ -113,7 +113,7 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
   return {
-    fetchUIData: () => dispatch(fetchUIData(dispatch)),
+    fetchUIData: () => dispatch(fetchUIData()),
     fetchInfo: () => dispatch(fetchInfo(dispatch))
   }
 }

--- a/front-end/src/redux/actions/ui.js
+++ b/front-end/src/redux/actions/ui.js
@@ -67,16 +67,16 @@ export const fetchManagerData = (dispatch) => {
   dispatch(fetchInstances())
 }
 
-export const fetchUIData = (dispatch) => {
-  return getAction(
+export const fetchUIData = () => {
+  return dispatch => dispatch(getAction(
     'capabilities',
     (capabilities) => {
       if (capabilities.manager) {
         fetchManagerData(dispatch)
-        return (capabilitiesLoaded(capabilities))
+        return capabilitiesLoaded(capabilities)
       }
       fetchControllerData(dispatch, capabilities)
-      return (capabilitiesLoaded(capabilities))
+      return capabilitiesLoaded(capabilities)
     }
-  )
+  ))
 }

--- a/front-end/src/redux/actions/ui.test.js
+++ b/front-end/src/redux/actions/ui.test.js
@@ -44,8 +44,24 @@ describe('ui actions', () => {
     fetchMock.getOnce('/api/outlets', [])
     fetchMock.getOnce('/api/errors', [])
     const store = mockStore()
-    return store.dispatch(fetchUIData(store.dispatch)).then(() => {
+    return store.dispatch(fetchUIData()).then(() => {
       expect(store.getActions()).not.toEqual([])
+    })
+  })
+
+  it('fetchUIData fetches manager data when manager capability is enabled', () => {
+    const caps = {
+      manager: true
+    }
+    fetchMock.getOnce('/api/capabilities', caps)
+    fetchMock.getOnce('/api/instances', [])
+    const store = mockStore()
+    return store.dispatch(fetchUIData()).then(() => {
+      expect(fetchMock.called('/api/instances')).toBe(true)
+      expect(store.getActions()).toContainEqual(expect.objectContaining({
+        type: 'CAPABILITIES_LOADED',
+        payload: expect.objectContaining(caps)
+      }))
     })
   })
 })


### PR DESCRIPTION
## Summary
- make fetchUIData a standard thunk that owns dispatch internally
- stop passing dispatch through MainPanel mapDispatchToProps
- add manager-capability coverage for the UI data fetch path

## Tests
- rtk yarn jest front-end/src/redux/actions/ui.test.js front-end/src/main_panel.test.js --runInBand
- rtk yarn standard
- rtk git diff --check