### PR TITLE
Assert ATO usage rollup values

### DIFF
--- a/controller/modules/ato/usage_test.go
+++ b/controller/modules/ato/usage_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestUsage(t *testing.T) {
+	t.Parallel()
 	t1 := time.Now()
 	u1 := Usage{
 		Pump: 2,
@@ -22,11 +23,19 @@ func TestUsage(t *testing.T) {
 	if !u1.Before(u2) {
 		t.Error(u1, "should be before", u2)
 	}
-	if u3, next := u1.Rollup(u2); !next {
-		t.Error("expected to rollup. Metric:", u3)
+	result, next := u1.Rollup(u2)
+	if !next {
+		t.Error("expected next=true for next-hour rollup")
+	}
+	if result.(Usage).Pump != u2.Pump {
+		t.Errorf("expected rolled-up pump=%d, got %d", u2.Pump, result.(Usage).Pump)
 	}
 	u2.Time = u1.Time
-	if u3, next := u1.Rollup(u2); next {
-		t.Error("expected to not rollup. Metric:", u3)
+	result, next = u1.Rollup(u2)
+	if next {
+		t.Error("expected next=false for same-hour rollup")
+	}
+	if result.(Usage).Pump != u1.Pump+u2.Pump {
+		t.Errorf("expected accumulated pump=%d, got %d", u1.Pump+u2.Pump, result.(Usage).Pump)
 	}
 }


### PR DESCRIPTION
## Summary
- assert ATO usage rollover returns the next metric value
- assert same-hour ATO usage accumulates pump counts
- mark the focused usage test parallel

## Tests
- rtk go test ./controller/modules/ato
- rtk git diff --check