### PR TITLE
Test drivers main redux mapping

### DIFF
--- a/front-end/src/drivers/main.jsx
+++ b/front-end/src/drivers/main.jsx
@@ -61,14 +61,14 @@ export class RawDriversMain extends React.Component {
   }
 }
 
-const mapStateToProps = state => {
+export const mapStateToProps = state => {
   return {
     drivers: state.drivers,
     driverOptions: state.driverOptions
   }
 }
 
-const mapDispatchToProps = dispatch => {
+export const mapDispatchToProps = dispatch => {
   return {
     fetch: () => dispatch(fetchDrivers()),
     fetchDriverOptions: () => dispatch(fetchDriverOptions()),

--- a/front-end/src/drivers/main.test.js
+++ b/front-end/src/drivers/main.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import Drivers, { RawDriversMain } from './main'
+import Drivers, { RawDriversMain, mapDispatchToProps, mapStateToProps } from './main'
 import Driver from './driver'
 import New from './new'
 import 'isomorphic-fetch'
@@ -200,5 +200,21 @@ describe('Drivers Main', () => {
 
     expect(() => main.render()).not.toThrow()
     expect(Drivers).toBeDefined()
+  })
+
+  it('maps state and dispatch props for the connected driver container', () => {
+    const state = { drivers, driverOptions }
+    expect(mapStateToProps(state)).toEqual({ drivers, driverOptions })
+
+    const dispatch = jest.fn(action => action)
+    const props = mapDispatchToProps(dispatch)
+    props.fetch()
+    props.fetchDriverOptions()
+    props.create({ name: 'new' })
+    props.delete('1')
+    props.update('2', { name: 'updated' })
+    props.provision('2')
+
+    expect(dispatch).toHaveBeenCalledTimes(6)
   })
 })


### PR DESCRIPTION
## Summary
- export the drivers main Redux mapping helpers for direct coverage
- verify mapped state and dispatch callbacks alongside existing render coverage

## Tests
- rtk yarn jest front-end/src/drivers/main.test.js --runInBand
- rtk yarn standard
- rtk git diff --check