### PR TITLE
[claude design] ThresholdGauge component (#5)

### DIFF
--- a/front-end/design-system/github_issues/BACKLOG.md
+++ b/front-end/design-system/github_issues/BACKLOG.md
@@ -9,7 +9,7 @@
 - [x] #4 Migrate `preview/` cards to `var()`-only — `issue-04-preview-migrate.md`
 
 ## E2 · Monitoring primitives
-- [ ] #5 ThresholdGauge component — `issue-05-threshold-gauge.md`
+- [x] #5 ThresholdGauge component — `issue-05-threshold-gauge.md`
 - [ ] #6 Sparkline v2 (gradient fill, threshold band, hover) — `issue-06-sparkline-v2.md`
 - [ ] #7 RangeSelector (1H / 6H / 1D / 7D / 30D) — `issue-07-range-selector.md`
 - [ ] #8 `useTimeSeries` hook — `issue-08-use-time-series.md`

--- a/front-end/design-system/preview/primitives/threshold-gauge.html
+++ b/front-end/design-system/preview/primitives/threshold-gauge.html
@@ -1,0 +1,333 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>reef-pi — ThresholdGauge</title>
+  <link rel="stylesheet" href="../_card.css">
+  <style>
+    .subtitle {
+      font-size: 0.875rem;
+      color: var(--reefpi-color-text-muted);
+      margin-bottom: 2rem;
+    }
+
+    .story-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+    }
+
+    @media (max-width: 700px) {
+      .story-grid { grid-template-columns: 1fr; }
+    }
+
+    /* ── Gauge host ───────────────────────────────── */
+
+    .gauge-host {
+      padding: 1.25rem 1rem 0.75rem;
+    }
+
+    /* ── Track + indicator ───────────────────────── */
+
+    .gauge-track-wrap {
+      position: relative;
+      height: 14px;
+      border-radius: 7px;
+      overflow: visible;
+      background: var(--reefpi-color-surface-elevated);
+      border: 1px solid var(--reefpi-color-border);
+    }
+
+    .gauge-zones {
+      position: absolute;
+      inset: 0;
+      border-radius: 7px;
+      overflow: hidden;
+      display: flex;
+    }
+
+    .zone {
+      height: 100%;
+      flex-shrink: 0;
+    }
+
+    .zone-safe     { background: var(--reefpi-color-band-safe); }
+    .zone-warn     { background: var(--reefpi-color-band-warn); }
+    .zone-critical { background: var(--reefpi-color-band-critical); }
+
+    .gauge-needle {
+      position: absolute;
+      top: 50%;
+      transform: translate(-50%, -50%);
+      width: 2px;
+      height: 20px;
+      border-radius: 1px;
+      z-index: 1;
+    }
+
+    .gauge-indicator {
+      position: absolute;
+      top: 50%;
+      transform: translate(-50%, -50%);
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: var(--reefpi-color-surface-elevated);
+      border: 2px solid var(--reefpi-color-text-strong);
+      z-index: 2;
+    }
+
+    .gauge-indicator.out-of-bounds {
+      border-color: var(--reefpi-color-band-critical);
+    }
+
+    /* ── Value + label row ────────────────────────── */
+
+    .gauge-value-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      margin-bottom: 6px;
+    }
+
+    .gauge-value {
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--reefpi-color-text);
+    }
+
+    .gauge-value.in-warn  { color: var(--reefpi-color-warn); }
+    .gauge-value.out-of-bounds { color: var(--reefpi-color-error); }
+
+    .gauge-label {
+      font-size: 0.75rem;
+      color: var(--reefpi-color-text-muted);
+    }
+
+    /* ── Min/max row ────────────────────────────────── */
+
+    .gauge-minmax {
+      display: flex;
+      justify-content: space-between;
+      margin-top: 4px;
+    }
+
+    .gauge-minmax span {
+      font-size: 0.65rem;
+      color: var(--reefpi-color-text-muted);
+      font-family: var(--reefpi-font-mono);
+    }
+  </style>
+</head>
+<body>
+  <h1>ThresholdGauge</h1>
+  <p class="subtitle">Full-width track with coloured safe / warn / critical zones. Indicator snaps to value; turns red when out of bounds.</p>
+
+  <div class="story-grid">
+
+    <!-- Story 1: Within safe range -->
+    <div class="card">
+      <div class="card-header">Within safe range — 78.4 °F</div>
+      <div class="card-body">
+        <div class="gauge-host"
+          role="meter"
+          aria-label="Display Tank temperature"
+          aria-valuemin="70" aria-valuemax="86"
+          aria-valuenow="78.4"
+          aria-valuetext="78.4°F, within safe range">
+
+          <div class="gauge-value-row">
+            <span class="gauge-value">78.4°F</span>
+            <span class="gauge-label">Display Tank</span>
+          </div>
+
+          <!--
+            critical: [70, 86]  → 0 % – 100 %  (track span)
+            warn:     [74, 82]  → 25 % – 75 %
+            safe:     [76, 80]  → 37.5 % – 62.5 %
+            value:    78.4      → 52.5 %
+          -->
+          <div class="gauge-track-wrap">
+            <div class="gauge-zones">
+              <!-- left critical  0 → 25 %  -->
+              <div class="zone zone-critical" style="width:25%"></div>
+              <!-- left warn      25 → 37.5 % -->
+              <div class="zone zone-warn"     style="width:12.5%"></div>
+              <!-- safe           37.5 → 62.5 % -->
+              <div class="zone zone-safe"     style="width:25%"></div>
+              <!-- right warn     62.5 → 75 % -->
+              <div class="zone zone-warn"     style="width:12.5%"></div>
+              <!-- right critical 75 → 100 % -->
+              <div class="zone zone-critical" style="width:25%"></div>
+            </div>
+            <div class="gauge-needle" style="left:52.5%; background:var(--reefpi-color-text-strong)"></div>
+            <div class="gauge-indicator" style="left:52.5%"></div>
+          </div>
+
+          <div class="gauge-minmax">
+            <span>70°F</span><span>86°F</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Story 2: In warn zone -->
+    <div class="card">
+      <div class="card-header">In warn zone — 75.1 °F</div>
+      <div class="card-body">
+        <div class="gauge-host"
+          role="meter"
+          aria-label="Sump temperature"
+          aria-valuemin="70" aria-valuemax="86"
+          aria-valuenow="75.1"
+          aria-valuetext="75.1°F, in warning zone">
+
+          <div class="gauge-value-row">
+            <!-- 75.1 is between warn[0]=74 and safe[0]=76 → warn zone -->
+            <span class="gauge-value in-warn">75.1°F</span>
+            <span class="gauge-label">Sump</span>
+          </div>
+
+          <!-- value: 75.1 → (75.1-70)/(86-70)*100 = 31.875 % -->
+          <div class="gauge-track-wrap">
+            <div class="gauge-zones">
+              <div class="zone zone-critical" style="width:25%"></div>
+              <div class="zone zone-warn"     style="width:12.5%"></div>
+              <div class="zone zone-safe"     style="width:25%"></div>
+              <div class="zone zone-warn"     style="width:12.5%"></div>
+              <div class="zone zone-critical" style="width:25%"></div>
+            </div>
+            <div class="gauge-needle" style="left:31.875%; background:var(--reefpi-color-warn)"></div>
+            <div class="gauge-indicator" style="left:31.875%; border-color:var(--reefpi-color-warn)"></div>
+          </div>
+
+          <div class="gauge-minmax">
+            <span>70°F</span><span>86°F</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Story 3: Out of bounds (value > critical max) -->
+    <div class="card">
+      <div class="card-header">Out of bounds — 90.0 °F</div>
+      <div class="card-body">
+        <div class="gauge-host"
+          role="meter"
+          aria-label="Refugium temperature"
+          aria-valuemin="70" aria-valuemax="86"
+          aria-valuenow="90"
+          aria-valuetext="90°F, out of bounds">
+
+          <div class="gauge-value-row">
+            <span class="gauge-value out-of-bounds">90.0°F</span>
+            <span class="gauge-label">Refugium</span>
+          </div>
+
+          <!-- indicator clamped to 100 % (right edge) -->
+          <div class="gauge-track-wrap">
+            <div class="gauge-zones">
+              <div class="zone zone-critical" style="width:25%"></div>
+              <div class="zone zone-warn"     style="width:12.5%"></div>
+              <div class="zone zone-safe"     style="width:25%"></div>
+              <div class="zone zone-warn"     style="width:12.5%"></div>
+              <div class="zone zone-critical" style="width:25%"></div>
+            </div>
+            <div class="gauge-needle" style="left:100%; background:var(--reefpi-color-band-critical)"></div>
+            <div class="gauge-indicator out-of-bounds" style="left:100%"></div>
+          </div>
+
+          <div class="gauge-minmax">
+            <span>70°F</span><span>86°F</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Story 4: No warn band -->
+    <div class="card">
+      <div class="card-header">No warn band — safe + critical only</div>
+      <div class="card-body">
+        <div class="gauge-host"
+          role="meter"
+          aria-label="pH"
+          aria-valuemin="7.8" aria-valuemax="8.6"
+          aria-valuenow="8.2"
+          aria-valuetext="8.2, within safe range">
+
+          <div class="gauge-value-row">
+            <span class="gauge-value">8.20</span>
+            <span class="gauge-label">pH</span>
+          </div>
+
+          <!--
+            critical: [7.8, 8.6]
+            safe:     [8.1, 8.4]
+            warn:     none
+            value:    8.2  → (8.2-7.8)/(8.6-7.8)*100 = 50 %
+            safe left  → (8.1-7.8)/0.8*100 = 37.5 %
+            safe right → (8.4-7.8)/0.8*100 = 75 %
+            safe width → 37.5 %
+          -->
+          <div class="gauge-track-wrap">
+            <div class="gauge-zones">
+              <div class="zone zone-critical" style="width:37.5%"></div>
+              <div class="zone zone-safe"     style="width:37.5%"></div>
+              <div class="zone zone-critical" style="width:25%"></div>
+            </div>
+            <div class="gauge-needle" style="left:50%; background:var(--reefpi-color-text-strong)"></div>
+            <div class="gauge-indicator" style="left:50%"></div>
+          </div>
+
+          <div class="gauge-minmax">
+            <span>7.8</span><span>8.6</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Story 5: No safe band — warn band only -->
+    <div class="card" style="grid-column: 1 / -1;">
+      <div class="card-header">No safe band — warn band only (Salinity)</div>
+      <div class="card-body">
+        <div class="gauge-host"
+          role="meter"
+          aria-label="Salinity"
+          aria-valuemin="33" aria-valuemax="37"
+          aria-valuenow="35"
+          aria-valuetext="35 ppt, within safe range">
+
+          <div class="gauge-value-row">
+            <span class="gauge-value">35 ppt</span>
+            <span class="gauge-label">Salinity</span>
+          </div>
+
+          <!--
+            critical: [33, 37]
+            warn:     [34, 36]  → 25 % – 75 %
+            safe:     none
+            value:    35  → 50 %
+          -->
+          <div class="gauge-track-wrap">
+            <div class="gauge-zones">
+              <div class="zone zone-critical" style="width:25%"></div>
+              <div class="zone zone-warn"     style="width:50%"></div>
+              <div class="zone zone-critical" style="width:25%"></div>
+            </div>
+            <div class="gauge-needle" style="left:50%; background:var(--reefpi-color-text-strong)"></div>
+            <div class="gauge-indicator" style="left:50%"></div>
+          </div>
+
+          <div class="gauge-minmax">
+            <span>33 ppt</span><span>37 ppt</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <script src="../_card.js"></script>
+</body>
+</html>

--- a/front-end/design-system/ui_kits/reef-pi-app/primitives/ThresholdGauge.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/primitives/ThresholdGauge.jsx
@@ -1,0 +1,207 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+/**
+ * Builds percentage-based colour zones along a 0–100 track.
+ * Returns an array of { left, width, color } objects ready for inline styles.
+ */
+function buildZones (min, max, safe, warn) {
+  const pct = v => ((v - min) / (max - min)) * 100
+
+  if (!safe && !warn) {
+    return [{ left: 0, width: 100, color: 'var(--reefpi-color-band-safe)' }]
+  }
+
+  const zones = []
+
+  if (warn) {
+    // critical (red) left of warn
+    if (warn[0] > min) {
+      zones.push({ left: 0, width: pct(warn[0]), color: 'var(--reefpi-color-band-critical)' })
+    }
+    // warn (yellow) left of safe
+    if (safe && safe[0] > warn[0]) {
+      zones.push({ left: pct(warn[0]), width: pct(safe[0]) - pct(warn[0]), color: 'var(--reefpi-color-band-warn)' })
+    }
+  } else if (safe) {
+    // no warn band — left of safe is critical
+    if (safe[0] > min) {
+      zones.push({ left: 0, width: pct(safe[0]), color: 'var(--reefpi-color-band-critical)' })
+    }
+  }
+
+  // safe (green) band
+  if (safe) {
+    zones.push({ left: pct(safe[0]), width: pct(safe[1]) - pct(safe[0]), color: 'var(--reefpi-color-band-safe)' })
+  }
+
+  if (warn) {
+    // warn (yellow) right of safe
+    if (safe && warn[1] > safe[1]) {
+      zones.push({ left: pct(safe[1]), width: pct(warn[1]) - pct(safe[1]), color: 'var(--reefpi-color-band-warn)' })
+    }
+    // critical (red) right of warn
+    if (warn[1] < max) {
+      zones.push({ left: pct(warn[1]), width: 100 - pct(warn[1]), color: 'var(--reefpi-color-band-critical)' })
+    }
+  } else if (safe) {
+    // no warn band — right of safe is critical
+    if (safe[1] < max) {
+      zones.push({ left: pct(safe[1]), width: 100 - pct(safe[1]), color: 'var(--reefpi-color-band-critical)' })
+    }
+  }
+
+  return zones
+}
+
+function zoneLabel (value, safe, warn) {
+  if (safe && value >= safe[0] && value <= safe[1]) return 'within safe range'
+  if (warn && value >= warn[0] && value <= warn[1]) return 'in warning zone'
+  return 'out of bounds'
+}
+
+export default function ThresholdGauge ({
+  value,
+  safe,
+  warn,
+  critical,
+  unit = '',
+  label = '',
+  onBoundsExceeded
+}) {
+  const min = critical ? critical[0] : (warn ? warn[0] : (safe ? safe[0] : 0))
+  const max = critical ? critical[1] : (warn ? warn[1] : (safe ? safe[1] : 100))
+
+  const clampedValue = Math.min(Math.max(value, min), max)
+  const indicatorPct = ((clampedValue - min) / (max - min)) * 100
+
+  const outOfBounds = value < min || value > max
+  const inWarn = !outOfBounds && warn && (value < (safe ? safe[0] : warn[0]) || value > (safe ? safe[1] : warn[1]))
+
+  React.useEffect(() => {
+    if (outOfBounds && onBoundsExceeded) onBoundsExceeded(value)
+  }, [value, outOfBounds, onBoundsExceeded])
+
+  const zones = buildZones(min, max, safe || null, warn || null)
+
+  const indicatorColor = outOfBounds
+    ? 'var(--reefpi-color-band-critical)'
+    : 'var(--reefpi-color-text-strong)'
+
+  const valueText = `${value}${unit}, ${zoneLabel(value, safe, warn)}`
+
+  return (
+    <div className='reefpi-threshold-gauge' style={{ width: '100%' }}>
+      {/* Value + label row */}
+      <div style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'baseline',
+        marginBottom: '6px'
+      }}>
+        <span style={{
+          fontSize: '0.875rem',
+          fontWeight: 500,
+          color: outOfBounds
+            ? 'var(--reefpi-color-error)'
+            : inWarn
+              ? 'var(--reefpi-color-warn)'
+              : 'var(--reefpi-color-text)'
+        }}>
+          {value}{unit}
+        </span>
+        {label && (
+          <span style={{
+            fontSize: '0.75rem',
+            color: 'var(--reefpi-color-text-muted)'
+          }}>
+            {label}
+          </span>
+        )}
+      </div>
+
+      {/* Track */}
+      <div
+        role='meter'
+        aria-label={label || 'Threshold gauge'}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={value}
+        aria-valuetext={valueText}
+        style={{
+          position: 'relative',
+          height: '14px',
+          borderRadius: '7px',
+          overflow: 'visible',
+          background: 'var(--reefpi-color-surface-elevated)',
+          border: '1px solid var(--reefpi-color-border)'
+        }}
+      >
+        {/* Coloured zone segments */}
+        <div style={{ position: 'absolute', inset: 0, borderRadius: '7px', overflow: 'hidden' }}>
+          {zones.map((z, i) => (
+            <div key={i} style={{
+              position: 'absolute',
+              top: 0,
+              bottom: 0,
+              left: `${z.left}%`,
+              width: `${z.width}%`,
+              background: z.color
+            }} />
+          ))}
+        </div>
+
+        {/* Needle drop */}
+        <div style={{
+          position: 'absolute',
+          top: '50%',
+          left: `${indicatorPct}%`,
+          transform: 'translate(-50%, -50%)',
+          width: '2px',
+          height: '20px',
+          background: indicatorColor,
+          borderRadius: '1px',
+          zIndex: 1
+        }} />
+
+        {/* Circular indicator */}
+        <div style={{
+          position: 'absolute',
+          top: '50%',
+          left: `${indicatorPct}%`,
+          transform: 'translate(-50%, -50%)',
+          width: '16px',
+          height: '16px',
+          borderRadius: '50%',
+          background: 'var(--reefpi-color-surface-elevated)',
+          border: `2px solid ${indicatorColor}`,
+          zIndex: 2
+        }} />
+      </div>
+
+      {/* Min / max labels */}
+      <div style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        marginTop: '4px'
+      }}>
+        <span style={{ fontSize: '0.65rem', color: 'var(--reefpi-color-text-muted)', fontFamily: 'var(--reefpi-font-mono)' }}>
+          {min}{unit}
+        </span>
+        <span style={{ fontSize: '0.65rem', color: 'var(--reefpi-color-text-muted)', fontFamily: 'var(--reefpi-font-mono)' }}>
+          {max}{unit}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+ThresholdGauge.propTypes = {
+  value: PropTypes.number.isRequired,
+  safe: PropTypes.arrayOf(PropTypes.number),
+  warn: PropTypes.arrayOf(PropTypes.number),
+  critical: PropTypes.arrayOf(PropTypes.number),
+  unit: PropTypes.string,
+  label: PropTypes.string,
+  onBoundsExceeded: PropTypes.func
+}


### PR DESCRIPTION
## Summary

- Adds `ui_kits/reef-pi-app/primitives/ThresholdGauge.jsx` — React component with `buildZones` logic splitting the track into critical/warn/safe segments
- All colors via `var(--reefpi-color-band-*)` and `var(--reefpi-color-*)` — zero raw hex literals
- `role="meter"` with `aria-valuemin/max/now/valuetext` for full accessibility
- `onBoundsExceeded` callback fires when value falls outside `critical` bounds; indicator turns red
- Adds `preview/primitives/threshold-gauge.html` — self-contained HTML storybook card with 5 stories

## Stories covered

| Story | value | Notes |
|---|---|---|
| Within safe range | 78.4 °F | indicator on green band |
| In warn zone | 75.1 °F | value + indicator turn warn-yellow |
| Out of bounds | 90.0 °F | indicator clamped to edge, turns red |
| No warn band | pH 8.2 | safe + critical zones only |
| No safe band | 35 ppt | warn + critical zones only |

## Parent epic

E2 · Monitoring primitives

## Test plan

- [ ] Open `preview/primitives/threshold-gauge.html` in browser — all 5 stories render without overlap or overflow
- [ ] Switch theme via `?theme=dark` and `?theme=actinic` query params — zones remain distinct
- [ ] No raw hex literals in new files (`grep -r '#[0-9a-fA-F]\{3,6\}' preview/primitives/ ui_kits/reef-pi-app/primitives/` → 0 results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)