### PR TITLE
[claude design] F6: Alert center bridge

### DIFF
--- a/front-end/src/main_panel.jsx
+++ b/front-end/src/main_panel.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { BrowserRouter, Routes, NavLink, useLocation } from 'react-router-dom'
 import NotificationAlert from 'notifications/alert'
+import { AlertCenterBell } from '../design-system/ui_kits/reef-pi-app/dashboard/AlertCenter'
 import { fetchUIData } from 'redux/actions/ui'
 import { fetchInfo } from 'redux/actions/info'
 import { connect } from 'react-redux'
@@ -76,7 +77,7 @@ export class RawMainPanel extends React.Component {
           </nav>
           <div className='container-fluid'>
             <FatalError />
-            <NotificationAlert />
+            {window.FEATURE_FLAGS?.alert_center ? <AlertCenterBell /> : <NotificationAlert />}
             <div className='row body-panel'>
               <div className='col'>
                 <ErrorBoundary>

--- a/front-end/src/utils/alert.js
+++ b/front-end/src/utils/alert.js
@@ -2,6 +2,14 @@ import { setAlert } from 'notifications/statics'
 import { addAlert, delAlert } from 'redux/actions/alert'
 import { MsgLevel } from 'utils/enums'
 import i18n from 'utils/i18n'
+import { dispatchAlert as dispatchToAlertCenter } from '../../design-system/ui_kits/reef-pi-app/hooks/useAlertsStore'
+
+// Maps Redux MsgLevel to AlertCenter severity
+function toSeverity (type) {
+  if (type === MsgLevel.error)   return 'critical'
+  if (type === MsgLevel.warning) return 'warn'
+  return null // info + success don't surface in AlertCenter
+}
 
 let dispatchAlertAction
 
@@ -36,6 +44,12 @@ export function showUpdateSuccessful () {
 function _showAlert (type, msg) {
   const alert = setAlert(type, msg)
   _dispatchAlert(addAlert(alert))
+  if (window.FEATURE_FLAGS?.alert_center) {
+    const severity = toSeverity(type)
+    if (severity) {
+      dispatchToAlertCenter({ severity, title: msg, ts: Date.now() })
+    }
+  }
   return alert
 }
 function _dispatchAlert (action) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,7 @@ var config = {
       },
       {
         test: /\.jsx?/,
-        include: APP_DIR,
+        include: [APP_DIR, path.resolve(__dirname, 'front-end', 'design-system')],
         loader: 'babel-loader',
         options: {
           presets: [['@babel/preset-env', { modules: false }], '@babel/preset-react']


### PR DESCRIPTION
Closes #2918

## Summary
- `utils/alert.js`: when `alert_center` flag is on, relay `MsgLevel.error` → `'critical'` and `MsgLevel.warning` → `'warn'` to the `useAlertsStore` event emitter; info/success are not surfaced in the alert center
- `main_panel.jsx`: import `AlertCenterBell` from design system; render it instead of `<NotificationAlert />` when `window.FEATURE_FLAGS.alert_center` is truthy — falls back to existing notification UI otherwise

## Test plan
- [ ] Default (flag off): `<NotificationAlert />` renders as before, no regression
- [ ] Flag on (`window.FEATURE_FLAGS.alert_center = true`): bell icon appears in navbar; errors and warnings populate the slide-over; info/success toasts are suppressed from the alert center
- [ ] `showError` / `showWarning` calls from any module appear as alerts in the center
- [ ] `showInfo` / `showSuccess` do NOT appear in the alert center

🤖 Generated with [Claude Code](https://claude.com/claude-code)