### PR TITLE
[claude design] F3: add SignInConfidenceCard to sign-in page

### DIFF
--- a/front-end/src/sign_in.jsx
+++ b/front-end/src/sign_in.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import i18n from 'utils/i18n'
 import { isSignedIn, signIn, signOut } from './session_api'
+import SignInConfidenceCard from '../design-system/ui_kits/reef-pi-app/shell/SignInConfidenceCard'
 
 export default class SignIn extends React.Component {
   constructor (props) {
@@ -119,6 +120,7 @@ export default class SignIn extends React.Component {
                 </button>
               </div>
             </form>
+            <SignInConfidenceCard />
           </div>
         </div>
       </div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,7 @@ var config = {
       },
       {
         test: /\.jsx?/,
-        include: APP_DIR,
+        include: [APP_DIR, path.resolve(__dirname, 'front-end', 'design-system')],
         loader: 'babel-loader',
         options: {
           presets: [['@babel/preset-env', { modules: false }], '@babel/preset-react']


### PR DESCRIPTION
## Summary
Mounts `SignInConfidenceCard` below the sign-in form. It fetches `GET /api/meta` (unauthenticated) and renders controller name, IP, version, and uptime — confirming the user is connecting to the right device. Renders nothing on fetch failure (offline / unreachable).

## Test plan
- [ ] Sign-in page shows controller info card when the API is reachable
- [ ] No visible change when `/api/meta` is unreachable
- [ ] Existing login flow unaffected
- [ ] Dark / actinic themes render correctly

Depends on: #2925 (F1 — tokens)
Closes #2915

🤖 Generated with [Claude Code](https://claude.com/claude-code)