### PR TITLE
Sort health chart stats by timestamp

### DIFF
--- a/front-end/src/health_chart.jsx
+++ b/front-end/src/health_chart.jsx
@@ -31,7 +31,7 @@ export class RawHealthChart extends React.Component {
     const healthStats = this.props.health_stats[this.state.trend]
       ?.slice()
       .sort((a, b) => {
-        return ParseTimestamp(a.time) > ParseTimestamp(b.time) ? 1 : -1
+        return ParseTimestamp(a.time).getTime() - ParseTimestamp(b.time).getTime()
       })
       .map(m => ({ ...m, ts: timestampToEpoch(m.time) }))
     return (

--- a/front-end/src/health_chart.test.js
+++ b/front-end/src/health_chart.test.js
@@ -55,7 +55,10 @@ describe('Health', () => {
       height: 100
     })
 
-    chart.render()
+    const rendered = chart.render()
+    const lineChart = rendered.props.children[1].props.children
+
+    expect(lineChart.props.data.map(item => item.time)).toEqual(['Jul-01-10:00, 2024', 'Jul-01-10:10, 2024'])
 
     expect(current.map(item => item.time)).toEqual(['Jul-01-10:10, 2024', 'Jul-01-10:00, 2024'])
     expect(current[0].ts).toBeUndefined()


### PR DESCRIPTION
## Summary
- compare health chart timestamps numerically when preparing chart data
- assert rendered chart rows are chronological while source health stats remain unmutated

## Tests
- rtk yarn jest front-end/src/health_chart.test.js --runInBand
- rtk yarn standard
- rtk git diff --check