### PR TITLE
Centralize non-Redux request behavior

### DIFF
--- a/front-end/src/drivers/api.js
+++ b/front-end/src/drivers/api.js
@@ -1,7 +1,9 @@
+import { nonReduxRequest } from '../utils/ajax'
+
 export const validateDriver = payload => {
-  return fetch('api/drivers/validate', {
+  return nonReduxRequest({
+    url: 'api/drivers/validate',
     method: 'POST',
-    credentials: 'same-origin',
-    body: JSON.stringify(payload)
+    data: payload
   })
 }

--- a/front-end/src/drivers/main.test.js
+++ b/front-end/src/drivers/main.test.js
@@ -47,6 +47,7 @@ describe('Drivers Main', () => {
     expect(global.fetch).toHaveBeenCalledWith('api/drivers/validate', {
       method: 'POST',
       credentials: 'same-origin',
+      headers: expect.any(Headers),
       body: JSON.stringify(payload)
     })
   })

--- a/front-end/src/fatal_error.test.js
+++ b/front-end/src/fatal_error.test.js
@@ -18,7 +18,8 @@ describe('FatalError', () => {
     await flushPromises()
     expect(global.fetch).toHaveBeenLastCalledWith('/api/me', {
       method: 'GET',
-      credentials: 'same-origin'
+      credentials: 'same-origin',
+      headers: expect.any(Headers)
     })
     expect(instance.state.up).toBe(true)
 

--- a/front-end/src/session_api.js
+++ b/front-end/src/session_api.js
@@ -1,23 +1,25 @@
+import { nonReduxRequest } from './utils/ajax'
+
 export function isSignedIn () {
-  return fetch('/api/me', {
-    method: 'GET',
-    credentials: 'same-origin'
+  return nonReduxRequest({
+    url: '/api/me',
+    method: 'GET'
   }).then(r => {
     return r.ok
   })
 }
 
 export function signOut () {
-  return fetch('/auth/signout', {
-    method: 'GET',
-    credentials: 'same-origin'
+  return nonReduxRequest({
+    url: '/auth/signout',
+    method: 'GET'
   })
 }
 
 export function signIn (creds) {
-  return fetch('/auth/signin', {
+  return nonReduxRequest({
+    url: '/auth/signin',
     method: 'POST',
-    credentials: 'same-origin',
-    body: JSON.stringify(creds)
+    data: creds
   })
 }

--- a/front-end/src/sign_in.test.js
+++ b/front-end/src/sign_in.test.js
@@ -1,5 +1,6 @@
 import SignIn from './sign_in'
 import { mountClassComponent } from '../test/class_component'
+import 'isomorphic-fetch'
 
 describe('SignIn', () => {
   beforeEach(() => {
@@ -26,6 +27,7 @@ describe('SignIn', () => {
     expect(global.fetch).toHaveBeenLastCalledWith('/auth/signin', {
       method: 'POST',
       credentials: 'same-origin',
+      headers: expect.any(Headers),
       body: JSON.stringify({
         user: 'foo',
         password: 'bar'
@@ -58,7 +60,8 @@ describe('SignIn', () => {
     await SignIn.logout()
     expect(global.fetch).toHaveBeenLastCalledWith('/auth/signout', {
       method: 'GET',
-      credentials: 'same-origin'
+      credentials: 'same-origin',
+      headers: expect.any(Headers)
     })
     expect(SignIn.refreshPage).toHaveBeenCalledTimes(1)
 
@@ -66,7 +69,8 @@ describe('SignIn', () => {
     await expect(SignIn.isSignedIn()).resolves.toBe(true)
     expect(global.fetch).toHaveBeenLastCalledWith('/api/me', {
       method: 'GET',
-      credentials: 'same-origin'
+      credentials: 'same-origin',
+      headers: expect.any(Headers)
     })
   })
 })

--- a/front-end/src/utils/ajax.js
+++ b/front-end/src/utils/ajax.js
@@ -62,8 +62,12 @@ function dispatchSuccess (data, params, dispatch) {
   return dispatch(params.success(data))
 }
 
-function request (params, dispatch) {
+export function nonReduxRequest (params) {
   return fetch(params.url, buildRequestOptions(params))
+}
+
+function request (params, dispatch) {
+  return nonReduxRequest(params)
     .then(response => {
       if (!response.ok) {
         return handleErrorResponse(response, params)

--- a/front-end/src/utils/ajax.test.js
+++ b/front-end/src/utils/ajax.test.js
@@ -1,4 +1,4 @@
-import { reduxGet, reduxDelete, reduxPut, reduxPost } from './ajax'
+import { nonReduxRequest, reduxGet, reduxDelete, reduxPut, reduxPost } from './ajax'
 import { showError } from 'utils/alert'
 import 'isomorphic-fetch'
 
@@ -81,6 +81,24 @@ describe('Ajax', () => {
         body: raw
       })
       expect(dispatch).toHaveBeenCalledWith(success(res))
+    })
+  })
+
+  it('nonReduxRequest returns the raw fetch response with shared request options', () => {
+    const res = response()
+    global.fetch.mockResolvedValue(res)
+
+    return expect(nonReduxRequest({
+      url: '/foo',
+      method: 'POST',
+      data: { name: 'reef-pi' }
+    })).resolves.toBe(res).then(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/foo', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: expect.any(Headers),
+        body: JSON.stringify({ name: 'reef-pi' })
+      })
     })
   })
 


### PR DESCRIPTION
## Summary
- add a nonReduxRequest helper backed by shared ajax request option construction
- migrate session and driver validation API helpers to use it
- update focused request option tests for shared headers behavior

## Tests
- rtk yarn jest front-end/src/utils/ajax.test.js --runInBand
- rtk yarn jest front-end/src/sign_in.test.js --runInBand
- rtk yarn jest front-end/src/drivers/main.test.js --runInBand
- rtk yarn standard
- rtk git diff --check