### PR TITLE
Sort instances with numeric comparator

### DIFF
--- a/front-end/src/instances/instances.test.js
+++ b/front-end/src/instances/instances.test.js
@@ -31,6 +31,18 @@ const countByType = (node, predicate) => {
   return count
 }
 
+const findAll = (node, predicate, acc = []) => {
+  if (!node || typeof node !== 'object') {
+    return acc
+  }
+  if (predicate(node)) {
+    acc.push(node)
+  }
+  const children = React.Children.toArray(node.props?.children)
+  children.forEach(child => findAll(child, predicate, acc))
+  return acc
+}
+
 const findNode = (node, predicate) => {
   if (!node || typeof node !== 'object') {
     return null
@@ -76,7 +88,9 @@ describe('Instances Main', () => {
     expect(fetch).toHaveBeenCalled()
 
     const rendered = main.render()
-    expect(countByType(rendered, node => node.type === Instance)).toBe(2)
+    const renderedInstances = findAll(rendered, node => node.type === Instance)
+    expect(renderedInstances).toHaveLength(2)
+    expect(renderedInstances.map(node => node.props.instance.name)).toEqual(['Remote Tank B', 'Remote Tank A'])
     expect(instances.map(instance => instance.name)).toEqual(['Remote Tank B', 'Remote Tank A'])
   })
 

--- a/front-end/src/instances/main.jsx
+++ b/front-end/src/instances/main.jsx
@@ -45,7 +45,7 @@ export class RawInstancesMain extends React.Component {
     }
     return (
       <ul className='list-group list-group-flush'>
-        {this.props.instances.slice().sort((a, b) => { return parseInt(a.id) < parseInt(b.id) }).map(item => {
+        {this.props.instances.slice().sort((a, b) => parseInt(b.id) - parseInt(a.id)).map(item => {
           return (
             <Instance
               key={item.id}


### PR DESCRIPTION
## Summary
- replace boolean instance sort comparator with explicit numeric descending order
- add rendered-order coverage while preserving source array immutability

## Tests
- rtk yarn jest front-end/src/instances/instances.test.js --runInBand
- rtk yarn standard
- rtk git diff --check