### PR TITLE
Sort pH chart readings by timestamp

### DIFF
--- a/front-end/src/ph/chart.jsx
+++ b/front-end/src/ph/chart.jsx
@@ -31,7 +31,7 @@ class chart extends React.Component {
       ? filterToday(this.props.readings[this.props.type])
       : [...this.props.readings[this.props.type]]
     const metrics = raw.sort((a, b) => {
-      return ParseTimestamp(a.time) > ParseTimestamp(b.time) ? 1 : -1
+      return ParseTimestamp(a.time).getTime() - ParseTimestamp(b.time).getTime()
     }).map(m => ({ ...m, ts: timestampToEpoch(m.time) }))
     let current = ''
     if (metrics.length >= 1) {

--- a/front-end/src/ph/control_chart.jsx
+++ b/front-end/src/ph/control_chart.jsx
@@ -29,7 +29,7 @@ export class RawControlChart extends React.Component {
       return <div />
     }
     const metrics = [...this.props.readings.historical].sort((a, b) => {
-      return ParseTimestamp(a.time) > ParseTimestamp(b.time) ? 1 : -1
+      return ParseTimestamp(a.time).getTime() - ParseTimestamp(b.time).getTime()
     })
     let current = ''
     if (metrics.length >= 1) {

--- a/front-end/src/ph/control_chart.test.js
+++ b/front-end/src/ph/control_chart.test.js
@@ -30,7 +30,14 @@ describe('Ph ControlChart', () => {
   })
 
   it('renders with config and readings present', () => {
-    const readings = { historical: [{ time: '08:00', value: 7.5, up: 10, down: 5 }] }
+    const historical = [
+      { time: 'Jul-01-10:10, 2024', value: 7.8, up: 10, down: 5 },
+      { time: 'Jul-01-10:00, 2024', value: 7.5, up: 6, down: 2 },
+      { time: 'Jul-01-10:05, 2024', value: 7.6, up: 7, down: 3 },
+      { time: 'Jul-01-10:05, 2024', value: 7.7, up: 8, down: 4 }
+    ]
+    const originalHistorical = historical.map(reading => ({ ...reading }))
+    const readings = { historical }
     const chart = new RawControlChart({
       probe_id: '1',
       config: probeConfig,
@@ -38,7 +45,16 @@ describe('Ph ControlChart', () => {
       fetchProbeReadings: jest.fn(),
       height: 200
     })
-    expect(() => chart.render()).not.toThrow()
+    const rendered = chart.render()
+    const chartData = rendered.props.children[1].props.children.props.data
+    expect(chartData.map(reading => reading.time)).toEqual([
+      'Jul-01-10:00, 2024',
+      'Jul-01-10:05, 2024',
+      'Jul-01-10:05, 2024',
+      'Jul-01-10:10, 2024'
+    ])
+    expect(chartData.map(reading => reading.value)).toEqual([7.5, 7.6, 7.7, 7.8])
+    expect(readings.historical).toEqual(originalHistorical)
   })
 
   it('fetches probe readings on mount via interval', () => {

--- a/front-end/src/ph/ph.test.js
+++ b/front-end/src/ph/ph.test.js
@@ -229,6 +229,13 @@ describe('Ph ui', () => {
     expect(new RawPhChart({ config: { chart: {} }, readings: undefined, probe_id: '1', fetchProbeReadings: jest.fn() }).render().type).toBe('div')
 
     const fetchProbeReadings = jest.fn()
+    const historical = [
+      { time: 'Jul-01-10:10, 2024', value: 7.4 },
+      { time: 'Jul-01-10:00, 2024', value: 7.1 },
+      { time: 'Jul-01-10:05, 2024', value: 7.2 },
+      { time: 'Jul-01-10:05, 2024', value: 7.3 }
+    ]
+    const originalHistorical = historical.map(reading => ({ ...reading }))
     const instance = new RawPhChart({
       config: {
         id: '1',
@@ -237,20 +244,28 @@ describe('Ph ui', () => {
         notify: { enable: true, min: 7, max: 8.5 }
       },
       readings: {
-        current: [
-          { time: '2026-04-27T10:00:00Z', value: 7.1 },
-          { time: '2026-04-27T10:10:00Z', value: 7.2 }
-        ]
+        historical
       },
       probe_id: '1',
       fetchProbeReadings,
-      type: 'current',
+      type: 'historical',
       height: 200
     })
     setComponentState(instance)
     instance.componentDidMount()
     expect(fetchProbeReadings).toHaveBeenCalledWith('1')
-    expect(instance.render().props.className).toBe('container')
+    const rendered = instance.render()
+    expect(rendered.props.className).toBe('container')
+    const chartData = rendered.props.children[1].props.children.props.data
+    expect(chartData.map(reading => reading.time)).toEqual([
+      'Jul-01-10:00, 2024',
+      'Jul-01-10:05, 2024',
+      'Jul-01-10:05, 2024',
+      'Jul-01-10:10, 2024'
+    ])
+    expect(chartData.map(reading => reading.value)).toEqual([7.1, 7.2, 7.3, 7.4])
+    expect(chartData.map(reading => reading.ts)).toEqual([...chartData.map(reading => reading.ts)].sort((a, b) => a - b))
+    expect(historical).toEqual(originalHistorical)
     instance.componentWillUnmount()
   })
 })


### PR DESCRIPTION
## Summary
- compare pH chart timestamps numerically when preparing current and control chart data
- assert rendered chart data is chronological while source readings remain unmutated

## Tests
- rtk yarn jest front-end/src/ph/ph.test.js front-end/src/ph/control_chart.test.js --runInBand
- rtk yarn standard
- rtk git diff --check