### PR TITLE
Derive ATO form control value

### DIFF
--- a/front-end/src/ato/ato_form.jsx
+++ b/front-end/src/ato/ato_form.jsx
@@ -2,6 +2,13 @@ import EditAto from './edit_ato'
 import AtoSchema from './ato_schema'
 import { withFormik } from 'formik'
 
+export const atoControlValue = data => {
+  if (data.control !== true) {
+    return ''
+  }
+  return data.is_macro === true ? 'macro' : 'equipment'
+}
+
 export const mapAtoPropsToValues = props => {
   let data = props.data
   if (data === undefined) {
@@ -11,11 +18,11 @@ export const mapAtoPropsToValues = props => {
       notify: {}
     }
   }
-  const values = {
+  return {
     id: data.id || '',
     name: data.name || '',
     enable: (data.enable === undefined ? true : data.enable),
-    control: '',
+    control: atoControlValue(data),
     inlet: data.inlet || '',
     one_shot: data.one_shot || false,
     disable_on_alert: data.disable_on_alert || false,
@@ -25,10 +32,6 @@ export const mapAtoPropsToValues = props => {
     notify: (data.notify && data.notify.enable) || false,
     maxAlert: (data.notify && data.notify.max) || 120
   }
-  if (data.control === true) {
-    if (data.is_macro === true) { values.control = 'macro' } else { values.control = 'equipment' }
-  }
-  return values
 }
 
 export const submitAtoForm = (values, props) => {

--- a/front-end/src/ato/ato_form.test.js
+++ b/front-end/src/ato/ato_form.test.js
@@ -1,4 +1,4 @@
-import AtoForm, { mapAtoPropsToValues, submitAtoForm } from './ato_form'
+import AtoForm, { atoControlValue, mapAtoPropsToValues, submitAtoForm } from './ato_form'
 import 'isomorphic-fetch'
 
 describe('AtoForm', () => {
@@ -65,5 +65,11 @@ describe('AtoForm', () => {
 
     expect(mapAtoPropsToValues({ data: macroData }).control).toBe('macro')
     expect(mapAtoPropsToValues({ data: sensorOnlyData }).control).toBe('')
+  })
+
+  it('derives control value from control flags', () => {
+    expect(atoControlValue({ control: true, is_macro: false })).toBe('equipment')
+    expect(atoControlValue({ control: true, is_macro: true })).toBe('macro')
+    expect(atoControlValue({ control: false, is_macro: true })).toBe('')
   })
 })


### PR DESCRIPTION
## Summary
- derive ATO form control mode with a small pure helper
- return mapped form values directly instead of assigning control after object creation
- add focused tests for equipment, macro, and disabled control values

## Tests
- rtk yarn jest front-end/src/ato/ato_form.test.js --runInBand
- rtk yarn standard
- rtk git diff --check