### PR TITLE
[claude design] F7: wire DashboardV2 behind dashboard_v2 flag

### DIFF
--- a/front-end/src/dashboard/main.jsx
+++ b/front-end/src/dashboard/main.jsx
@@ -12,11 +12,14 @@ import HealthChart from 'health_chart'
 import PhChart from 'ph/chart'
 import PhUsageChart from 'ph/control_chart'
 import { fetchDashboard } from 'redux/actions/dashboard'
+import { updateEquipment } from 'redux/actions/equipment'
 import { connect } from 'react-redux'
 import Config from './config'
 import { numColsToColSize } from './grid'
 import ErrorBoundary from '../ui_components/error_boundary'
 import i18n from 'utils/i18n'
+import DashboardV2 from '../../design-system/ui_kits/reef-pi-app/dashboard/DashboardV2'
+import { buildEquipmentPayload } from 'equipment/utils'
 
 export class RawDashboardMain extends React.Component {
   constructor (props) {
@@ -26,6 +29,7 @@ export class RawDashboardMain extends React.Component {
     }
     this.charts = this.charts.bind(this)
     this.handleToggle = this.handleToggle.bind(this)
+    this.handleEquipmentToggle = this.handleEquipmentToggle.bind(this)
   }
 
   componentDidMount () {
@@ -34,6 +38,12 @@ export class RawDashboardMain extends React.Component {
 
   handleToggle () {
     this.setState({ showConfig: !this.state.showConfig })
+  }
+
+  handleEquipmentToggle (id, next) {
+    const eq = (this.props.equipment || []).find(e => String(e.id) === String(id))
+    if (!eq) return
+    this.props.updateEquipment(parseInt(id), buildEquipmentPayload(eq, { on: next === 'on' }))
   }
 
   charts () {
@@ -198,36 +208,46 @@ export class RawDashboardMain extends React.Component {
       lbl = i18n.t('configure')
     }
 
-    return (
-      <>
-        <div key='content'>
-          <div className='row'>
-            <div className='col'>
-              {content}
-            </div>
-          </div>
-          <div className='row' key='configure'>
-            <div className='col-12'>
-              <button className='btn btn-outline-dark btn-sm' onClick={this.handleToggle} id='configure-dashboard' data-testid='smoke-dashboard-configure'>
-                {lbl}
-              </button>
-            </div>
+    const legacyDashboard = (
+      <div key='content'>
+        <div className='row'>
+          <div className='col'>
+            {content}
           </div>
         </div>
-      </>
+        <div className='row' key='configure'>
+          <div className='col-12'>
+            <button className='btn btn-outline-dark btn-sm' onClick={this.handleToggle} id='configure-dashboard' data-testid='smoke-dashboard-configure'>
+              {lbl}
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+
+    return (
+      <DashboardV2
+        equipment={this.props.equipment}
+        onToggle={this.handleEquipmentToggle}
+        sseEndpoint='/api/alerts'
+      >
+        {legacyDashboard}
+      </DashboardV2>
     )
   }
 }
 
 const mapStateToProps = state => {
   return {
-    config: state.dashboard
+    config: state.dashboard,
+    equipment: state.equipment
   }
 }
 
 const mapDispatchToProps = dispatch => {
   return {
-    fetchDashboard: () => dispatch(fetchDashboard())
+    fetchDashboard: () => dispatch(fetchDashboard()),
+    updateEquipment: (id, payload) => dispatch(updateEquipment(id, payload))
   }
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,7 @@ var config = {
       },
       {
         test: /\.jsx?/,
-        include: APP_DIR,
+        include: [APP_DIR, path.resolve(__dirname, 'front-end', 'design-system')],
         loader: 'babel-loader',
         options: {
           presets: [['@babel/preset-env', { modules: false }], '@babel/preset-react']


### PR DESCRIPTION
Closes #2919

## Summary
- Imports `DashboardV2` from the design-system UI kit into `dashboard/main.jsx`
- Wraps legacy dashboard in `<DashboardV2>` — when `dashboard_v2` flag is off it renders children (legacy grid) unchanged; when on, shows the new system strip, temperature/pH/ATO tiles, and equipment strip
- Adds `equipment` state and `updateEquipment` dispatch to Redux bindings; `handleEquipmentToggle` adapter maps `(id, 'on'|'off')` to the existing `buildEquipmentPayload` + `updateEquipment` pattern
- `sseEndpoint='/api/alerts'` threads into `SystemStrip` for live alert polling

## Test plan
- [ ] Flag off (default): dashboard renders exactly as before, configure button works, all chart types display
- [ ] Flag on (`window.FEATURE_FLAGS.dashboard_v2 = true`): new layout renders — SystemStrip, TemperatureTile, PhTile, AtoTile, EquipmentStrip
- [ ] Equipment toggle in EquipmentStrip fires `updateEquipment` and syncs Redux state

🤖 Generated with [Claude Code](https://claude.com/claude-code)