### PR TITLE
[claude design] F4: ThemePicker + useTheme system listener

### DIFF
--- a/front-end/src/app.jsx
+++ b/front-end/src/app.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import $ from 'jquery'
 import MainPanel from 'main_panel'
 import SignIn from 'sign_in'

--- a/front-end/src/app.jsx
+++ b/front-end/src/app.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import $ from 'jquery'
 import MainPanel from 'main_panel'
 import SignIn from 'sign_in'
@@ -6,6 +6,13 @@ import 'style.scss'
 import 'bootstrap/dist/js/bootstrap.min.js'
 import 'react-toggle-switch/dist/css/switch.min.css'
 import i18n from 'utils/i18n'
+import { useTheme } from '../design-system/ui_kits/reef-pi-app/hooks/useTheme'
+
+// Mounts the system-preference change listener for the duration of the session
+function ThemeInitializer () {
+  useTheme()
+  return null
+}
 
 export default class App extends React.Component {
   constructor (props) {
@@ -41,7 +48,12 @@ export default class App extends React.Component {
     if (!this.state.loaded) {
       return <div>{i18n.t('loading')}</div>
     } else {
-      return this.getComponent()
+      return (
+        <>
+          <ThemeInitializer />
+          {this.getComponent()}
+        </>
+      )
     }
   }
 }

--- a/front-end/src/configuration/settings.jsx
+++ b/front-end/src/configuration/settings.jsx
@@ -7,6 +7,7 @@ import { updateSettings, fetchSettings } from 'redux/actions/settings'
 import { connect } from 'react-redux'
 import SettingsSchema from './settings_schema'
 import i18n from 'utils/i18n'
+import ThemePicker from '../../design-system/ui_kits/reef-pi-app/shell/ThemePicker'
 
 export class RawSettings extends React.Component {
   constructor (props) {
@@ -302,6 +303,12 @@ export class RawSettings extends React.Component {
             {this.checkBoxComponent('pprof')}
             {this.checkBoxComponent('prometheus')}
             {this.checkBoxComponent('cors')}
+          </div>
+        </div>
+        <hr />
+        <div className='row'>
+          <div className='col-12'>
+            <ThemePicker />
           </div>
         </div>
         <hr />

--- a/front-end/test/setup.js
+++ b/front-end/test/setup.js
@@ -9,3 +9,15 @@ class ResizeObserver {
 }
 
 global.ResizeObserver = ResizeObserver
+
+global.matchMedia = global.matchMedia || function (query) {
+  return {
+    matches: false,
+    media: query,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,7 @@ var config = {
       },
       {
         test: /\.jsx?/,
-        include: APP_DIR,
+        include: [APP_DIR, path.resolve(__dirname, 'front-end', 'design-system')],
         loader: 'babel-loader',
         options: {
           presets: [['@babel/preset-env', { modules: false }], '@babel/preset-react']


### PR DESCRIPTION
## Summary
- `settings.jsx`: renders `ThemePicker` fieldset (Light / Dark / Actinic / System) above Capabilities; writes to `localStorage.reefpi.theme` and toggles `data-theme` on `<html>` immediately
- `app.jsx`: mounts `ThemeInitializer` (calls `useTheme`) so the `prefers-color-scheme` media query listener stays active for the full session, not just while the settings page is open

## Test plan
- [ ] Configuration › Settings shows Appearance fieldset with four theme options
- [ ] Selecting Dark switches UI to dark theme immediately
- [ ] Hard-refresh restores the chosen theme (the no-flash script from #2925 handles the pre-JS flash)
- [ ] System option tracks `prefers-color-scheme` without page reload

Depends on: #2925 (F1)
Closes #2916

🤖 Generated with [Claude Code](https://claude.com/claude-code)