### PR TITLE
Avoid mutating pH schema test fixture

### DIFF
--- a/front-end/src/ph/ph_schema.test.js
+++ b/front-end/src/ph/ph_schema.test.js
@@ -1,58 +1,56 @@
 import PhSchema from './ph_schema'
 
 describe('PhValidation', () => {
-  let probe = {}
-
-  beforeEach(() => {
-    probe = {
-      name: 'name',
-      enable: true,
-      analog_input: '1',
-      period: 60,
-      notify: true,
-      minAlert: 8.0,
-      maxAlert: 8.6,
-      control: '',
-      chart: {ymin:0, ymax:100, color: '#000'}
-    }
+  const buildProbe = overrides => ({
+    name: 'name',
+    enable: true,
+    analog_input: '1',
+    period: 60,
+    notify: true,
+    minAlert: 8.0,
+    maxAlert: 8.6,
+    control: '',
+    chart: { ymin: 0, ymax: 100, color: '#000' },
+    ...overrides
   })
 
   it('should be valid for alerts', () => {
     expect.assertions(1)
-    return PhSchema.isValid(probe).then(
+    return PhSchema.isValid(buildProbe()).then(
       valid => expect(valid).toBe(true)
     )
   })
 
   it('should be valid for no alerts', () => {
-    probe.notify = false
-    probe.minAlert = 0
-    probe.maxAlert = 0
-
     expect.assertions(1)
-    return PhSchema.isValid(probe).then(
+    return PhSchema.isValid(buildProbe({
+      notify: false,
+      minAlert: 0,
+      maxAlert: 0
+    })).then(
       valid => expect(valid).toBe(true)
     )
   })
 
   it('should require threshold if controlling macros', () => {
-    probe.control = 'macro'
     expect.assertions(1)
-    return PhSchema.isValid(probe).then(
+    return PhSchema.isValid(buildProbe({
+      control: 'macro'
+    })).then(
       valid => expect(valid).toBe(false)
     )
   })
 
   it('should be valid if controlling equipment with required settings', () => {
-    probe.control = 'equipment'
-    probe.lowerThreshold = 8
-    probe.lowerFunction = '2'
-    probe.upperThreshold = 9
-    probe.upperFunction = '5'
-    probe.hysteresis = 0.1
-
     expect.assertions(1)
-    return PhSchema.isValid(probe).then(
+    return PhSchema.isValid(buildProbe({
+      control: 'equipment',
+      lowerThreshold: 8,
+      lowerFunction: '2',
+      upperThreshold: 9,
+      upperFunction: '5',
+      hysteresis: 0.1
+    })).then(
       valid => expect(valid).toBe(true)
     )
   })


### PR DESCRIPTION
## Summary
- replace shared pH schema fixture mutation with per-test probe builders
- preserve schema behavior and assertions
- keep production code unchanged

## Tests
- rtk yarn jest front-end/src/ph/ph_schema.test.js --runInBand
- rtk yarn standard
- rtk git diff --check