### PR TITLE
Test connectors main redux mapping

### DIFF
--- a/front-end/src/connectors/connectors.test.js
+++ b/front-end/src/connectors/connectors.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { RawConnectors } from './main'
+import { RawConnectors, mapDispatchToProps, mapStateToProps } from './main'
 import { RawInlets } from './inlets'
 import Inlet from './inlet'
 import Outlet from './outlet'
@@ -67,6 +67,13 @@ describe('Connectors', () => {
       'row analog-inputs',
       'row jacks'
     ])
+  })
+
+  it('<Main /> maps state and fetch dispatch props', () => {
+    expect(mapStateToProps({ drivers: stockDrivers })).toEqual({ drivers: stockDrivers })
+    const dispatch = jest.fn(action => action)
+    mapDispatchToProps(dispatch).fetchDrivers()
+    expect(dispatch).toHaveBeenCalledTimes(1)
   })
 
   it('<InletSelector />', () => {

--- a/front-end/src/connectors/main.jsx
+++ b/front-end/src/connectors/main.jsx
@@ -41,13 +41,13 @@ class connectors extends React.Component {
   }
 }
 
-const mapStateToProps = state => {
+export const mapStateToProps = state => {
   return {
     drivers: state.drivers
   }
 }
 
-const mapDispatchToProps = dispatch => {
+export const mapDispatchToProps = dispatch => {
   return {
     fetchDrivers: () => dispatch(fetchDrivers())
   }


### PR DESCRIPTION
## Summary
- export the connectors main Redux mapping helpers for direct coverage
- verify driver state mapping and fetch dispatch wiring

## Tests
- rtk yarn jest front-end/src/connectors/connectors.test.js --runInBand
- rtk yarn standard
- rtk git diff --check