### PR TITLE
Group connectors by driver with shared helper

### DIFF
--- a/front-end/src/connectors/analog_inputs.jsx
+++ b/front-end/src/connectors/analog_inputs.jsx
@@ -3,8 +3,8 @@ import { confirm } from 'utils/confirm'
 import { connect } from 'react-redux'
 import Pin from './pin'
 import i18n from 'utils/i18n'
-import { SortByName } from 'utils/sort_by_name'
 import { byCapability } from './driver_filter'
+import { groupByDriverName } from './driver_groups'
 
 import {
   fetchAnalogInputs,
@@ -88,31 +88,22 @@ class analogInputs extends React.Component {
   }
 
   list () {
-    const driverMap = {}
-    this.props.drivers.forEach(d => { driverMap[d.id] = d })
-
-    const groups = {}
-    this.props.analog_inputs.slice().sort((a, b) => SortByName(a, b))
-      .forEach(j => {
-        const driverName = (driverMap[j.driver] || {}).name || j.driver
-        if (!groups[driverName]) groups[driverName] = []
-        groups[driverName].push(j)
-      })
+    const driverGroups = groupByDriverName(this.props.analog_inputs, this.props.drivers)
 
     const list = []
-    Object.keys(groups).sort().forEach(driverName => {
+    driverGroups.groups.forEach(group => {
       list.push(
-        <div key={'driver-' + driverName} className='mt-2'>
-          <small className='text-muted font-weight-bold'>{driverName}</small>
+        <div key={'driver-' + group.driverName} className='mt-2'>
+          <small className='text-muted font-weight-bold'>{group.driverName}</small>
         </div>
       )
-      groups[driverName].forEach(j => {
+      group.connectors.forEach(j => {
         list.push(
           <AnalogInput
             name={j.name}
             key={j.id}
             pin={j.pin}
-            driver={driverMap[j.driver] || {}}
+            driver={driverGroups.driverMap[j.driver] || {}}
             drivers={this.props.drivers}
             analog_input_id={j.id}
             remove={this.remove(j)}

--- a/front-end/src/connectors/connectors.test.js
+++ b/front-end/src/connectors/connectors.test.js
@@ -12,6 +12,7 @@ import Pin from './pin'
 import AnalogInput from './analog_input'
 import { RawAnalogInputs } from './analog_inputs'
 import { byCapability } from './driver_filter'
+import { groupByDriverName } from './driver_groups'
 import 'isomorphic-fetch'
 
 const stockDrivers = [
@@ -305,6 +306,21 @@ describe('Connectors', () => {
   it('byCapability returns false for driver without pinmap', () => {
     const driver = { id: '1' }
     expect(byCapability('analog-input')(driver)).toBe(false)
+  })
+
+  it('groups connectors by display driver name without mutating input', () => {
+    const connectors = [
+      { id: '2', name: 'Outlet B', driver: 'missing' },
+      { id: '1', name: 'Outlet A', driver: 'rpi' },
+      { id: '3', name: 'Outlet C', driver: 'rpi' }
+    ]
+
+    const grouped = groupByDriverName(connectors, stockDrivers)
+
+    expect(grouped.driverMap.rpi).toBe(stockDrivers[0])
+    expect(grouped.groups.map(group => group.driverName)).toEqual(['Rasoverry Pi', 'missing'])
+    expect(grouped.groups[0].connectors.map(connector => connector.name)).toEqual(['Outlet A', 'Outlet C'])
+    expect(connectors.map(connector => connector.name)).toEqual(['Outlet B', 'Outlet A', 'Outlet C'])
   })
 
   it('<Pin /> renders select with options for driver pins', () => {

--- a/front-end/src/connectors/driver_groups.js
+++ b/front-end/src/connectors/driver_groups.js
@@ -1,0 +1,24 @@
+import { SortByName } from 'utils/sort_by_name'
+
+export const groupByDriverName = (connectors, drivers) => {
+  const driverMap = {}
+  drivers.forEach(d => { driverMap[d.id] = d })
+
+  const groups = {}
+  connectors.slice().sort((a, b) => SortByName(a, b))
+    .forEach(connector => {
+      const driverName = (driverMap[connector.driver] || {}).name || connector.driver
+      if (!groups[driverName]) groups[driverName] = []
+      groups[driverName].push(connector)
+    })
+
+  return {
+    driverMap,
+    groups: Object.keys(groups).sort().map(driverName => {
+      return {
+        driverName,
+        connectors: groups[driverName]
+      }
+    })
+  }
+}

--- a/front-end/src/connectors/jacks.jsx
+++ b/front-end/src/connectors/jacks.jsx
@@ -5,8 +5,8 @@ import { connect } from 'react-redux'
 import { fetchJacks, updateJack, deleteJack, createJack } from 'redux/actions/jacks'
 import Jack from './jack'
 import i18n from 'utils/i18n'
-import { SortByName } from 'utils/sort_by_name'
 import { byCapability } from './driver_filter'
+import { groupByDriverName } from './driver_groups'
 
 class jacks extends React.Component {
   constructor (props) {
@@ -99,25 +99,16 @@ class jacks extends React.Component {
   }
 
   list () {
-    const driverMap = {}
-    this.props.drivers.forEach(d => { driverMap[d.id] = d })
-
-    const groups = {}
-    this.props.jacks.slice().sort((a, b) => SortByName(a, b))
-      .forEach(j => {
-        const driverName = (driverMap[j.driver] || {}).name || j.driver
-        if (!groups[driverName]) groups[driverName] = []
-        groups[driverName].push(j)
-      })
+    const driverGroups = groupByDriverName(this.props.jacks, this.props.drivers)
 
     const list = []
-    Object.keys(groups).sort().forEach(driverName => {
+    driverGroups.groups.forEach(group => {
       list.push(
-        <div key={'driver-' + driverName} className='mt-2'>
-          <small className='text-muted font-weight-bold'>{driverName}</small>
+        <div key={'driver-' + group.driverName} className='mt-2'>
+          <small className='text-muted font-weight-bold'>{group.driverName}</small>
         </div>
       )
-      groups[driverName].forEach(j => {
+      group.connectors.forEach(j => {
         list.push(
           <Jack
             name={j.name}

--- a/front-end/src/connectors/outlets.jsx
+++ b/front-end/src/connectors/outlets.jsx
@@ -5,8 +5,8 @@ import { connect } from 'react-redux'
 import Outlet from './outlet'
 import Pin from './pin'
 import i18n from 'utils/i18n'
-import { SortByName } from 'utils/sort_by_name'
 import { byCapability } from './driver_filter'
+import { groupByDriverName } from './driver_groups'
 
 class outlets extends React.Component {
   constructor (props) {
@@ -91,26 +91,16 @@ class outlets extends React.Component {
   }
 
   list () {
-    const driverMap = {}
-    this.props.drivers.forEach(d => { driverMap[d.id] = d })
-
-    const groups = {}
-    this.props.outlets.slice()
-      .sort((a, b) => SortByName(a, b))
-      .forEach(o => {
-        const driverName = (driverMap[o.driver] || {}).name || o.driver
-        if (!groups[driverName]) groups[driverName] = []
-        groups[driverName].push(o)
-      })
+    const driverGroups = groupByDriverName(this.props.outlets, this.props.drivers)
 
     const list = []
-    Object.keys(groups).sort().forEach(driverName => {
+    driverGroups.groups.forEach(group => {
       list.push(
-        <div key={'driver-' + driverName} className='mt-2'>
-          <small className='text-muted font-weight-bold'>{driverName}</small>
+        <div key={'driver-' + group.driverName} className='mt-2'>
+          <small className='text-muted font-weight-bold'>{group.driverName}</small>
         </div>
       )
-      groups[driverName].forEach(o => {
+      group.connectors.forEach(o => {
         list.push(
           <Outlet
             name={o.name}
@@ -121,7 +111,7 @@ class outlets extends React.Component {
             equipment={o.equipment}
             remove={this.remove(o)}
             drivers={this.props.drivers}
-            driver={driverMap[o.driver] || {}}
+            driver={driverGroups.driverMap[o.driver] || {}}
             update={p => {
               this.props.update(o.id, p)
               this.props.fetch()


### PR DESCRIPTION
## Summary
- extract connector driver grouping into a shared helper
- use the helper from jacks, outlets, and analog inputs lists
- add coverage for grouped ordering and input immutability

## Tests
- rtk yarn jest front-end/src/connectors/connectors.test.js --runInBand
- rtk yarn standard
- rtk git diff --check