### PR TITLE
Test timers main handlers

### DIFF
--- a/front-end/src/timers/timers.test.js
+++ b/front-end/src/timers/timers.test.js
@@ -7,6 +7,7 @@ import configureMockStore from 'redux-mock-store'
 import { thunk } from 'redux-thunk'
 import { RawTimersMain } from './main'
 import TimerForm from './timer_form'
+import Collapsible from '../ui_components/collapsible'
 import 'isomorphic-fetch'
 
 jest.mock('utils/confirm', () => {
@@ -38,6 +39,19 @@ const timerData = {
   minute: '*',
   second: '0',
   duration: 10
+}
+
+const findNodes = (node, predicate, acc = []) => {
+  if (!node || typeof node !== 'object') {
+    return acc
+  }
+  if (predicate(node)) {
+    acc.push(node)
+  }
+  React.Children.toArray(node.props?.children).forEach(child => {
+    findNodes(child, predicate, acc)
+  })
+  return acc
 }
 
 describe('Timer ui', () => {
@@ -136,6 +150,95 @@ describe('Timer ui', () => {
       }
     })
     expect(component.state.addTimer).toBe(false)
+  })
+
+  it('<Main /> updates timers using normalized payloads', () => {
+    const props = makeProps({ update: jest.fn() })
+    const component = new RawTimersMain(props)
+
+    component.handleUpdateTimer({
+      ...timerData,
+      id: 'timer-id',
+      month: '*',
+      week: '*',
+      target: {
+        id: 'eq-1',
+        on: false,
+        duration: '45',
+        revert: false
+      }
+    })
+
+    expect(props.update).toHaveBeenCalledWith('timer-id', {
+      name: 'foo',
+      type: 'equipment',
+      month: '*',
+      week: '*',
+      day: '*',
+      hour: '*',
+      minute: '*',
+      second: '0',
+      enable: false,
+      target: {
+        id: 'eq-1',
+        on: false,
+        duration: 45,
+        revert: false
+      }
+    })
+  })
+
+  it('<Main /> leaves timer target duration absent when not provided', () => {
+    const component = new RawTimersMain(makeProps())
+
+    expect(component.valuesToTimer({
+      name: 'reminder',
+      type: 'reminder',
+      month: '*',
+      week: '*',
+      day: '*',
+      hour: '12',
+      minute: '30',
+      second: '0',
+      enable: true,
+      target: { title: 'Dose', message: 'Check pump' }
+    }).target).toEqual({ title: 'Dose', message: 'Check pump' })
+  })
+
+  it('<Main /> timer list toggle flips enable state and updates timer', () => {
+    const timer = { ...timerData, enable: false }
+    const props = makeProps({ timers: [timer], update: jest.fn() })
+    const component = new RawTimersMain(props)
+
+    component.timerList()[0].props.onToggleState()
+
+    expect(timer.enable).toBe(true)
+    expect(props.update).toHaveBeenCalledWith('1', timer)
+  })
+
+  it('<Main /> renders add form and add button state when addTimer is true', () => {
+    const component = new RawTimersMain(makeProps({ timers: [] }))
+    component.state.addTimer = true
+
+    const rendered = component.render()
+    const addButton = findNodes(rendered, node => node.type === 'input' && node.props.id === 'add_timer')[0]
+    const form = findNodes(rendered, node => node.type === TimerForm)[0]
+
+    expect(addButton.props.value).toBe('-')
+    expect(form.props.onSubmit).toBe(component.handleSubmit)
+    expect(form.props.equipment).toBe(component.props.equipment)
+    expect(form.props.macros).toBe(component.props.macros)
+  })
+
+  it('<Main /> passes readOnly timer setting to TimerForm', () => {
+    const timer = { ...timerData, readOnly: true }
+    const component = new RawTimersMain(makeProps({ timers: [timer] }))
+    const panel = component.timerList()[0]
+    const form = findNodes(panel, node => node.type === TimerForm)[0]
+
+    expect(panel.type).toBe(Collapsible)
+    expect(form.props.readOnly).toBe(true)
+    expect(form.props.timer).toBe(timer)
   })
 
   it('<TimerForm /> for create', () => {


### PR DESCRIPTION
## Summary
- cover timer update normalization, missing duration handling, enable toggle, add form rendering, and readOnly passthrough

## Coverage target
front-end/src/timers/main.jsx

## Tests
- rtk yarn jest front-end/src/timers/timers.test.js --runInBand
- rtk yarn standard
- rtk git diff --check