### PR TITLE
Split equipment controller API tests

### DIFF
--- a/controller/modules/equipment/controller_test.go
+++ b/controller/modules/equipment/controller_test.go
@@ -12,57 +12,67 @@ import (
 	"github.com/reef-pi/reef-pi/controller/utils"
 )
 
-func TestEquipmentController(t *testing.T) {
-	t.Parallel()
-
+func newTestEquipmentController(t *testing.T) (*Controller, *utils.TestRouter) {
+	t.Helper()
 	con, err := controller.TestController()
-	defer con.Store().Close()
-
 	if err != nil {
 		t.Fatal("Failed to create test controller. Error:", err)
 	}
-	con.DM().Outlets().Setup()
+	t.Cleanup(func() {
+		con.Store().Close()
+	})
+	if err := con.DM().Outlets().Setup(); err != nil {
+		t.Fatal(err)
+	}
 	c := New(con)
-	c.Setup()
-	c.Stop()
-	o := connectors.Outlet{
-		Name:   "bar",
-		Pin:    23,
-		Driver: "rpi",
-	}
-	outlets := con.DM().Outlets()
-	if err := outlets.Create(o); err != nil {
-		t.Fatal(err)
-	}
-	o.Equipment = "1"
-	// Create another outlet thats in use
-	if err := outlets.Create(o); err != nil {
-		t.Fatal(err)
-	}
-
-	tr := utils.NewTestRouter()
-	c.LoadAPI(tr.Router)
-	outlets.LoadAPI(tr.Router)
-	eq := Equipment{
-		Name:   "foo",
-		Outlet: "1",
-	}
 	if err := c.Setup(); err != nil {
 		t.Fatal("Failed to setup equipment subsystem. Error:", err)
 	}
-	body := new(bytes.Buffer)
-	enc := json.NewEncoder(body)
-	enc.Encode(eq)
-	if err := tr.Do("PUT", "/api/equipment", body, nil); err != nil {
-		t.Fatal("Failed to create equipment using api")
-	}
+	tr := utils.NewTestRouter()
+	c.LoadAPI(tr.Router)
+	con.DM().Outlets().LoadAPI(tr.Router)
+	return c, tr
+}
 
-	c.Start()
-	body.Reset()
-	ea := EquipmentAction{true}
-	enc.Encode(ea)
-	if err := tr.Do("POST", "/api/equipment/1/control", body, nil); err != nil {
-		t.Fatal("Failed to control equipment using api")
+func createTestOutlet(t *testing.T, c *Controller, outlet connectors.Outlet) {
+	t.Helper()
+	if err := c.outlets.Create(outlet); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func equipmentBody(t *testing.T, eq Equipment) *bytes.Buffer {
+	t.Helper()
+	body := new(bytes.Buffer)
+	if err := json.NewEncoder(body).Encode(eq); err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func equipmentActionBody(t *testing.T, on bool) *bytes.Buffer {
+	t.Helper()
+	body := new(bytes.Buffer)
+	if err := json.NewEncoder(body).Encode(EquipmentAction{On: on}); err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func TestEquipmentAPICRUD(t *testing.T) {
+	c, tr := newTestEquipmentController(t)
+	createTestOutlet(t, c, connectors.Outlet{
+		Name:   "return",
+		Pin:    23,
+		Driver: "rpi",
+	})
+
+	eq := Equipment{
+		Name:   "Return Pump",
+		Outlet: "1",
+	}
+	if err := tr.Do("PUT", "/api/equipment", equipmentBody(t, eq), nil); err != nil {
+		t.Fatal("Failed to create equipment using api")
 	}
 
 	var resp []Equipment
@@ -77,58 +87,112 @@ func TestEquipmentController(t *testing.T) {
 	if err := tr.Do("GET", "/api/equipment/"+id, strings.NewReader("{}"), &e1); err != nil {
 		t.Fatal("GET '/api/equipment/<id>' API failure. Error:", err)
 	}
+	if e1.Name != "Return Pump" || e1.Outlet != "1" {
+		t.Fatalf("Unexpected equipment response: %#v", e1)
+	}
+	e1.Name = "Skimmer"
+	if err := tr.Do("POST", "/api/equipment/"+e1.ID, equipmentBody(t, e1), nil); err != nil {
+		t.Fatal("Failed to update  equipment using api. Error:", err)
+	}
+
+	var updated Equipment
+	if err := tr.Do("GET", "/api/equipment/"+e1.ID, strings.NewReader("{}"), &updated); err != nil {
+		t.Fatal("GET updated equipment API failure. Error:", err)
+	}
+	if updated.Name != "Skimmer" {
+		t.Fatalf("Expected updated equipment name. Found: %s", updated.Name)
+	}
+
+	if err := tr.Do("DELETE", "/api/equipment/"+e1.ID, new(bytes.Buffer), nil); err != nil {
+		t.Fatal("Failed to delete equipment using api. Error:", err)
+	}
+}
+
+func TestEquipmentAPIControl(t *testing.T) {
+	c, tr := newTestEquipmentController(t)
+	createTestOutlet(t, c, connectors.Outlet{
+		Name:   "heater",
+		Pin:    23,
+		Driver: "rpi",
+	})
+	if err := tr.Do("PUT", "/api/equipment", equipmentBody(t, Equipment{Name: "Heater", Outlet: "1"}), nil); err != nil {
+		t.Fatal("Failed to create equipment using api")
+	}
+
+	c.Start()
+	if err := tr.Do("POST", "/api/equipment/1/control", equipmentActionBody(t, true), nil); err != nil {
+		t.Fatal("Failed to control equipment using api")
+	}
+	eq, err := c.Get("1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !eq.On {
+		t.Fatal("Expected equipment to be on after control API call")
+	}
+
+	if err := c.On("-11", true); err == nil {
+		t.Error("Controlling invalid equipment should fail")
+	}
+}
+
+func TestEquipmentOutletSync(t *testing.T) {
+	c, tr := newTestEquipmentController(t)
+	createTestOutlet(t, c, connectors.Outlet{
+		Name:   "return",
+		Pin:    23,
+		Driver: "rpi",
+	})
+	createTestOutlet(t, c, connectors.Outlet{
+		Name:      "skimmer",
+		Pin:       24,
+		Driver:    "rpi",
+		Equipment: "1",
+	})
+
+	eq := Equipment{Name: "Return Pump", Outlet: "1", On: true}
+	if err := c.Create(eq); err != nil {
+		t.Fatal(err)
+	}
 	if err := c.outlets.Configure(eq.Outlet, true); err != nil {
 		t.Fatal("Failed to configure outlet. Error:", err)
 	}
-	es, err := c.List()
-	if err != nil {
-		t.Fatal("Failed to list equipment. Error:", err)
-	}
 
-	if len(es) != 1 {
-		t.Fatal("Expected only one equipment to be present. Found:", len(es))
-	}
-	eq = es[0]
-	eq.Name = "Baz"
-	body = new(bytes.Buffer)
-	enc = json.NewEncoder(body)
-	enc.Encode(eq)
-	if err := tr.Do("POST", "/api/equipment/"+eq.ID, body, nil); err != nil {
-		t.Fatal("Failed to update  equipment using api. Error:", err)
-	}
 	var outletsList []connectors.Outlet
 	if err := tr.Do("GET", "/api/outlets", strings.NewReader("{}"), &outletsList); err != nil {
-		t.Fatal("Failed to list outlets  using api")
+		t.Fatal("Failed to list outlets using api")
 	}
 	if len(outletsList) != 2 {
 		t.Fatal("Expected 2 outlets, found:", len(outletsList))
 	}
+
 	var outlet connectors.Outlet
 	if err := tr.Do("GET", "/api/outlets/1", strings.NewReader("{}"), &outlet); err != nil {
-		t.Fatal("Failed to get individual outlet  using api. Error:", err)
+		t.Fatal("Failed to get individual outlet using api. Error:", err)
 	}
 
-	o.Name = "updated"
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(&o)
-	if err := tr.Do("POST", "/api/outlets/1", buf, nil); err != nil {
-		t.Fatal("Failed to update individual outlet  using api. Error:", err)
+	outlet.Name = "updated"
+	if err := tr.Do("POST", "/api/outlets/1", outletBody(t, outlet), nil); err != nil {
+		t.Fatal("Failed to update individual outlet using api. Error:", err)
 	}
 	c.synEquipment()
 	if err := c.On("1", true); err != nil {
 		t.Error(err)
 	}
-	if err := tr.Do("DELETE", "/api/equipment/"+eq.ID, buf, nil); err != nil {
-		t.Fatal("Failed to delete equipment using api. Error:", err)
-	}
+
 	eq.Outlet = "123"
 	if err := c.Create(eq); err == nil {
 		t.Error("Equipment creation should fail if outlet is not present")
 	}
-	if err := c.On("-11", true); err == nil {
-		t.Error("Controlling invalid equipment should fail")
-	}
+}
 
+func outletBody(t *testing.T, outlet connectors.Outlet) *bytes.Buffer {
+	t.Helper()
+	body := new(bytes.Buffer)
+	if err := json.NewEncoder(body).Encode(outlet); err != nil {
+		t.Fatal(err)
+	}
+	return body
 }
 
 func TestEquipmentInUseAndGetEntity(t *testing.T) {


### PR DESCRIPTION
## Summary
- split the long mixed equipment controller API test into focused CRUD, control, and outlet sync tests
- add shared test helpers for controller/router setup and JSON request bodies
- preserve existing coverage for outlet list/get/update sync, invalid outlet creation, and invalid control paths

## Tests
- rtk go test ./controller/modules/equipment ./controller/device_manager/connectors
- rtk git diff --check