### PR TITLE
[claude design] Storybook index for E2 primitives (#9)

### DIFF
--- a/front-end/design-system/github_issues/BACKLOG.md
+++ b/front-end/design-system/github_issues/BACKLOG.md
@@ -13,7 +13,7 @@
 - [x] #6 Sparkline v2 (gradient fill, threshold band, hover) — `issue-06-sparkline-v2.md`
 - [x] #7 RangeSelector (1H / 6H / 1D / 7D / 30D) — `issue-07-range-selector.md`
 - [x] #8 `useTimeSeries` hook — `issue-08-use-time-series.md`
-- [ ] #9 Storybook entries for primitives — `issue-09-storybook-primitives.md`
+- [x] #9 Storybook entries for primitives — `issue-09-storybook-primitives.md`
 
 ## E3 · Dashboard v2 (flag: `dashboard_v2`)
 - [ ] #10 System status strip — `issue-10-system-strip.md`

--- a/front-end/design-system/preview/MANIFEST.md
+++ b/front-end/design-system/preview/MANIFEST.md
@@ -71,6 +71,17 @@ Before shipping a PR that touches tokens or components, verify each row is up to
 
 All preview cards load `_card.css` (shared base styles + Questrial + token import) and `_card.js` (query-string theme handler). Open any card with `?theme=dark` or `?theme=actinic` to preview it in that theme.
 
+## Components (E2)
+
+All stories live under `preview/primitives/`. Open with `?theme=dark` or `?theme=actinic` for theme verification. No network calls — fixtures only.
+
+| Component | Stories | Preview card |
+|---|---|---|
+| `ThresholdGauge` | within safe / in warn zone / out of bounds / no warn band / no safe band | [primitives/threshold-gauge.html](primitives/threshold-gauge.html) |
+| `Sparkline` | no fill / gradient fill / threshold band / band+hover / back-compat (number[]) | [primitives/sparkline.html](primitives/sparkline.html) |
+| `RangeSelector` | default / compact / keyboard / custom options+scope | [primitives/range-selector.html](primitives/range-selector.html) |
+| `useTimeSeries` | loading / loaded (120 pts LTTB) / error / stale-while-revalidate | [primitives/use-time-series.html](primitives/use-time-series.html) |
+
 ## CI scripts
 
 | Script | Command | Output |


### PR DESCRIPTION
## Summary

Registers all four E2 primitive preview cards in `preview/MANIFEST.md` under a new **Components** section. All HTML storybook files were already merged; this closes E2.

| Component | Stories | Card |
|---|---|---|
| ThresholdGauge | 5 | primitives/threshold-gauge.html |
| Sparkline | 5 | primitives/sparkline.html |
| RangeSelector | 4 | primitives/range-selector.html |
| useTimeSeries | 4 | primitives/use-time-series.html |

## Test plan
- [ ] Open MANIFEST.md — Components section renders with correct links
- [ ] Each linked card opens without 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)