### PR TITLE
Test light form profile mapping

### DIFF
--- a/front-end/src/lighting/lighting.test.js
+++ b/front-end/src/lighting/lighting.test.js
@@ -251,6 +251,27 @@ describe('Lighting ui', () => {
     )).toContain('form-light-1')
   })
 
+  it('<LightForm /> maps legacy auto profiles to interval profiles', () => {
+    const config = {
+      ...light,
+      channels: {
+        1: {
+          ...light.channels[1],
+          profile: {
+            ...light.channels[1].profile,
+            type: 'auto'
+          }
+        }
+      }
+    }
+
+    renderToStaticMarkup(
+      <LightForm onSubmit={jest.fn()} config={config} jacks={[{ id: '1', name: 'foo' }]} />
+    )
+
+    expect(config.channels[1].profile.type).toBe('interval')
+  })
+
   it('<Light /> should submit', () => {
     const fn = jest.fn()
     const values = { config: light }


### PR DESCRIPTION
## Summary
- cover LightForm mapping of legacy auto profiles to interval profiles

## Coverage target
front-end/src/lighting/light_form.jsx

## Tests
- rtk yarn jest front-end/src/lighting/lighting.test.js --runInBand
- rtk yarn standard
- rtk git diff --check