### PR TITLE
[claude design] F5: ToggleSwitch + pending states for equipment (pending_states flag)

### DIFF
--- a/front-end/src/equipment/ctrl_panel.jsx
+++ b/front-end/src/equipment/ctrl_panel.jsx
@@ -1,8 +1,42 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import { fetchEquipment, updateEquipment } from '../redux/actions/equipment'
 import { connect } from 'react-redux'
 import Switch from 'react-toggle-switch'
+import ToggleSwitch from '../../design-system/ui_kits/reef-pi-app/primitives/ToggleSwitch'
+import { useEquipmentToggle } from '../../design-system/ui_kits/reef-pi-app/hooks/useEquipmentToggle'
 import { buildEquipmentPayload, EQUIPMENT_POLL_INTERVAL_MS, sortEquipment } from './utils'
+
+// Per-item toggle with pending states — must be its own component to call hooks
+function PendingEquipmentToggle ({ item, dispatch }) {
+  const send = useCallback(next => {
+    const payload = buildEquipmentPayload(item, { on: next === 'on' })
+    return fetch(`/api/equipment/${item.id}`, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    }).then(r => {
+      if (!r.ok) throw new Error(`HTTP ${r.status}`)
+      dispatch(fetchEquipment())
+    })
+  }, [item, dispatch])
+
+  const { mutate, state, retry } = useEquipmentToggle({
+    id:   item.id,
+    name: item.name,
+    send
+  })
+
+  return (
+    <ToggleSwitch
+      state={state === 'idle' || state === 'ok'
+        ? (item.on ? 'on' : 'off')
+        : state}
+      onRequestChange={next => mutate(next)}
+      onRetry={retry}
+    />
+  )
+}
 
 export class RawEquipmentCtrlPanel extends React.Component {
   constructor (props) {
@@ -29,39 +63,39 @@ export class RawEquipmentCtrlPanel extends React.Component {
       return <div />
     }
 
+    const usePending = !!window.FEATURE_FLAGS?.pending_states
+
     return (
       <div className='container' style={{ marginBottom: '3px' }}>
         <div className='row'>
           {sortEquipment(this.props.equipment)
-            .map(item => {
-              return (
-                <div className='col-12 col-sm-6 col-md-2 col-lg-3 order-sm-3' key={'eq-' + item.id}>
-                  <label className='d-inline-flex align-items-center mb-0'>
-                    <Switch on={item.on} onClick={(e) => { this.toggleState(e, item) }} />
-                    <span className='ml-2'>{item.name}</span>
-                  </label>
-                </div>
-              )
-            })}
+            .map(item => (
+              <div className='col-12 col-sm-6 col-md-2 col-lg-3 order-sm-3' key={'eq-' + item.id}>
+                <label className='d-inline-flex align-items-center mb-0'>
+                  {usePending
+                    ? <PendingEquipmentToggle item={item} dispatch={this.props.dispatch} />
+                    : <Switch on={item.on} onClick={(e) => { this.toggleState(e, item) }} />}
+                  <span className='ml-2'>{item.name}</span>
+                </label>
+              </div>
+            ))}
         </div>
       </div>
     )
   }
 }
 
-const mapStateToProps = state => {
-  return {
-    equipment: state.equipment,
-    outlets: state.outlets
-  }
-}
+const mapStateToProps = (state, ownProps) => ({
+  equipment: state.equipment,
+  outlets: state.outlets,
+  dispatch: ownProps.dispatch
+})
 
-const mapDispatchToProps = dispatch => {
-  return {
-    fetchEquipment: () => dispatch(fetchEquipment()),
-    updateEquipment: (id, e) => dispatch(updateEquipment(id, e))
-  }
-}
+const mapDispatchToProps = dispatch => ({
+  fetchEquipment: () => dispatch(fetchEquipment()),
+  updateEquipment: (id, e) => dispatch(updateEquipment(id, e)),
+  dispatch
+})
 
 const EquipmentCtrlPanel = connect(
   mapStateToProps,

--- a/front-end/src/equipment/view_equipment.jsx
+++ b/front-end/src/equipment/view_equipment.jsx
@@ -1,11 +1,52 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import PropTypes from 'prop-types'
 import Switch from 'react-toggle-switch'
 import { FaEdit, FaTrashAlt } from 'react-icons/fa'
 import i18next from 'i18next'
+import ToggleSwitch from '../../design-system/ui_kits/reef-pi-app/primitives/ToggleSwitch'
+import { useEquipmentToggle } from '../../design-system/ui_kits/reef-pi-app/hooks/useEquipmentToggle'
+
+// Wraps ViewEquipment with pending-states UX when pending_states flag is on
+function PendingToggle ({ equipment, onStateChange }) {
+  const send = useCallback(next => {
+    const payload = {
+      name: equipment.name,
+      on: next === 'on',
+      outlet: equipment.outlet,
+      stay_off_on_boot: equipment.stay_off_on_boot
+    }
+    return fetch(`/api/equipment/${equipment.id}`, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    }).then(r => {
+      if (!r.ok) throw new Error(`HTTP ${r.status}`)
+      onStateChange(equipment.id, payload)
+    })
+  }, [equipment, onStateChange])
+
+  const { mutate, state, retry } = useEquipmentToggle({
+    id:   equipment.id,
+    name: equipment.name,
+    send
+  })
+
+  return (
+    <ToggleSwitch
+      state={state === 'idle' || state === 'ok'
+        ? (equipment.on ? 'on' : 'off')
+        : state}
+      onRequestChange={next => mutate(next)}
+      onRetry={retry}
+    />
+  )
+}
 
 const ViewEquipment = ({ equipment, outletName, onStateChange, onDelete, onEdit }) => {
-  const toggleState = (e) => {
+  const usePending = !!window.FEATURE_FLAGS?.pending_states
+
+  const toggleState = () => {
     const payload = {
       name: equipment.name,
       on: !equipment.on,
@@ -24,9 +65,13 @@ const ViewEquipment = ({ equipment, outletName, onStateChange, onDelete, onEdit 
         <small>{outletName}</small>
       </div>
       <div className='p-2'>
-        <Switch onClick={toggleState} on={equipment.on}>
-          <small className='ml-1 align-top'>{equipment.on ? i18next.t('on') : i18next.t('off')}</small>
-        </Switch>
+        {usePending
+          ? <PendingToggle equipment={equipment} onStateChange={onStateChange} />
+          : (
+            <Switch onClick={toggleState} on={equipment.on}>
+              <small className='ml-1 align-top'>{equipment.on ? i18next.t('on') : i18next.t('off')}</small>
+            </Switch>
+            )}
       </div>
       <div className='p2'>
         <div className='d-inline p-2' onClick={onEdit}>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,7 @@ var config = {
       },
       {
         test: /\.jsx?/,
-        include: APP_DIR,
+        include: [APP_DIR, path.resolve(__dirname, 'front-end', 'design-system')],
         loader: 'babel-loader',
         options: {
           presets: [['@babel/preset-env', { modules: false }], '@babel/preset-react']


### PR DESCRIPTION
## Summary
Replaces `react-toggle-switch` with `ToggleSwitch` + `useEquipmentToggle` in both equipment toggle locations, behind the `pending_states` flag.

**`view_equipment.jsx`** — `PendingToggle` functional component:
- Uses `useEquipmentToggle` with a direct `fetch()` `send` function so HTTP errors propagate as rejections (Redux's `postAction` swallows errors)
- On success, calls `onStateChange(id, payload)` to update Redux via the existing parent path
- `state` from `useEquipmentToggle` maps to `ToggleSwitch` state: `idle|ok → on|off`, `pending → pending`, `error → error`

**`ctrl_panel.jsx`** — `PendingEquipmentToggle` component per list item:
- Same direct-fetch pattern; dispatches `fetchEquipment()` on success to sync store
- `dispatch` threaded through `mapDispatchToProps` so the hook component can trigger the refresh

Without the flag, both files fall back to existing `react-toggle-switch` behaviour — no test regressions.

## Test plan
- [ ] `window.FEATURE_FLAGS = { pending_states: true }` — throttle Network to Slow 3G, toggle equipment — spinner ring visible for ~1–3s
- [ ] Simulate 500 from DevTools — red error ring + Retry button appear
- [ ] Retry re-enters pending state
- [ ] Without flag — existing toggle behaviour unchanged

Depends on: #2925 (F1), #2918 (F6 — alert on exhausted retries)
Closes #2917

🤖 Generated with [Claude Code](https://claude.com/claude-code)