### PR TITLE
Sort driver config options numerically

### DIFF
--- a/front-end/src/drivers/edit_driver.jsx
+++ b/front-end/src/drivers/edit_driver.jsx
@@ -48,7 +48,7 @@ const EditDriver = ({
     if (selectedType == null) { return null }
     const params = []
 
-    selectedType.slice().sort((a, b) => { return parseInt(a.order) > parseInt(b.order) })
+    selectedType.slice().sort((a, b) => parseInt(a.order) - parseInt(b.order))
       .forEach((item) => {
         const param = (
           <div key={item.name} className='col col-sm-6 col-md-3'>

--- a/front-end/src/drivers/edit_driver.test.js
+++ b/front-end/src/drivers/edit_driver.test.js
@@ -13,6 +13,15 @@ const findNode = (node, predicate) => {
   return undefined
 }
 
+const findAll = (node, predicate, acc = []) => {
+  if (!node || typeof node !== 'object') return acc
+  if (predicate(node)) acc.push(node)
+  for (const child of [].concat(node.props?.children || [])) {
+    findAll(child, predicate, acc)
+  }
+  return acc
+}
+
 jest.mock('utils/alert', () => ({
   showError: jest.fn(),
   showUpdateSuccessful: jest.fn()
@@ -116,7 +125,10 @@ describe('<EditDriver />', () => {
     }
     const values = { type: 'ezo', config: { address: '99', enabled: 'true' } }
     const form = EditDriver(baseProps({ values, driverOptions }))
-    expect(form).not.toBeNull()
+    const labels = findAll(form, node => node.type === 'label' && node.props?.htmlFor?.startsWith('config.'))
+      .map(node => node.props.children)
+
+    expect(labels).toEqual(['Address', 'Enabled'])
     expect(selectedType.map(item => item.name)).toEqual(['Enabled', 'Address'])
   })
 


### PR DESCRIPTION
## Summary
- use a numeric comparator for driver config option ordering
- assert rendered driver config fields follow ascending order
- keep source driver option arrays immutable in tests

## Tests
- rtk yarn jest front-end/src/drivers/edit_driver.test.js --runInBand
- rtk yarn standard
- rtk git diff --check