### PR TITLE
[claude design] F1: no-flash theme script, FEATURE_FLAGS init, missing CSS tokens

### DIFF
--- a/front-end/assets/home.html
+++ b/front-end/assets/home.html
@@ -4,8 +4,10 @@
     <title>reef-pi</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <script>(function(){var t=localStorage.getItem('reefpi.theme')||'system';var r=t==='system'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):t;if(r!=='light')document.documentElement.setAttribute('data-theme',r);})();</script>
   </head>
   <body>
     <div id="main-panel"></div>
+    <script>window.FEATURE_FLAGS = window.FEATURE_FLAGS || {};</script>
   </body>
 </html>

--- a/front-end/assets/sass/style.scss
+++ b/front-end/assets/sass/style.scss
@@ -39,6 +39,16 @@
   --reefpi-radius-md: #{$radius-md};
   --reefpi-tap-target-min: 2.75rem;
 
+  // Typography
+  --reefpi-font-app:  'Century Gothic', CenturyGothic, Geneva, AppleGothic, sans-serif;
+  --reefpi-font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+
+  // Gradient (navbar + shell components)
+  --reefpi-gradient-brand: linear-gradient(180deg, #{$main-color} 0%, #{$main-alternate-color} 100%);
+
+  // Shadow
+  --reefpi-shadow-navbar: 0 2px 8px #{$shadow-color};
+
   // State tokens (E1 #1)
   --reefpi-color-pending:        #{$color-pending};
   --reefpi-color-pending-bg:     #{$color-pending-bg};

--- a/front-end/design-system/github_issues/INTEGRATION_BACKLOG.md
+++ b/front-end/design-system/github_issues/INTEGRATION_BACKLOG.md
@@ -1,0 +1,91 @@
+# Integration Backlog — wiring UI kit into reef-pi app
+
+> One PR per row. Commit prefix: `[claude design]`. Read `CLAUDE.md` + `SKILL.md` first.
+> All issues target `front-end/src/` (the live app), not the design-system preview cards.
+
+## F1 · CSS Foundation (prerequisite for all F2+)
+- [ ] #2913 Inject design system token CSS + no-flash theme script into `home.html` + `entry.js`
+
+## F2 · Shell (flag: `new_shell`)
+- [ ] #2914 Replace Bootstrap top navbar with `Sidebar` + `BottomNav` in `main_panel.jsx`
+
+## F3 · Sign-in page
+- [ ] #2915 Wrap sign-in form with `SignInConfidenceCard` layout
+
+## F4 · Theme system
+- [ ] #2916 Wire `useTheme` hook + `ThemePicker` into `configuration/settings` appearance section
+
+## F5 · Equipment — toggle states (flag: `pending_states`)
+- [ ] #2917 Replace `react-toggle-switch` with `ToggleSwitch` + `useEquipmentToggle` in `view_equipment.jsx` + `ctrl_panel.jsx`
+
+## F6 · Alert center (flag: `alert_center`)
+- [ ] #2918 Bridge Redux `alerts` → `useAlertsStore`; replace `NotificationAlert` with `AlertCenter` slide-over + bell
+
+## F7 · Dashboard v2 wire-up (flag: `dashboard_v2`)
+- [ ] #2919 Wire `DashboardV2` into `dashboard/main.jsx` with live API data (temp, pH, ATO, equipment, health)
+
+## F8 · Temperature module — monitoring primitives
+- [ ] #2920 Wire `RangeSelector` + `useTimeSeries` + `Sparkline` + `ThresholdGauge` into `temperature/main.jsx`
+
+## F9 · pH module — monitoring primitives
+- [ ] #2921 Wire `RangeSelector` + `useTimeSeries` + `Sparkline` + `ThresholdGauge` into `ph/main.jsx`
+
+## F10 · ATO module — monitoring primitives
+- [ ] #2922 Wire `RangeSelector` + `useTimeSeries` + `Sparkline` into `ato/main.jsx`
+
+## F11 · Doser module — monitoring primitives
+- [ ] #2923 Wire `RangeSelector` + `useTimeSeries` + `Sparkline` into `doser/main.jsx`
+
+## F12 · Empty states across all list modules
+- [ ] #2924 Wire `EmptyState` to: equipment, timers, lighting, doser, ATO, pH, macro, camera, journal
+
+---
+
+## Sequencing
+
+```
+F1 (CSS foundation)  ──▶ unlocks all others (tokens available in app)
+F2 (Shell)           ──▶ after F1; unlocks F6 (bell placement)
+F3 (Sign-in)         ──▶ after F1; standalone
+F4 (Theme)           ──▶ after F1; standalone
+F5 (Equipment)       ──▶ after F1; standalone toggle replacement
+F6 (Alert center)    ──▶ after F2 (shell must have bell slot)
+F7 (Dashboard v2)    ──▶ after F1, F5 (equipment toggle); parallel with F8-F11
+F8-F11 (Primitives)  ──▶ after F1; can run in parallel per module
+F12 (Empty states)   ──▶ after F1; standalone per module
+```
+
+## File map
+
+| Source module | Key files |
+|---|---|
+| Shell | `front-end/src/main_panel.jsx`, `front-end/assets/home.html`, `front-end/src/entry.js` |
+| Sign-in | `front-end/src/sign_in.jsx` |
+| Configuration | `front-end/src/configuration/settings.jsx` |
+| Equipment | `front-end/src/equipment/view_equipment.jsx`, `ctrl_panel.jsx` |
+| Notifications | `front-end/src/notifications/alert.jsx`, `utils/alert.js` |
+| Dashboard | `front-end/src/dashboard/main.jsx` |
+| Temperature | `front-end/src/temperature/main.jsx`, `readings_chart.jsx`, `control_chart.jsx` |
+| pH | `front-end/src/ph/main.jsx` |
+| ATO | `front-end/src/ato/main.jsx`, `chart.jsx` |
+| Doser | `front-end/src/doser/main.jsx`, `chart.jsx` |
+| List modules | `equipment/main.jsx`, `timers/main.jsx`, `lighting/main.jsx`, `doser/main.jsx`, `ato/main.jsx`, `ph/main.jsx`, `macro/main.jsx`, `camera/main.jsx`, `journal/main.jsx` |
+
+## UI kit source paths
+
+| Kit component / hook | Path |
+|---|---|
+| `Sidebar` | `front-end/design-system/ui_kits/reef-pi-app/shell/Sidebar.jsx` |
+| `BottomNav` | `front-end/design-system/ui_kits/reef-pi-app/shell/BottomNav.jsx` |
+| `ThemePicker` + `useTheme` | `shell/ThemePicker.jsx`, `hooks/useTheme.js` |
+| `SignInConfidenceCard` | `shell/SignInConfidenceCard.jsx` |
+| `EmptyState` | `shell/EmptyState.jsx` |
+| `AlertCenter` | `dashboard/AlertCenter.jsx` |
+| `useAlertsStore` | `hooks/useAlertsStore.js` |
+| `ToggleSwitch` | `primitives/ToggleSwitch.jsx` |
+| `useEquipmentToggle` | `hooks/useEquipmentToggle.js` |
+| `DashboardV2` | `dashboard/DashboardV2.jsx` |
+| `ThresholdGauge` | `primitives/ThresholdGauge.jsx` |
+| `Sparkline` | `primitives/Sparkline.jsx` |
+| `RangeSelector` | `primitives/RangeSelector.jsx` |
+| `useTimeSeries` | `hooks/useTimeSeries.js` |


### PR DESCRIPTION
## Summary
- `home.html`: inline no-flash script restores dark/actinic theme before first paint; `window.FEATURE_FLAGS` guard prevents `?.` throws in all downstream flag checks
- `style.scss`: adds `--reefpi-font-app`, `--reefpi-font-mono`, `--reefpi-gradient-brand`, `--reefpi-shadow-navbar` — tokens referenced by Sidebar, BottomNav, EmptyState kit components
- `INTEGRATION_BACKLOG.md`: full 12-issue integration plan with GitHub issue links (#2913–#2924)

## Test plan
- [ ] Hard-refresh with `localStorage.reefpi.theme = 'dark'` set — no light flash before CSS loads
- [ ] `window.FEATURE_FLAGS` exists in console without errors
- [ ] `var(--reefpi-gradient-brand)` resolves in DevTools Elements panel

Closes #2913

🤖 Generated with [Claude Code](https://claude.com/claude-code)