### PR TITLE
Sort journal chart entries by timestamp

### DIFF
--- a/front-end/src/journal/chart.jsx
+++ b/front-end/src/journal/chart.jsx
@@ -27,7 +27,7 @@ export class RawJournalChart extends React.Component {
       return (<div />)
     }
     const metrics = [...this.props.readings.historical].sort((a, b) => {
-      return ParseTimestamp(a.timestamp) > ParseTimestamp(b.timestamp) ? 1 : -1
+      return ParseTimestamp(a.timestamp).getTime() - ParseTimestamp(b.timestamp).getTime()
     })
     let current = ''
     if (metrics.length >= 1) {

--- a/front-end/src/journal/chart.test.js
+++ b/front-end/src/journal/chart.test.js
@@ -27,16 +27,26 @@ describe('<Chart />', () => {
     expect(Chart).toBeDefined()
   })
 
-  it('renders without throwing when readings available', () => {
+  it('renders sorted chart data without mutating readings', () => {
+    const historical = [
+      { timestamp: 'Jan-01-11:00, 2023', value: 7.4 },
+      { timestamp: 'Jan-01-10:00, 2023', value: 7.2 },
+      { timestamp: 'Jan-01-10:00, 2023', value: 7.3 }
+    ]
+    const originalHistorical = historical.map(reading => ({ ...reading }))
     const chart = new RawJournalChart({
       journal_id: '1',
       width: 500,
       height: 300,
       config: journal,
-      readings,
+      readings: { historical },
       fetch: jest.fn()
     })
-    expect(() => chart.render()).not.toThrow()
+    const rendered = chart.render()
+    const lineChart = rendered.props.children[1].props.children
+
+    expect(lineChart.props.data.map(reading => reading.value)).toEqual([7.2, 7.3, 7.4])
+    expect(historical).toEqual(originalHistorical)
   })
 
   it('polls on mount and clears timer on unmount', () => {


### PR DESCRIPTION
## Summary
- compare journal chart timestamps numerically when preparing chart entries
- assert rendered chart data is chronological while source readings remain unmutated

## Tests
- rtk yarn jest front-end/src/journal/chart.test.js --runInBand
- rtk yarn standard
- rtk git diff --check