### PR TITLE
Test doser chart rendering

### DIFF
--- a/front-end/src/doser/chart.test.js
+++ b/front-end/src/doser/chart.test.js
@@ -1,4 +1,5 @@
 import Chart, { RawDoserChart } from './chart'
+import { Bar, Tooltip, XAxis, YAxis } from 'recharts'
 import 'isomorphic-fetch'
 
 const doserConfig = { id: '1', name: 'Kalk Doser' }
@@ -23,14 +24,27 @@ describe('Doser Chart', () => {
     })
     expect(() => chart.render()).not.toThrow()
     const rendered = chart.render()
-    const renderedData = rendered.props.children[1].props.children.props.data
+    const responsiveContainer = rendered.props.children[1]
+    const barChart = responsiveContainer.props.children
+    const renderedData = barChart.props.data
+    const [bar, yAxis, xAxis, tooltip] = barChart.props.children
 
+    expect(rendered.props.children[0].props.children).toEqual(['Kalk Doser', ' - ', 'doser_usage'])
+    expect(responsiveContainer.props).toMatchObject({ height: 200, width: '100%' })
+    expect(barChart.props.barSize).toBe(8)
     expect(renderedData.map(item => item.pump)).toEqual([3, 5, 4])
     expect(renderedData.map(item => item.ts)).toEqual([
       renderedData[0].ts,
       renderedData[1].ts,
       renderedData[2].ts
     ].sort((a, b) => a - b))
+    expect(bar.type).toBe(Bar)
+    expect(bar.props).toMatchObject({ dataKey: 'pump', fill: '#33b5e5', isAnimationActive: false })
+    expect(yAxis.type).toBe(YAxis)
+    expect(yAxis.props.label).toBe('sec')
+    expect(xAxis.type).toBe(XAxis)
+    expect(xAxis.props).toMatchObject({ dataKey: 'ts', type: 'number', scale: 'time', domain: ['auto', 'auto'] })
+    expect(tooltip.type).toBe(Tooltip)
     expect(usage.historical).toEqual(originalHistorical)
     expect(usage.historical.map(item => item.ts)).toEqual([undefined, undefined, undefined])
     expect(Chart).toBeDefined()


### PR DESCRIPTION
## Summary
- assert doser usage chart title, container dimensions, bar size, and sorted data
- cover bar, y-axis label, x-axis, and tooltip wiring
- keep source usage immutability coverage

## Tests
- rtk yarn jest front-end/src/doser/chart.test.js --runInBand
- rtk yarn standard
- rtk git diff --check