### PR TITLE
Sort temperature chart usage by timestamp

### DIFF
--- a/front-end/src/temperature/control_chart.jsx
+++ b/front-end/src/temperature/control_chart.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Tooltip, ResponsiveContainer, ComposedChart, Line, YAxis, XAxis, Bar, ReferenceLine } from 'recharts'
-import { ParseTimestamp, timestampToEpoch, formatChartTime } from 'utils/timestamp'
+import { timestampToEpoch, formatChartTime } from 'utils/timestamp'
 import { fetchTCUsage } from '../redux/actions/tcs'
 import { connect } from 'react-redux'
 import { TwoDecimalParse } from 'utils/two_decimal_parse'
@@ -31,9 +31,7 @@ export class RawControlChart extends React.Component {
     }
     const usage = this.props.usage.historical
       .map(v => ({ ...v, cooler: v.cooler * -1 }))
-      .sort((a, b) => {
-        return ParseTimestamp(a.time) > ParseTimestamp(b.time) ? 1 : -1
-      })
+      .sort((a, b) => timestampToEpoch(a.time) - timestampToEpoch(b.time))
       .map(m => ({ ...m, ts: timestampToEpoch(m.time) }))
 
     const c = this.props.config.chart

--- a/front-end/src/temperature/readings_chart.jsx
+++ b/front-end/src/temperature/readings_chart.jsx
@@ -3,7 +3,7 @@ import { Tooltip, Area, YAxis, XAxis, AreaChart, ResponsiveContainer } from 'rec
 import { fetchTCUsage } from '../redux/actions/tcs'
 import { connect } from 'react-redux'
 import { TwoDecimalParse } from 'utils/two_decimal_parse'
-import { ParseTimestamp, filterToday } from 'utils/timestamp'
+import { filterToday, timestampToEpoch } from 'utils/timestamp'
 
 export class RawReadingsChart extends React.Component {
   componentDidMount () {
@@ -31,9 +31,8 @@ export class RawReadingsChart extends React.Component {
     }
     const c = this.props.config.chart
     const unit = this.props.config.fahrenheit ? '°F' : '°C'
-    const readings = filterToday([...this.props.usage.current]).sort((a, b) => {
-      return ParseTimestamp(a.time) > ParseTimestamp(b.time) ? 1 : -1
-    })
+    const readings = filterToday([...this.props.usage.current])
+      .sort((a, b) => timestampToEpoch(a.time) - timestampToEpoch(b.time))
 
     return (
       <div className='container'>

--- a/front-end/src/temperature/temperature.test.js
+++ b/front-end/src/temperature/temperature.test.js
@@ -28,6 +28,13 @@ const renderForm = props => renderToStaticMarkup(
   />
 )
 
+const renderedChartData = component => component.render().props.children[1].props.children.props.data
+const todayTimestamp = time => {
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+  const today = new Date()
+  return `${months[today.getMonth()]}-${String(today.getDate()).padStart(2, '0')}-${time}, ${today.getFullYear()}`
+}
+
 const tcState = {
   tcs: [{ id: '1', name: 'Water', chart: {}, enable: false, notify: { enable: false } }],
   tc_usage: {},
@@ -317,9 +324,15 @@ describe('Temperature controller ui', () => {
       tc_usage: { 1: { historical: [{ cooler: 1 }], current: [{ temperature: 1 }, { temperature: 4 }] } }
     }
     const fetch = jest.fn()
+    const current = [
+      { time: todayTimestamp('10:10'), value: 4 },
+      { time: todayTimestamp('10:00'), value: 1 },
+      { time: todayTimestamp('10:00'), value: 2 }
+    ]
+    const originalCurrent = current.map(reading => ({ ...reading }))
     const instance = new RawReadingsChart({
       config: { id: '1', name: 'Water', chart: { color: '#f00', ymin: 70, ymax: 90 }, fahrenheit: true },
-      usage: { current: [{ time: '2026-04-27T10:00:00Z', value: 1 }, { time: '2026-04-27T10:10:00Z', value: 4 }] },
+      usage: { current },
       sensor_id: '1',
       fetch,
       height: 200
@@ -328,6 +341,8 @@ describe('Temperature controller ui', () => {
     instance.componentDidMount()
     expect(fetch).toHaveBeenCalledWith('1')
     expect(instance.render().props.className).toBe('container')
+    expect(renderedChartData(instance).map(reading => reading.value)).toEqual([1, 2, 4])
+    expect(current).toEqual(originalCurrent)
     instance.componentWillUnmount()
     stateCurrent = {
       tcs: [{ id: '2', min: 72, max: 78, chart:{}}],
@@ -340,7 +355,12 @@ describe('Temperature controller ui', () => {
     expect(new RawControlChart({ config: undefined, usage: { historical: [] }, sensor_id: '1', fetchTCUsage: jest.fn() }).render().type).toBe('div')
     expect(new RawControlChart({ config: { chart: {} }, usage: undefined, sensor_id: '1', fetchTCUsage: jest.fn() }).render().type).toBe('div')
     const fetchTCUsage = jest.fn()
-    const historical = [{ time: '2026-04-27T10:00:00Z', cooler: 1, up: 2, down: 0, value: 72 }]
+    const historical = [
+      { time: 'Jul-01-10:10, 2024', cooler: 4, up: 4, down: 0, value: 74 },
+      { time: 'Jul-01-10:00, 2024', cooler: 1, up: 2, down: 0, value: 72 },
+      { time: 'Jul-01-10:00, 2024', cooler: 2, up: 3, down: 0, value: 73 }
+    ]
+    const originalHistorical = historical.map(reading => ({ ...reading }))
     const instance = new RawControlChart({
       config: { id: '1', name: 'Water', chart: { color: '#f00', ymin: 70, ymax: 90 }, fahrenheit: true },
       usage: { historical, current: [] },
@@ -352,7 +372,9 @@ describe('Temperature controller ui', () => {
     instance.componentDidMount()
     expect(fetchTCUsage).toHaveBeenCalledWith('1')
     expect(instance.render().props.className).toBe('container')
-    expect(historical[0].cooler).toBe(1)
+    expect(renderedChartData(instance).map(reading => reading.value)).toEqual([72, 73, 74])
+    expect(renderedChartData(instance).map(reading => reading.cooler)).toEqual([-1, -2, -4])
+    expect(historical).toEqual(originalHistorical)
     expect(historical[0].ts).toBeUndefined()
     instance.componentWillUnmount()
   })


### PR DESCRIPTION
## Summary
- compare temperature chart timestamps numerically when preparing current and control chart data
- assert rendered chart data is chronological while source usage remains unmutated

## Tests
- rtk yarn jest front-end/src/temperature/temperature.test.js --runInBand
- rtk yarn standard
- rtk git diff --check