### PR TITLE
Test driver form value fallbacks

### DIFF
--- a/front-end/src/drivers/driver.test.js
+++ b/front-end/src/drivers/driver.test.js
@@ -172,4 +172,22 @@ describe('driver UI', () => {
     expect(onSubmit).toHaveBeenCalledWith({ id: 1 }, { props: { onSubmit } })
     expect(DriverForm).toBeDefined()
   })
+
+  it('<DriverForm /> maps defaults for create', () => {
+    expect(mapDriverPropsToValues({})).toEqual({
+      id: '',
+      name: '',
+      type: '',
+      config: {}
+    })
+  })
+
+  it('<DriverForm /> fills missing edit fields with defaults', () => {
+    expect(mapDriverPropsToValues({ data: { id: 'driver-2', name: 'Secondary driver' } })).toEqual({
+      id: 'driver-2',
+      name: 'Secondary driver',
+      type: '',
+      config: {}
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- cover driver form create defaults
- cover partial edit data falling back to empty type and config values
- keep existing explicit map and submit coverage

## Tests
- rtk yarn jest front-end/src/drivers/driver.test.js --runInBand
- rtk yarn standard
- rtk git diff --check