### PR TITLE
[claude design] Sign-in confidence card (#24)

### DIFF
--- a/front-end/design-system/github_issues/BACKLOG.md
+++ b/front-end/design-system/github_issues/BACKLOG.md
@@ -34,6 +34,6 @@
 - [ ] #21 Bottom nav + drawer — `issue-21-bottom-nav.md`
 - [ ] #22 Dark theme pass — `issue-22-dark-pass.md`
 - [ ] #23 Actinic theme — `issue-23-actinic.md`
-- [ ] #24 Sign-in confidence card — `issue-24-signin-confidence.md`
+- [x] #24 Sign-in confidence card — `issue-24-signin-confidence.md`
 - [ ] #25 Empty states for every list page — `issue-25-empty-states.md`
 - [ ] #26 Theme picker + persistence — `issue-26-theme-picker.md`

--- a/front-end/design-system/preview/shell/signin-confidence.html
+++ b/front-end/design-system/preview/shell/signin-confidence.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>reef-pi — SignInConfidenceCard</title>
+  <link rel="stylesheet" href="../_card.css">
+  <style>
+    .subtitle { font-size: 0.875rem; color: var(--reefpi-color-text-muted); margin-bottom: 1.5rem; }
+
+    .signin-frame {
+      max-width: 360px;
+      margin: 0 auto;
+    }
+
+    .signin-form-mock {
+      background: var(--reefpi-color-surface-elevated);
+      border: 1px solid var(--reefpi-color-border);
+      border-radius: var(--reefpi-radius-md);
+      padding: 1.75rem;
+      font-family: var(--reefpi-font-app);
+    }
+
+    .form-title {
+      font-size: 1.25rem;
+      font-weight: 500;
+      color: var(--reefpi-color-text);
+      text-align: center;
+      margin-bottom: 1.25rem;
+    }
+
+    .form-field {
+      margin-bottom: 0.75rem;
+    }
+    .form-field label {
+      display: block;
+      font-size: 0.78rem;
+      font-weight: 500;
+      color: var(--reefpi-color-text-muted);
+      margin-bottom: 0.25rem;
+    }
+    .form-field input {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 0.5rem 0.75rem;
+      border: 1px solid var(--reefpi-color-border);
+      border-radius: var(--reefpi-radius-sm);
+      background: var(--reefpi-color-surface);
+      color: var(--reefpi-color-text);
+      font-family: var(--reefpi-font-app);
+      font-size: 0.875rem;
+      min-height: var(--reefpi-tap-target-min);
+    }
+
+    .signin-btn {
+      width: 100%;
+      min-height: var(--reefpi-tap-target-min);
+      background: var(--reefpi-gradient-brand);
+      border: none;
+      border-radius: var(--reefpi-radius-sm);
+      color: var(--reefpi-color-nav-text-strong);
+      font-family: var(--reefpi-font-app);
+      font-size: 0.875rem;
+      font-weight: 500;
+      cursor: pointer;
+      margin-top: 0.5rem;
+    }
+
+    /* ── Confidence card ────────────────────────── */
+    .confidence-card {
+      margin-top: 1.25rem;
+      padding: 0.75rem 1rem;
+      background: var(--reefpi-color-surface);
+      border: 1px solid var(--reefpi-color-border);
+      border-radius: var(--reefpi-radius-md);
+      text-align: center;
+      font-family: var(--reefpi-font-app);
+    }
+    .conf-name {
+      font-size: 0.85rem;
+      font-weight: 500;
+      color: var(--reefpi-color-text);
+      margin-bottom: 0.2rem;
+    }
+    .conf-meta {
+      font-size: 0.72rem;
+      color: var(--reefpi-color-text-muted);
+      font-family: var(--reefpi-font-mono);
+      line-height: 1.6;
+    }
+
+    .story-row { display: flex; gap: 2rem; flex-wrap: wrap; }
+  </style>
+</head>
+<body>
+<div class="card-page">
+  <header class="card-header">
+    <div class="card-title">SignInConfidenceCard</div>
+    <div class="card-desc">Below sign-in form · /api/meta · hides silently on error</div>
+    <div class="theme-toggle">
+      <button onclick="setTheme('')">Light</button>
+      <button onclick="setTheme('dark')">Dark</button>
+      <button onclick="setTheme('actinic')">Actinic</button>
+    </div>
+  </header>
+
+  <!-- Story 1: with data -->
+  <section class="story">
+    <h2 class="story-title">With controller info</h2>
+    <p class="subtitle">GET /api/meta returns name, IP, version, device, uptime</p>
+    <div class="signin-frame">
+      <div class="signin-form-mock">
+        <div class="form-title">Sign in</div>
+        <div class="form-field">
+          <label>Username</label>
+          <input type="text" placeholder="reef-pi" value="reef-pi" readonly>
+        </div>
+        <div class="form-field">
+          <label>Password</label>
+          <input type="password" placeholder="••••••••" value="password" readonly>
+        </div>
+        <button class="signin-btn">Sign in</button>
+      </div>
+      <footer aria-label="Controller info" class="confidence-card">
+        <div class="conf-name">My Reef Controller</div>
+        <div class="conf-meta">192.168.1.40 · v5.2.0</div>
+        <div class="conf-meta">Raspberry Pi 4 Model B · up 4d 6h</div>
+      </footer>
+    </div>
+  </section>
+
+  <!-- Story 2: minimal data -->
+  <section class="story">
+    <h2 class="story-title">Minimal (IP + version only)</h2>
+    <p class="subtitle">device and uptime fields absent from /api/meta response</p>
+    <div class="signin-frame">
+      <div class="signin-form-mock">
+        <div class="form-title">Sign in</div>
+        <div class="form-field">
+          <label>Username</label>
+          <input type="text" placeholder="reef-pi" readonly>
+        </div>
+        <div class="form-field">
+          <label>Password</label>
+          <input type="password" placeholder="••••••••" readonly>
+        </div>
+        <button class="signin-btn">Sign in</button>
+      </div>
+      <footer aria-label="Controller info" class="confidence-card">
+        <div class="conf-meta">10.0.0.5 · v5.2.0</div>
+      </footer>
+    </div>
+  </section>
+
+  <!-- Story 3: hidden (error) -->
+  <section class="story">
+    <h2 class="story-title">Hidden on fetch failure</h2>
+    <p class="subtitle">/api/meta unreachable — card renders nothing, no error banner</p>
+    <div class="signin-frame">
+      <div class="signin-form-mock">
+        <div class="form-title">Sign in</div>
+        <div class="form-field">
+          <label>Username</label>
+          <input type="text" placeholder="reef-pi" readonly>
+        </div>
+        <div class="form-field">
+          <label>Password</label>
+          <input type="password" placeholder="••••••••" readonly>
+        </div>
+        <button class="signin-btn">Sign in</button>
+      </div>
+      <!-- no confidence card — renders null -->
+      <p style="text-align:center;font-size:0.72rem;color:var(--reefpi-color-text-muted);font-family:var(--reefpi-font-mono);margin-top:0.5rem;">(card hidden — fetch failed silently)</p>
+    </div>
+  </section>
+</div>
+
+<script src="../_card.js"></script>
+</body>
+</html>

--- a/front-end/design-system/ui_kits/reef-pi-app/shell/SignInConfidenceCard.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/shell/SignInConfidenceCard.jsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
+
+/*
+ * Confirms the user is signing into the right controller.
+ * Fetched from unauthenticated GET /api/meta.
+ * Hides silently on fetch failure — never shows an error banner.
+ *
+ * Usage (below the sign-in form):
+ *   <SignInConfidenceCard endpoint='/api/meta' />
+ */
+
+function formatUptime (seconds) {
+  if (!seconds) return null
+  const d = Math.floor(seconds / 86400)
+  const h = Math.floor((seconds % 86400) / 3600)
+  if (d > 0) return `up ${d}d ${h}h`
+  const m = Math.floor((seconds % 3600) / 60)
+  return h > 0 ? `up ${h}h ${m}m` : `up ${m}m`
+}
+
+export default function SignInConfidenceCard ({ endpoint = '/api/meta' }) {
+  const [meta, setMeta] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    fetch(endpoint)
+      .then(r => r.ok ? r.json() : null)
+      .then(data => { if (!cancelled && data) setMeta(data) })
+      .catch(() => {})
+    return () => { cancelled = true }
+  }, [endpoint])
+
+  if (!meta) return null
+
+  const uptime = formatUptime(meta.uptime)
+
+  return (
+    <footer
+      aria-label='Controller info'
+      style={{
+        marginTop: '1.25rem',
+        padding: '0.75rem 1rem',
+        background: 'var(--reefpi-color-surface)',
+        border: '1px solid var(--reefpi-color-border)',
+        borderRadius: 'var(--reefpi-radius-md)',
+        textAlign: 'center',
+        fontFamily: 'var(--reefpi-font-app)'
+      }}
+    >
+      {meta.name && (
+        <div style={{ fontSize: '0.85rem', fontWeight: 500, color: 'var(--reefpi-color-text)', marginBottom: '0.2rem' }}>
+          {meta.name}
+        </div>
+      )}
+      <div style={{ fontSize: '0.72rem', color: 'var(--reefpi-color-text-muted)', fontFamily: 'var(--reefpi-font-mono)' }}>
+        {[meta.ip, meta.version].filter(Boolean).join(' · ')}
+      </div>
+      {(meta.device || uptime) && (
+        <div style={{ fontSize: '0.72rem', color: 'var(--reefpi-color-text-muted)', fontFamily: 'var(--reefpi-font-mono)', marginTop: '0.1rem' }}>
+          {[meta.device, uptime].filter(Boolean).join(' · ')}
+        </div>
+      )}
+    </footer>
+  )
+}
+
+SignInConfidenceCard.propTypes = {
+  endpoint: PropTypes.string
+}


### PR DESCRIPTION
## Summary
- Adds `SignInConfidenceCard`: fetches unauthenticated `GET /api/meta`, shows name, IP, version, device, uptime below sign-in form
- Hides completely on fetch error — no error banner, no flash
- `<footer aria-label="Controller info">` for screen readers
- Preview card: full data, minimal data (IP+version only), hidden-on-error stories

## Test plan
- [ ] Card renders with all fields when `/api/meta` returns `{name, ip, version, device, uptime}`
- [ ] Card renders IP+version only when `device`/`uptime` absent
- [ ] Card hides silently when fetch fails or returns non-200
- [ ] No error banner or broken UI on fetch failure
- [ ] `aria-label="Controller info"` present on footer element
🤖 Generated with [Claude Code](https://claude.com/claude-code)