### PR TITLE
[claude design] F9: wire monitoring primitives into pH module

### DIFF
--- a/front-end/src/ph/main.jsx
+++ b/front-end/src/ph/main.jsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { fetchPhProbes, createProbe, updateProbe, deleteProbe, calibrateProbe, readProbe } from 'redux/actions/phprobes'
+import React, { useState } from 'react'
+import { fetchPhProbes, createProbe, updateProbe, deleteProbe, calibrateProbe, readProbe, fetchProbeReadings } from 'redux/actions/phprobes'
 import { connect } from 'react-redux'
 import PhForm from './ph_form'
 import Collapsible from '../ui_components/collapsible'
@@ -8,6 +8,56 @@ import { confirm } from 'utils/confirm'
 import CalibrationWizard from './calibration_wizard'
 import i18next from 'i18next'
 import { SortByName } from 'utils/sort_by_name'
+import { timestampToEpoch } from 'utils/timestamp'
+import RangeSelector from '../../design-system/ui_kits/reef-pi-app/primitives/RangeSelector'
+import Sparkline from '../../design-system/ui_kits/reef-pi-app/primitives/Sparkline'
+import ThresholdGauge from '../../design-system/ui_kits/reef-pi-app/primitives/ThresholdGauge'
+
+const RANGE_MS = { '1h': 3600000, '6h': 21600000, '1d': 86400000, '7d': 604800000, '30d': 2592000000 }
+
+function PhPrimitives ({ probe, readings, currentReading }) {
+  const [range, setRange] = useState('1d')
+  if (!readings || !readings.current) return null
+
+  const cutoff = Date.now() - (RANGE_MS[range] || RANGE_MS['1d'])
+  const points = readings.current
+    .filter(d => timestampToEpoch(d.time) >= cutoff)
+    .map(d => ({ t: timestampToEpoch(d.time), v: d.value }))
+    .sort((a, b) => a.t - b.t)
+
+  const latestValue = currentReading != null ? currentReading : (points.length ? points[points.length - 1].v : null)
+  const safe = (probe.min != null && probe.max != null) ? [probe.min, probe.max] : undefined
+  const warn = (probe.notify && probe.notify.enable && probe.notify.min != null && probe.notify.max != null)
+    ? [probe.notify.min, probe.notify.max]
+    : undefined
+
+  return (
+    <div style={{ padding: '8px 0' }}>
+      <RangeSelector value={range} onChange={setRange} compact scope={`ph-${probe.id}`} />
+      <div style={{ marginTop: '8px' }}>
+        <Sparkline
+          points={points}
+          stroke='var(--reefpi-color-brand)'
+          fill='var(--reefpi-color-brand)'
+          band={safe}
+          height={56}
+          hover
+        />
+      </div>
+      {latestValue != null && (
+        <div style={{ marginTop: '8px' }}>
+          <ThresholdGauge
+            value={latestValue}
+            safe={safe}
+            warn={warn}
+            unit='pH'
+            label={probe.name}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
 
 class ph extends React.Component {
   constructor (props) {
@@ -29,6 +79,9 @@ class ph extends React.Component {
 
   componentDidMount () {
     this.props.fetchPhProbes()
+    if (window.FEATURE_FLAGS?.dashboard_v2) {
+      this.props.probes.forEach(probe => this.props.fetchProbeReadings(probe.id))
+    }
   }
 
   probeList () {
@@ -51,6 +104,13 @@ class ph extends React.Component {
             {i18next.t('ph:calibrate')}
           </button>
         )
+        const enhancedView = !!window.FEATURE_FLAGS?.dashboard_v2 && (
+          <PhPrimitives
+            probe={probe}
+            readings={this.props.phReadings[probe.id]}
+            currentReading={this.props.currentReading[probe.id]}
+          />
+        )
         return (
           <Collapsible
             key={'panel-ph-' + probe.id}
@@ -62,6 +122,7 @@ class ph extends React.Component {
             onToggleState={handleToggleState}
             enabled={probe.enable}
           >
+            {enhancedView}
             <PhForm
               onSubmit={this.handleUpdateProbe}
               key={Number(probe.id)}
@@ -216,6 +277,7 @@ const mapStateToProps = state => {
     probes: state.phprobes,
     ais: state.analog_inputs,
     currentReading: state.ph_reading,
+    phReadings: state.ph_readings || {},
     macros: state.macros,
     equipment: state.equipment
   }
@@ -228,7 +290,8 @@ const mapDispatchToProps = dispatch => {
     delete: id => dispatch(deleteProbe(id)),
     update: (id, t) => dispatch(updateProbe(id, t)),
     calibrateProbe: (id, p) => dispatch(calibrateProbe(id, p)),
-    readProbe: id => dispatch(readProbe(id))
+    readProbe: id => dispatch(readProbe(id)),
+    fetchProbeReadings: id => dispatch(fetchProbeReadings(id))
   }
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,7 @@ var config = {
       },
       {
         test: /\.jsx?/,
-        include: APP_DIR,
+        include: [APP_DIR, path.resolve(__dirname, 'front-end', 'design-system')],
         loader: 'babel-loader',
         options: {
           presets: [['@babel/preset-env', { modules: false }], '@babel/preset-react']


### PR DESCRIPTION
Closes #2921

## Summary
- Adds `PhPrimitives` functional component combining `RangeSelector`, `Sparkline`, and `ThresholdGauge` inside each probe's `Collapsible` in `ph/main.jsx`
- Gated behind `window.FEATURE_FLAGS.dashboard_v2`; legacy recharts chart is unaffected
- Uses existing Redux `ph_readings` data filtered by selected range — no new backend endpoint
- `ThresholdGauge` uses `probe.min/max` as safe band, `probe.notify` thresholds as warn band; unit is `pH`

## Test plan
- [ ] Flag off: pH module renders exactly as before
- [ ] Flag on: each probe shows `RangeSelector`, `Sparkline` with threshold band, and `ThresholdGauge`
- [ ] `fetchProbeReadings` called per probe on mount under flag guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)