### PR TITLE
Refactor temperature form value mapping

### DIFF
--- a/front-end/src/temperature/temperature.test.js
+++ b/front-end/src/temperature/temperature.test.js
@@ -4,7 +4,7 @@ import { RawControlChart } from './control_chart'
 import { RawTemperatureMain } from './main'
 import { RawReadingsChart } from './readings_chart'
 import 'isomorphic-fetch'
-import TemperatureForm from './temperature_form'
+import TemperatureForm, { mapTemperaturePropsToValues } from './temperature_form'
 jest.mock('utils/confirm', () => {
   return {
     confirm: jest
@@ -49,6 +49,95 @@ describe('Temperature controller ui', () => {
 
   afterEach(() => {
     jest.clearAllMocks()
+  })
+
+  it('maps <TemperatureForm /> defaults for create', () => {
+    expect(mapTemperaturePropsToValues({})).toEqual({
+      id: '',
+      name: '',
+      sensor: '',
+      analog_input: '',
+      one_shot: false,
+      fahrenheit: true,
+      period: '60',
+      enable: true,
+      alerts: false,
+      minAlert: '77',
+      maxAlert: '81',
+      fail_safe: false,
+      heater: '',
+      min: '',
+      hysteresis: 0,
+      cooler: '',
+      max: '',
+      control: '',
+      chart: { ymax: 86, ymin: 74, color: '#000' }
+    })
+  })
+
+  it('maps <TemperatureForm /> equipment control', () => {
+    const tc = {
+      id: '4',
+      name: 'Water',
+      sensor: 'sensor',
+      analog_input: 'analog-input',
+      one_shot: true,
+      fahrenheit: false,
+      period: '30',
+      enable: false,
+      control: true,
+      is_macro: false,
+      notify: { enable: true, min: 70, max: 90 },
+      fail_safe: true,
+      heater: 'heater',
+      min: 70,
+      hysteresis: 2,
+      cooler: 'cooler',
+      max: 85,
+      chart: { ymax: 90, ymin: 70, color: '#f00' }
+    }
+
+    expect(mapTemperaturePropsToValues({ tc })).toEqual({
+      id: '4',
+      name: 'Water',
+      sensor: 'sensor',
+      analog_input: 'analog-input',
+      one_shot: true,
+      fahrenheit: false,
+      period: '30',
+      enable: false,
+      alerts: true,
+      minAlert: 70,
+      maxAlert: 90,
+      fail_safe: true,
+      heater: 'heater',
+      min: 70,
+      hysteresis: 2,
+      cooler: 'cooler',
+      max: 85,
+      control: 'equipment',
+      chart: { ymax: 90, ymin: 70, color: '#f00' }
+    })
+  })
+
+  it('maps <TemperatureForm /> macro control', () => {
+    const tc = {
+      control: true,
+      is_macro: true,
+      notify: {}
+    }
+
+    expect(mapTemperaturePropsToValues({ tc }).control).toBe('macro')
+  })
+
+  it('maps <TemperatureForm /> no control', () => {
+    const tc = {
+      control: false,
+      is_macro: true,
+      notify: {}
+    }
+
+    expect(mapTemperaturePropsToValues({ tc }).control).toBe('')
   })
 
   it('<Main /> mounts with empty tcs', () => {

--- a/front-end/src/temperature/temperature_form.jsx
+++ b/front-end/src/temperature/temperature_form.jsx
@@ -2,47 +2,47 @@ import EditTemperature from './edit_temperature'
 import TemperatureSchema from './temperature_schema'
 import { withFormik } from 'formik'
 
+export const mapTemperaturePropsToValues = props => {
+  let tc = props.tc
+  if (tc === undefined) {
+    tc = {
+      enable: true,
+      fahrenheit: true,
+      notify: {},
+      chart: { ymax: 86, ymin: 74, color: '#000' }
+    }
+  }
+
+  const control = tc.control === true
+    ? (tc.is_macro === true ? 'macro' : 'equipment')
+    : ''
+
+  return {
+    id: tc.id || '',
+    name: tc.name || '',
+    sensor: tc.sensor || '',
+    analog_input: tc.analog_input || '',
+    one_shot: tc.one_shot || false,
+    fahrenheit: (tc.fahrenheit === undefined ? true : tc.fahrenheit),
+    period: tc.period || '60',
+    enable: (tc.enable === undefined ? true : tc.enable),
+    alerts: (tc.notify && tc.notify.enable) || false,
+    minAlert: (tc.notify && tc.notify.min) || '77',
+    maxAlert: (tc.notify && tc.notify.max) || '81',
+    fail_safe: tc.fail_safe || false,
+    heater: tc.heater || '',
+    min: tc.min || '',
+    hysteresis: tc.hysteresis || 0,
+    cooler: tc.cooler || '',
+    max: tc.max || '',
+    control,
+    chart: tc.chart || { ymax: 86, ymin: 74, color: '#000' }
+  }
+}
+
 const TemperatureForm = withFormik({
   displayName: 'TemperatureForm',
-  mapPropsToValues: props => {
-    let tc = props.tc
-    if (tc === undefined) {
-      tc = {
-        enable: true,
-        fahrenheit: true,
-        notify: {},
-        chart: { ymax: 86, ymin: 74, color: '#000' }
-      }
-    }
-
-    const values = {
-      id: tc.id || '',
-      name: tc.name || '',
-      sensor: tc.sensor || '',
-      analog_input: tc.analog_input || '',
-      one_shot: tc.one_shot || false,
-      fahrenheit: (tc.fahrenheit === undefined ? true : tc.fahrenheit),
-      period: tc.period || '60',
-      enable: (tc.enable === undefined ? true : tc.enable),
-      alerts: (tc.notify && tc.notify.enable) || false,
-      minAlert: (tc.notify && tc.notify.min) || '77',
-      maxAlert: (tc.notify && tc.notify.max) || '81',
-      fail_safe: tc.fail_safe || false,
-      heater: tc.heater || '',
-      min: tc.min || '',
-      hysteresis: tc.hysteresis || 0,
-      cooler: tc.cooler || '',
-      max: tc.max || '',
-      control: '',
-      chart: tc.chart || { ymax: 86, ymin: 74, color: '#000' }
-    }
-
-    if (tc.control === true) {
-      if (tc.is_macro === true) { values.control = 'macro' } else { values.control = 'equipment' }
-    }
-
-    return values
-  },
+  mapPropsToValues: mapTemperaturePropsToValues,
   validationSchema: TemperatureSchema,
   handleSubmit: (values, { props }) => {
     props.onSubmit(values)


### PR DESCRIPTION
## Summary
- export mapTemperaturePropsToValues for focused Formik value mapping coverage
- derive temperature control selection before constructing returned values
- add tests for default, equipment, macro, and no-control mapping cases

## Tests
- rtk yarn jest front-end/src/temperature/temperature.test.js --runInBand
- rtk yarn standard
- rtk git diff --check