### PR TITLE
[claude design] F10: wire monitoring primitives into ATO module

### DIFF
--- a/front-end/src/ato/main.jsx
+++ b/front-end/src/ato/main.jsx
@@ -1,15 +1,46 @@
-import React from 'react'
+import React, { useState } from 'react'
 import New from './new'
 import AtoForm from './ato_form'
 import CollapsibleList from '../ui_components/collapsible_list'
 import Collapsible from '../ui_components/collapsible'
-import { fetchATOs, deleteATO, updateATO, resetATO } from 'redux/actions/ato'
+import { fetchATOs, fetchATOUsage, deleteATO, updateATO, resetATO } from 'redux/actions/ato'
 import { connect } from 'react-redux'
 import { fetchEquipment } from 'redux/actions/equipment'
 import { fetchInlets } from 'redux/actions/inlets'
 import i18n from 'utils/i18n'
 import { confirm } from 'utils/confirm'
 import { SortByName } from 'utils/sort_by_name'
+import { timestampToEpoch } from 'utils/timestamp'
+import RangeSelector from '../../design-system/ui_kits/reef-pi-app/primitives/RangeSelector'
+import Sparkline from '../../design-system/ui_kits/reef-pi-app/primitives/Sparkline'
+
+const RANGE_MS = { '1h': 3600000, '6h': 21600000, '1d': 86400000, '7d': 604800000, '30d': 2592000000 }
+
+function AtoPrimitives ({ ato, usage }) {
+  const [range, setRange] = useState('1d')
+  if (!usage || !usage.historical) return null
+
+  const cutoff = Date.now() - (RANGE_MS[range] || RANGE_MS['1d'])
+  const points = usage.historical
+    .filter(d => timestampToEpoch(d.time) >= cutoff)
+    .map(d => ({ t: timestampToEpoch(d.time), v: d.pump }))
+    .sort((a, b) => a.t - b.t)
+
+  return (
+    <div style={{ padding: '8px 0' }}>
+      <RangeSelector value={range} onChange={setRange} compact scope={`ato-${ato.id}`} />
+      <div style={{ marginTop: '8px' }}>
+        <Sparkline
+          points={points}
+          stroke='var(--reefpi-color-brand)'
+          fill='var(--reefpi-color-brand)'
+          height={56}
+          hover
+        />
+      </div>
+    </div>
+  )
+}
 
 export class RawATOMain extends React.Component {
   constructor (props) {
@@ -27,6 +58,9 @@ export class RawATOMain extends React.Component {
     this.props.fetchATOs()
     this.props.fetchEquipment()
     this.props.fetchInlets()
+    if (window.FEATURE_FLAGS?.dashboard_v2) {
+      this.props.atos.forEach(ato => this.props.fetchATOUsage(ato.id))
+    }
   }
 
   handleSubmit (values) {
@@ -96,6 +130,12 @@ export class RawATOMain extends React.Component {
             {i18n.t('ato:reset_usage')}
           </button>
         )
+        const enhancedView = !!window.FEATURE_FLAGS?.dashboard_v2 && (
+          <AtoPrimitives
+            ato={probe}
+            usage={this.props.atoUsage[probe.id]}
+          />
+        )
         return (
           <Collapsible
             key={'panel-ato-' + probe.id}
@@ -107,6 +147,7 @@ export class RawATOMain extends React.Component {
             enabled={probe.enable}
             buttons={resetButton}
           >
+            {enhancedView}
             <AtoForm
               data={probe}
               onSubmit={this.handleSubmit}
@@ -114,7 +155,6 @@ export class RawATOMain extends React.Component {
               equipment={this.props.equipment}
               macros={this.props.macros}
             />
-
           </Collapsible>
         )
       })
@@ -141,7 +181,8 @@ const mapStateToProps = state => {
     atos: state.atos,
     equipment: state.equipment,
     inlets: state.inlets,
-    macros: state.macros
+    macros: state.macros,
+    atoUsage: state.ato_usage || {}
   }
 }
 
@@ -150,6 +191,7 @@ const mapDispatchToProps = dispatch => {
     fetchATOs: () => dispatch(fetchATOs()),
     fetchEquipment: () => dispatch(fetchEquipment()),
     fetchInlets: () => dispatch(fetchInlets()),
+    fetchATOUsage: id => dispatch(fetchATOUsage(id)),
     delete: id => dispatch(deleteATO(id)),
     update: (id, a) => dispatch(updateATO(id, a)),
     reset: (id) => dispatch(resetATO(id))

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,7 @@ var config = {
       },
       {
         test: /\.jsx?/,
-        include: APP_DIR,
+        include: [APP_DIR, path.resolve(__dirname, 'front-end', 'design-system')],
         loader: 'babel-loader',
         options: {
           presets: [['@babel/preset-env', { modules: false }], '@babel/preset-react']


### PR DESCRIPTION
Closes #2922

## Summary
- Adds `AtoPrimitives` functional component combining `RangeSelector` and `Sparkline` inside each ATO's `Collapsible` in `ato/main.jsx`
- Gated behind `window.FEATURE_FLAGS.dashboard_v2`
- Sparkline shows pump-on duration over time (from `ato_usage[id].historical.pump`)
- No `ThresholdGauge` — ATO is binary (float switch on/off), not a continuous measured value

## Test plan
- [ ] Flag off: ATO module renders exactly as before
- [ ] Flag on: each ATO shows `RangeSelector` and `Sparkline` with pump activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)