### PR TITLE
Test new journal form rendering

### DIFF
--- a/front-end/src/journal/new.test.js
+++ b/front-end/src/journal/new.test.js
@@ -1,6 +1,9 @@
 import New, { RawNewJournal } from './new'
+import JournalForm from './form'
 import fetchMock from 'fetch-mock'
 import 'isomorphic-fetch'
+
+const children = component => component.render().props.children
 
 describe('<New />', () => {
   afterEach(() => {
@@ -8,39 +11,56 @@ describe('<New />', () => {
     fetchMock.restore()
   })
 
-  it('renders without throwing', () => {
+  it('renders collapsed without a journal form', () => {
     const component = new RawNewJournal({ createJournal: jest.fn() })
     expect(() => component.render()).not.toThrow()
+    expect(children(component)[0].props.value).toBe('+')
+    expect(children(component)[1]).toBeUndefined()
     expect(New).toBeDefined()
   })
 
-  it('shows + initially', () => {
-    const component = new RawNewJournal({ createJournal: jest.fn() })
-    expect(component.render().props.children[0].props.value).toBe('+')
-  })
-
-  it('toggles to - on click', () => {
+  it('renders the journal form when expanded', () => {
     const component = new RawNewJournal({ createJournal: jest.fn() })
     component.setState = jest.fn(update => {
       component.state = { ...component.state, ...update }
     })
-    component.render().props.children[0].props.onClick()
-    expect(component.render().props.children[0].props.value).toBe('-')
+    children(component)[0].props.onClick()
+    expect(children(component)[0].props.value).toBe('-')
+    expect(children(component)[1].type).toBe(JournalForm)
+    expect(children(component)[1].props.onSubmit).toBe(component.handleSubmit)
   })
 
-  it('toggles state.add on button click', () => {
+  it('toggles expanded state and resets draft values', () => {
     const component = new RawNewJournal({ createJournal: jest.fn() })
+    component.state = {
+      name: 'old name',
+      description: 'old description',
+      unit: 'ppt',
+      add: false
+    }
     component.setState = jest.fn(update => {
       component.state = { ...component.state, ...update }
     })
-    expect(component.state.add).toBe(false)
     component.handleToggle()
-    expect(component.state.add).toBe(true)
+    expect(component.state).toEqual({
+      name: '',
+      description: '',
+      unit: '',
+      add: true
+    })
+    component.state.name = 'next name'
+    component.state.description = 'next description'
+    component.state.unit = 'dKH'
     component.handleToggle()
-    expect(component.state.add).toBe(false)
+    expect(component.state).toEqual({
+      name: '',
+      description: '',
+      unit: '',
+      add: false
+    })
   })
 
-  it('handleSubmit collapses the form', () => {
+  it('submits only journal fields and collapses the form', () => {
     const createJournal = jest.fn()
     const component = new RawNewJournal({ createJournal })
     component.setState = jest.fn(update => {
@@ -48,7 +68,7 @@ describe('<New />', () => {
     })
     component.handleToggle()
     expect(component.state.add).toBe(true)
-    component.handleSubmit({ name: 'test', description: 'desc', unit: 'pH' })
+    component.handleSubmit({ id: 7, name: 'test', description: 'desc', unit: 'pH', ignored: true })
     expect(createJournal).toHaveBeenCalledWith({ name: 'test', description: 'desc', unit: 'pH' })
     expect(component.state.add).toBe(false)
   })


### PR DESCRIPTION
## Summary
- assert the new journal control renders collapsed without a form
- verify expanding renders JournalForm with the submit handler wired
- cover toggle reset behavior and filtered submit payloads

## Tests
- rtk yarn jest front-end/src/journal/new.test.js --runInBand
- rtk yarn standard
- rtk git diff --check