### PR TITLE
[claude design] F11: wire monitoring primitives into doser module

### DIFF
--- a/front-end/src/doser/main.jsx
+++ b/front-end/src/doser/main.jsx
@@ -1,13 +1,44 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { confirm, showModal } from 'utils/confirm'
 import DoserForm from './doser_form'
-import { fetchDosingPumps, createDosingPump, deleteDosingPump, updateDosingPump, calibrateDosingPump, saveDosingPumpCalibration } from 'redux/actions/doser'
+import { fetchDosingPumps, createDosingPump, deleteDosingPump, updateDosingPump, calibrateDosingPump, saveDosingPumpCalibration, fetchDoserUsage } from 'redux/actions/doser'
 import { connect } from 'react-redux'
 import CollapsibleList from '../ui_components/collapsible_list'
 import Collapsible from '../ui_components/collapsible'
 import CalibrationModal from './calibration_modal'
 import { SortByName } from 'utils/sort_by_name'
 import i18n from 'utils/i18n'
+import { timestampToEpoch } from 'utils/timestamp'
+import RangeSelector from '../../design-system/ui_kits/reef-pi-app/primitives/RangeSelector'
+import Sparkline from '../../design-system/ui_kits/reef-pi-app/primitives/Sparkline'
+
+const RANGE_MS = { '1h': 3600000, '6h': 21600000, '1d': 86400000, '7d': 604800000, '30d': 2592000000 }
+
+function DoserPrimitives ({ doser, usage }) {
+  const [range, setRange] = useState('1d')
+  if (!usage || !usage.historical) return null
+
+  const cutoff = Date.now() - (RANGE_MS[range] || RANGE_MS['1d'])
+  const points = usage.historical
+    .filter(d => timestampToEpoch(d.time) >= cutoff)
+    .map(d => ({ t: timestampToEpoch(d.time), v: d.pump }))
+    .sort((a, b) => a.t - b.t)
+
+  return (
+    <div style={{ padding: '8px 0' }}>
+      <RangeSelector value={range} onChange={setRange} compact scope={`doser-${doser.id}`} />
+      <div style={{ marginTop: '8px' }}>
+        <Sparkline
+          points={points}
+          stroke='var(--reefpi-color-brand)'
+          fill='var(--reefpi-color-brand)'
+          height={56}
+          hover
+        />
+      </div>
+    </div>
+  )
+}
 
 export class RawDoser extends React.Component {
   constructor (props) {
@@ -22,6 +53,12 @@ export class RawDoser extends React.Component {
     this.handleUpdateDoser = this.handleUpdateDoser.bind(this)
     this.calibrateDoser = this.calibrateDoser.bind(this)
     this.valuesToDoser = this.valuesToDoser.bind(this)
+  }
+
+  componentDidMount () {
+    if (window.FEATURE_FLAGS?.dashboard_v2) {
+      this.props.dosers.forEach(doser => this.props.fetchDoserUsage(doser.id))
+    }
   }
 
   handleToggleAddDoserDiv () {
@@ -47,6 +84,12 @@ export class RawDoser extends React.Component {
             doser.regiment.enable = !doser.regiment.enable
             this.props.update(doser.id, doser)
           }
+          const enhancedView = !!window.FEATURE_FLAGS?.dashboard_v2 && (
+            <DoserPrimitives
+              doser={doser}
+              usage={this.props.doserUsage[doser.id]}
+            />
+          )
           return (
             <Collapsible
               key={'panel-doser-' + doser.id}
@@ -58,6 +101,7 @@ export class RawDoser extends React.Component {
               title={<b className='ml-2 align-middle'>{doser.name} </b>}
               onDelete={this.handleDeleteDoser}
             >
+              {enhancedView}
               <DoserForm
                 onSubmit={this.handleUpdateDoser}
                 jacks={this.props.jacks}
@@ -168,7 +212,8 @@ const mapStateToProps = state => {
   return {
     dosers: state.dosers,
     jacks: state.jacks,
-    outlets: state.outlets
+    outlets: state.outlets,
+    doserUsage: state.doser_usage || {}
   }
 }
 
@@ -179,7 +224,8 @@ const mapDispatchToProps = dispatch => {
     delete: id => dispatch(deleteDosingPump(id)),
     update: (id, t) => dispatch(updateDosingPump(id, t)),
     calibrateDoser: (id, p) => dispatch(calibrateDosingPump(id, p)),
-    saveCalibration: (id, p) => dispatch(saveDosingPumpCalibration(id, p))
+    saveCalibration: (id, p) => dispatch(saveDosingPumpCalibration(id, p)),
+    fetchDoserUsage: id => dispatch(fetchDoserUsage(id))
   }
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,7 @@ var config = {
       },
       {
         test: /\.jsx?/,
-        include: APP_DIR,
+        include: [APP_DIR, path.resolve(__dirname, 'front-end', 'design-system')],
         loader: 'babel-loader',
         options: {
           presets: [['@babel/preset-env', { modules: false }], '@babel/preset-react']


### PR DESCRIPTION
Closes #2923

## Summary
- Adds `DoserPrimitives` functional component combining `RangeSelector` and `Sparkline` inside each doser's `Collapsible` in `doser/main.jsx`
- Gated behind `window.FEATURE_FLAGS.dashboard_v2`
- Sparkline shows pump-on duration over time (from `doser_usage[id].historical.pump`)
- Adds `componentDidMount` to fetch usage per doser when flag is on

## Test plan
- [ ] Flag off: doser module renders exactly as before
- [ ] Flag on: each doser shows `RangeSelector` and `Sparkline` with pump activity history

🤖 Generated with [Claude Code](https://claude.com/claude-code)