### PR TITLE
Sort ATO chart usage by timestamp

### DIFF
--- a/front-end/src/ato/chart.jsx
+++ b/front-end/src/ato/chart.jsx
@@ -35,7 +35,7 @@ export class RawATOChart extends React.Component {
       return <div />
     }
     const metrics = this.props.usage.historical.slice()
-      .sort((a, b) => ParseTimestamp(a.time) > ParseTimestamp(b.time) ? 1 : -1)
+      .sort((a, b) => ParseTimestamp(a.time).getTime() - ParseTimestamp(b.time).getTime())
       .map(m => ({ ...m, ts: timestampToEpoch(m.time) }))
     return (
       <>

--- a/front-end/src/ato/chart.test.js
+++ b/front-end/src/ato/chart.test.js
@@ -19,7 +19,10 @@ describe('ATO Chart', () => {
       usage,
       fetchATOUsage: jest.fn()
     })
-    expect(() => chart.render()).not.toThrow()
+    const rendered = chart.render()
+    const barChart = rendered.props.children[1].props.children
+
+    expect(barChart.props.data.map(item => item.time)).toEqual(['Jul-01-10:00, 2024', 'Jul-01-10:10, 2024'])
     expect(usage.historical.map(item => item.time)).toEqual(['Jul-01-10:10, 2024', 'Jul-01-10:00, 2024'])
     expect(usage.historical[0].ts).toBeUndefined()
     expect(Chart).toBeDefined()


### PR DESCRIPTION
## Summary
- compare ATO usage timestamps numerically when sorting chart metrics
- assert the chart receives chronological data while preserving the source usage array

## Tests
- rtk yarn jest front-end/src/ato/chart.test.js --runInBand
- rtk yarn standard
- rtk git diff --check