### PR TITLE
Test macro form step mapping

### DIFF
--- a/front-end/src/macro/main.test.js
+++ b/front-end/src/macro/main.test.js
@@ -183,6 +183,30 @@ describe('Macro UI', () => {
     })
   })
 
+  it('<MacroForm /> maps alert and wait step config into flat form values', () => {
+    expect(mapMacroPropsToValues({
+      macro: {
+        id: '2',
+        name: 'Notify',
+        enable: true,
+        reversible: true,
+        steps: [
+          { type: 'alert', config: { title: 'ATO', message: 'Low reservoir' } },
+          { type: 'wait', config: { duration: 30 } }
+        ]
+      }
+    })).toEqual({
+      id: '2',
+      name: 'Notify',
+      enable: true,
+      reversible: true,
+      steps: [
+        { type: 'alert', duration: undefined, id: undefined, on: undefined, title: 'ATO', message: 'Low reservoir' },
+        { type: 'wait', duration: 30, id: undefined, on: undefined, title: undefined, message: undefined }
+      ]
+    })
+  })
+
   it('<MacroForm /> for edit with bad macro', () => {
     const badMacro = { name: 'bad' }
     expect(mapMacroPropsToValues({ macro: badMacro })).toEqual({


### PR DESCRIPTION
## Summary
- cover alert and wait macro step configs mapping into flat form values
- verify reversible/enabled macro fields pass through mapMacroPropsToValues
- keep existing create/edit/bad macro coverage intact

## Tests
- rtk yarn jest front-end/src/macro/main.test.js --runInBand
- rtk yarn standard
- rtk git diff --check