### PR TITLE
Test modal structure

### DIFF
--- a/front-end/src/modal.test.js
+++ b/front-end/src/modal.test.js
@@ -2,34 +2,53 @@ import React from 'react'
 import Modal from './modal'
 import 'isomorphic-fetch'
 
-const findAll = (node, predicate, acc = []) => {
-  if (!node || typeof node !== 'object') {
-    return acc
-  }
-  if (predicate(node)) {
-    acc.push(node)
-  }
-  React.Children.toArray(node.props?.children).forEach(child => findAll(child, predicate, acc))
-  return acc
-}
+const renderModal = children => new Modal({ children }).render()
+
+const topLevelChildren = tree => React.Children.toArray(tree.props.children)
 
 describe('<Modal />', () => {
-  it('renders children inside modal-content', () => {
-    const tree = new Modal({ children: <span id='child'>hello</span> }).render()
-    expect(findAll(tree, node => node.props?.id === 'child')).toHaveLength(1)
+  it('renders backdrop before modal', () => {
+    const tree = renderModal(<div />)
+    const children = topLevelChildren(tree)
+
+    expect(children).toHaveLength(2)
+    expect(children[0].type).toBe('div')
+    expect(children[0].props.className).toBe('modal-backdrop show')
+    expect(children[1].type).toBe('div')
+    expect(children[1].props.className).toBe('modal in')
   })
 
-  it('renders modal-backdrop', () => {
-    const tree = new Modal({ children: <div /> }).render()
-    expect(React.Children.toArray(tree.props.children)[0].props.className).toBe('modal-backdrop show')
+  it('renders modal attributes', () => {
+    const tree = renderModal(<div />)
+    const modal = topLevelChildren(tree)[1]
+
+    expect(modal.props.role).toBe('dialog')
+    expect(modal.props.tabIndex).toBe('-1')
+    expect(modal.props['aria-hidden']).toBe('false')
+    expect(modal.props.style).toEqual({ display: 'block' })
   })
 
-  it('renders modal div with role=dialog', () => {
-    const tree = new Modal({ children: <div /> }).render()
-    expect(React.Children.toArray(tree.props.children)[1].props.role).toBe('dialog')
+  it('renders modal-dialog and modal-content around children', () => {
+    const child = <span id='child'>hello</span>
+    const tree = renderModal(child)
+    const modal = topLevelChildren(tree)[1]
+    const dialog = React.Children.only(modal.props.children)
+    const content = React.Children.only(dialog.props.children)
+
+    expect(dialog.type).toBe('div')
+    expect(dialog.props.className).toBe('modal-dialog')
+    expect(content.type).toBe('div')
+    expect(content.props.className).toBe('modal-content')
+    expect(content.props.children).toBe(child)
   })
 
   it('renders without children', () => {
-    expect(() => new Modal({}).render()).not.toThrow()
+    const tree = new Modal({}).render()
+    const modal = topLevelChildren(tree)[1]
+    const dialog = React.Children.only(modal.props.children)
+    const content = React.Children.only(dialog.props.children)
+
+    expect(content.props.className).toBe('modal-content')
+    expect(content.props.children).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
- assert modal backdrop and dialog ordering
- cover modal accessibility/display props
- assert modal-dialog and modal-content nesting with and without children

## Tests
- rtk yarn jest front-end/src/modal.test.js --runInBand
- rtk yarn standard
- rtk git diff --check