### PR TITLE
Test equipment form value mapping

### DIFF
--- a/front-end/src/equipment/equipment.test.js
+++ b/front-end/src/equipment/equipment.test.js
@@ -325,6 +325,44 @@ describe('Equipment ui', () => {
     expect(html).toContain('smoke-equipment-name')
   })
 
+  it('<EquipmentForm /> maps defaults for create mode', () => {
+    const html = renderToStaticMarkup(
+      <EquipmentForm
+        actionLabel='add'
+        outlets={[{ id: '1', name: 'O1' }]}
+        onSubmit={() => true}
+      />
+    )
+
+    expect(html).toContain('name="name"')
+    expect(html).toContain('name="outlet"')
+    expect(html).toContain('name="boot_delay"')
+    expect(html).toContain('value="0"')
+  })
+
+  it('<EquipmentForm /> maps edit values including boot flags', () => {
+    const html = renderToStaticMarkup(
+      <EquipmentForm
+        actionLabel='save'
+        equipment={{
+          id: 'eq-1',
+          name: 'Heater',
+          outlet: '1',
+          on: true,
+          stay_off_on_boot: true,
+          boot_delay: 15
+        }}
+        outlets={[{ id: '1', name: 'O1' }]}
+        remove
+        onSubmit={() => true}
+      />
+    )
+
+    expect(html).toContain('value="Heater"')
+    expect(html).toContain('value="15"')
+    expect(html).toContain('checked=""')
+  })
+
   it('<Chart />', () => {
     jest.useFakeTimers()
     const fetchEquipment = jest.fn()


### PR DESCRIPTION
## Summary
- add create-mode coverage for EquipmentForm default value mapping
- add edit-mode coverage for pins, labels, names, and boot flag mapping

## Tests
- rtk yarn jest front-end/src/equipment/equipment.test.js --runInBand
- rtk yarn standard
- rtk git diff --check