### PR TITLE
Derive pH form control value

### DIFF
--- a/front-end/src/ph/ph.test.js
+++ b/front-end/src/ph/ph.test.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { Provider } from 'react-redux'
 import configureMockStore from 'redux-mock-store'
-import PhForm from './ph_form'
+import PhForm, { mapPhPropsToValues, phControlValue } from './ph_form'
 import { RawPhChart } from './chart'
 import { RawPhMain } from './main'
 import 'isomorphic-fetch'
@@ -209,6 +209,19 @@ describe('Ph ui', () => {
       chart_y_max: 14
     }
     expect(renderForm({ probe, onSubmit: jest.fn() })).toContain('option value="" selected=""')
+  })
+
+  it('maps pH form values with derived control modes', () => {
+    expect(mapPhPropsToValues({}).control).toBe('')
+    expect(mapPhPropsToValues({ probe: { notify: {}, control: true, is_macro: false } }).control).toBe('equipment')
+    expect(mapPhPropsToValues({ probe: { notify: {}, control: true, is_macro: true } }).control).toBe('macro')
+    expect(mapPhPropsToValues({ probe: { notify: {}, control: false, is_macro: true } }).control).toBe('')
+  })
+
+  it('derives pH control value from control flags', () => {
+    expect(phControlValue({ control: true, is_macro: false })).toBe('equipment')
+    expect(phControlValue({ control: true, is_macro: true })).toBe('macro')
+    expect(phControlValue({ control: false, is_macro: true })).toBe('')
   })
 
   it('<Chart />', () => {

--- a/front-end/src/ph/ph_form.jsx
+++ b/front-end/src/ph/ph_form.jsx
@@ -2,42 +2,45 @@ import EditPh from './edit_ph'
 import PhSchema from './ph_schema'
 import { withFormik } from 'formik'
 
+export const phControlValue = data => {
+  if (data.control !== true) {
+    return ''
+  }
+  return data.is_macro === true ? 'macro' : 'equipment'
+}
+
+export const mapPhPropsToValues = props => {
+  let data = props.probe
+  if (data === undefined) {
+    data = {
+      notify: {}
+    }
+  }
+
+  return {
+    id: data.id || '',
+    name: data.name || '',
+    analog_input: data.analog_input || '',
+    enable: (data.enable === undefined ? true : data.enable),
+    period: data.period || 60,
+    one_shot: data.one_shot || false,
+    notify: data.notify.enable || false,
+    maxAlert: (data.notify && data.notify.max) || 0,
+    minAlert: (data.notify && data.notify.min) || 0,
+    control: phControlValue(data),
+    lowerThreshold: data.min || 0,
+    lowerFunction: data.downer_eq || '',
+    upperThreshold: data.max || 0,
+    upperFunction: data.upper_eq || '',
+    hysteresis: data.hysteresis || 0,
+    transformer: data.transformer || '',
+    chart: data.chart || { ymin: 0, ymax: 100, color: '#000', unit: '' }
+  }
+}
+
 const PhForm = withFormik({
   displayName: 'PhForm',
-  mapPropsToValues: props => {
-    let data = props.probe
-    if (data === undefined) {
-      data = {
-        notify: {}
-      }
-    }
-
-    const value = {
-      id: data.id || '',
-      name: data.name || '',
-      analog_input: data.analog_input || '',
-      enable: (data.enable === undefined ? true : data.enable),
-      period: data.period || 60,
-      one_shot: data.one_shot || false,
-      notify: data.notify.enable || false,
-      maxAlert: (data.notify && data.notify.max) || 0,
-      minAlert: (data.notify && data.notify.min) || 0,
-      control: '',
-      lowerThreshold: data.min || 0,
-      lowerFunction: data.downer_eq || '',
-      upperThreshold: data.max || 0,
-      upperFunction: data.upper_eq || '',
-      hysteresis: data.hysteresis || 0,
-      transformer: data.transformer || '',
-      chart: data.chart || { ymin: 0, ymax: 100, color: '#000', unit: '' }
-    }
-
-    if (data.control === true) {
-      if (data.is_macro === true) { value.control = 'macro' } else { value.control = 'equipment' }
-    }
-
-    return value
-  },
+  mapPropsToValues: mapPhPropsToValues,
   validationSchema: PhSchema,
   handleSubmit: (values, { props }) => {
     props.onSubmit(values)


### PR DESCRIPTION
## Summary
- extract pH form value mapping into a named helper
- derive pH control mode with a pure helper instead of mutating mapped values
- add focused tests for equipment, macro, and disabled control modes

## Tests
- rtk yarn jest front-end/src/ph/ph.test.js --runInBand
- rtk yarn standard
- rtk git diff --check