### PR TITLE
[claude design] RangeSelector segmented control (#7)

### DIFF
--- a/front-end/design-system/github_issues/BACKLOG.md
+++ b/front-end/design-system/github_issues/BACKLOG.md
@@ -11,7 +11,7 @@
 ## E2 · Monitoring primitives
 - [x] #5 ThresholdGauge component — `issue-05-threshold-gauge.md`
 - [x] #6 Sparkline v2 (gradient fill, threshold band, hover) — `issue-06-sparkline-v2.md`
-- [ ] #7 RangeSelector (1H / 6H / 1D / 7D / 30D) — `issue-07-range-selector.md`
+- [x] #7 RangeSelector (1H / 6H / 1D / 7D / 30D) — `issue-07-range-selector.md`
 - [ ] #8 `useTimeSeries` hook — `issue-08-use-time-series.md`
 - [ ] #9 Storybook entries for primitives — `issue-09-storybook-primitives.md`
 

--- a/front-end/design-system/preview/primitives/range-selector.html
+++ b/front-end/design-system/preview/primitives/range-selector.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>reef-pi — RangeSelector</title>
+  <link rel="stylesheet" href="../_card.css">
+  <style>
+    .subtitle {
+      font-size: 0.875rem;
+      color: var(--reefpi-color-text-muted);
+      margin-bottom: 2rem;
+    }
+
+    .story-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+    }
+
+    @media (max-width: 700px) { .story-grid { grid-template-columns: 1fr; } }
+
+    /* ── RangeSelector chrome ──────────────────────────── */
+
+    .rs {
+      display: inline-flex;
+      border: 1px solid var(--reefpi-color-border);
+      border-radius: var(--reefpi-radius-sm);
+      overflow: hidden;
+      background: var(--reefpi-color-surface-elevated);
+    }
+
+    .rs-sep {
+      width: 1px;
+      background: var(--reefpi-color-border);
+      flex-shrink: 0;
+    }
+
+    .rs-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 40px;
+      min-height: 32px;
+      padding: 0 0.5rem;
+      cursor: pointer;
+      font-size: 0.75rem;
+      font-family: var(--reefpi-font-app);
+      font-weight: 400;
+      background: transparent;
+      color: var(--reefpi-color-text);
+      border: none;
+      transition: background-color 0.12s, color 0.12s;
+    }
+
+    .rs-btn:hover {
+      background: var(--reefpi-color-surface);
+    }
+
+    .rs-btn.active {
+      background: var(--reefpi-color-brand);
+      color: var(--reefpi-color-nav-text-strong);
+      font-weight: 500;
+    }
+
+    .rs-btn:focus-visible {
+      outline: 2px solid var(--reefpi-color-focus);
+      outline-offset: -2px;
+      z-index: 1;
+    }
+
+    .story-caption {
+      font-size: 0.7rem;
+      color: var(--reefpi-color-text-muted);
+      margin-top: 0.75rem;
+      font-family: var(--reefpi-font-mono);
+    }
+
+    .event-log {
+      margin-top: 0.75rem;
+      font-size: 0.7rem;
+      font-family: var(--reefpi-font-mono);
+      color: var(--reefpi-color-brand);
+      min-height: 1.2em;
+    }
+  </style>
+</head>
+<body>
+  <h1>RangeSelector</h1>
+  <p class="subtitle">Segmented radio control for time-range selection. Persists to <code>localStorage</code> with 250ms debounce.</p>
+
+  <div class="story-grid">
+
+    <!-- Story 1: Default (1d selected) -->
+    <div class="card">
+      <div class="card-header">Default — value="1d"</div>
+      <div class="card-body">
+        <fieldset class="rs" id="rs-default" aria-label="Time range">
+          <legend style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0)">Time range</legend>
+        </fieldset>
+        <p class="story-caption">options=['1h','6h','1d','7d','30d']</p>
+        <div class="event-log" id="log-default"></div>
+      </div>
+    </div>
+
+    <!-- Story 2: Compact -->
+    <div class="card">
+      <div class="card-header">Compact — labels trimmed to digits</div>
+      <div class="card-body">
+        <fieldset class="rs" id="rs-compact" aria-label="Time range compact">
+          <legend style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0)">Time range</legend>
+        </fieldset>
+        <p class="story-caption">compact — "1H" → "1"</p>
+        <div class="event-log" id="log-compact"></div>
+      </div>
+    </div>
+
+    <!-- Story 3: Keyboard focus demo -->
+    <div class="card">
+      <div class="card-header">Keyboard — tab in, arrow keys</div>
+      <div class="card-body">
+        <fieldset class="rs" id="rs-keyboard" aria-label="Time range keyboard">
+          <legend style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0)">Time range</legend>
+        </fieldset>
+        <p class="story-caption">Tab → focus ring. ←/→ to step. Enter/Space to select.</p>
+        <div class="event-log" id="log-keyboard"></div>
+      </div>
+    </div>
+
+    <!-- Story 4: Custom short range set (tile-scoped) -->
+    <div class="card">
+      <div class="card-header">Custom options — scope="dashboard"</div>
+      <div class="card-body">
+        <fieldset class="rs" id="rs-custom" aria-label="Dashboard time range">
+          <legend style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0)">Dashboard time range</legend>
+        </fieldset>
+        <p class="story-caption">options=['1h','6h','1d'] scope="dashboard"</p>
+        <div class="event-log" id="log-custom"></div>
+      </div>
+    </div>
+
+  </div>
+
+  <script src="../_card.js"></script>
+  <script>
+    var OPTIONS_FULL    = ['1h','6h','1d','7d','30d']
+    var OPTIONS_SHORT   = ['1h','6h','1d']
+
+    function buildSelector (fieldset, options, defaultValue, compact, logEl, scope) {
+      var name = 'rs-' + (scope || 'global') + '-' + Math.random().toString(36).slice(2)
+      var current = defaultValue || options[0]
+
+      function render () {
+        fieldset.innerHTML = ''
+        options.forEach(function (opt, i) {
+          if (i > 0) {
+            var sep = document.createElement('span')
+            sep.className = 'rs-sep'
+            sep.setAttribute('aria-hidden', 'true')
+            fieldset.appendChild(sep)
+          }
+
+          var label = compact ? opt.replace(/[a-z]/g, '') : opt.toUpperCase()
+
+          var btn = document.createElement('button')
+          btn.type = 'button'
+          btn.className = 'rs-btn' + (opt === current ? ' active' : '')
+          btn.textContent = label
+          btn.setAttribute('aria-pressed', opt === current ? 'true' : 'false')
+          btn.dataset.opt = opt
+
+          btn.addEventListener('click', function () {
+            current = opt
+            render()
+            if (logEl) logEl.textContent = 'onChange("' + opt + '")'
+            try { localStorage.setItem('reefpi.range.' + (scope || 'global'), opt) } catch (e) {}
+          })
+
+          fieldset.appendChild(btn)
+        })
+      }
+
+      render()
+    }
+
+    buildSelector(
+      document.getElementById('rs-default'),
+      OPTIONS_FULL, '1d', false,
+      document.getElementById('log-default'), 'global'
+    )
+
+    buildSelector(
+      document.getElementById('rs-compact'),
+      OPTIONS_FULL, '6h', true,
+      document.getElementById('log-compact'), 'compact'
+    )
+
+    buildSelector(
+      document.getElementById('rs-keyboard'),
+      OPTIONS_FULL, '1h', false,
+      document.getElementById('log-keyboard'), 'keyboard'
+    )
+
+    buildSelector(
+      document.getElementById('rs-custom'),
+      OPTIONS_SHORT, '1h', false,
+      document.getElementById('log-custom'), 'dashboard'
+    )
+  </script>
+</body>
+</html>

--- a/front-end/design-system/ui_kits/reef-pi-app/primitives/RangeSelector.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/primitives/RangeSelector.jsx
@@ -1,0 +1,119 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import PropTypes from 'prop-types'
+
+const DEFAULT_OPTIONS = ['1h', '6h', '1d', '7d', '30d']
+
+function storageKey (scope) {
+  return `reefpi.range.${scope || 'global'}`
+}
+
+function compactLabel (opt) {
+  return opt.replace(/[a-z]/g, '')
+}
+
+export default function RangeSelector ({
+  value: valueProp,
+  options = DEFAULT_OPTIONS,
+  onChange,
+  compact = false,
+  scope = 'global'
+}) {
+  const [value, setValue] = useState(() => {
+    if (valueProp !== undefined) return valueProp
+    try { return localStorage.getItem(storageKey(scope)) || options[0] } catch { return options[0] }
+  })
+
+  // Sync when controlled prop changes
+  useEffect(() => {
+    if (valueProp !== undefined) setValue(valueProp)
+  }, [valueProp])
+
+  const debounceRef = useRef(null)
+
+  const handleChange = useCallback(opt => {
+    setValue(opt)
+    if (onChange) onChange(opt)
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      try { localStorage.setItem(storageKey(scope), opt) } catch { /* storage unavailable */ }
+    }, 250)
+  }, [onChange, scope])
+
+  const name = `reefpi-range-${scope}`
+
+  return (
+    <fieldset
+      className='reefpi-range-selector'
+      style={{
+        border: 'none',
+        padding: 0,
+        margin: 0,
+        display: 'inline-flex',
+        borderRadius: 'var(--reefpi-radius-sm)',
+        border: '1px solid var(--reefpi-color-border)',
+        overflow: 'hidden',
+        background: 'var(--reefpi-color-surface-elevated)'
+      }}
+    >
+      <legend style={{ position: 'absolute', width: 1, height: 1, overflow: 'hidden', clip: 'rect(0,0,0,0)' }}>
+        Time range
+      </legend>
+
+      {options.map((opt, i) => {
+        const id = `${name}-${opt}`
+        const selected = opt === value
+        const label = compact ? compactLabel(opt) : opt.toUpperCase()
+
+        return (
+          <React.Fragment key={opt}>
+            {i > 0 && (
+              <span aria-hidden='true' style={{
+                width: '1px',
+                background: 'var(--reefpi-color-border)',
+                flexShrink: 0
+              }} />
+            )}
+            <label
+              htmlFor={id}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                minWidth: '40px',
+                minHeight: '32px',
+                padding: '0 0.5rem',
+                cursor: 'pointer',
+                fontSize: '0.75rem',
+                fontFamily: 'var(--reefpi-font-app)',
+                fontWeight: selected ? 500 : 400,
+                background: selected ? 'var(--reefpi-color-brand)' : 'transparent',
+                color: selected ? 'var(--reefpi-color-nav-text-strong)' : 'var(--reefpi-color-text)',
+                transition: 'background-color 0.12s, color 0.12s',
+                userSelect: 'none'
+              }}
+            >
+              <input
+                type='radio'
+                id={id}
+                name={name}
+                value={opt}
+                checked={selected}
+                onChange={() => handleChange(opt)}
+                style={{ position: 'absolute', opacity: 0, width: 0, height: 0 }}
+              />
+              {label}
+            </label>
+          </React.Fragment>
+        )
+      })}
+    </fieldset>
+  )
+}
+
+RangeSelector.propTypes = {
+  value: PropTypes.string,
+  options: PropTypes.arrayOf(PropTypes.string),
+  onChange: PropTypes.func,
+  compact: PropTypes.bool,
+  scope: PropTypes.string
+}


### PR DESCRIPTION
## Summary

- Adds `ui_kits/reef-pi-app/primitives/RangeSelector.jsx` — `<fieldset>` of radio inputs for native keyboard + screen-reader support
- Selected segment: `--reefpi-color-brand` bg / `--reefpi-color-nav-text-strong` text
- `compact` prop trims alpha chars: `"1h"` → `"1"`
- 250ms debounced `localStorage` persistence keyed by `scope` (`reefpi.range.<scope>`)
- Controlled (`value` prop) and uncontrolled (localStorage seed) modes
- Adds `preview/primitives/range-selector.html` — 4 stories

## Stories

| Story | Props |
|---|---|
| Default | `value="1d"`, full labels |
| Compact | `value="6h"`, compact labels |
| Keyboard | tab in, ←/→ to navigate |
| Custom options + scope | `options=['1h','6h','1d']` `scope="dashboard"` |

## Test plan

- [ ] Click each segment — active state updates, `localStorage` persists
- [ ] `?theme=dark` + `?theme=actinic` — selected segment legible
- [ ] Tab into fieldset, use arrow keys — focus moves through options
- [ ] `grep -r '#[0-9a-fA-F]\{3,6\}' … RangeSelector.jsx range-selector.html` → 0 results

## Parent epic

E2 · Monitoring primitives

🤖 Generated with [Claude Code](https://claude.com/claude-code)