### PR TITLE
Test driver validation API wrapper

### DIFF
--- a/front-end/src/drivers/api.test.js
+++ b/front-end/src/drivers/api.test.js
@@ -1,0 +1,32 @@
+import { validateDriver } from './api'
+import { nonReduxRequest } from '../utils/ajax'
+
+jest.mock('../utils/ajax', () => ({
+  nonReduxRequest: jest.fn()
+}))
+
+describe('drivers api', () => {
+  beforeEach(() => {
+    nonReduxRequest.mockClear()
+  })
+
+  it('validateDriver posts the payload to the validation endpoint', () => {
+    const payload = {
+      name: 'pca',
+      type: 'pca9685',
+      config: {
+        address: 64,
+        frequency: 1000
+      }
+    }
+    const response = Promise.resolve({ status: 200 })
+    nonReduxRequest.mockReturnValue(response)
+
+    expect(validateDriver(payload)).toBe(response)
+    expect(nonReduxRequest).toHaveBeenCalledWith({
+      url: 'api/drivers/validate',
+      method: 'POST',
+      data: payload
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add focused mock coverage for validateDriver
- lock the nonReduxRequest URL, method, payload, and returned promise behavior

## Tests
- rtk yarn jest front-end/src/drivers/api.test.js front-end/src/utils/ajax.test.js --runInBand
- rtk yarn standard
- rtk git diff --check