### PR TITLE
Test design system dashboard hooks

### DIFF
--- a/front-end/design-system/ui_kits/reef-pi-app/hooks/useAlertsStore.test.js
+++ b/front-end/design-system/ui_kits/reef-pi-app/hooks/useAlertsStore.test.js
@@ -1,0 +1,84 @@
+import React, { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { acknowledgeAlert, clearAlerts, dismissAlert, dispatchAlert, useAlertsStore } from './useAlertsStore'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const HookProbe = ({ endpoint, onUpdate }) => {
+  const store = useAlertsStore({ sseEndpoint: endpoint })
+  onUpdate(store)
+  return <span>{store.unacknowledgedCount}</span>
+}
+
+describe('design-system useAlertsStore', () => {
+  beforeEach(() => {
+    clearAlerts()
+  })
+
+  it('dispatches, acknowledges, dismisses, and clears alerts', () => {
+    const updates = []
+    const container = document.createElement('div')
+    const root = createRoot(container)
+
+    act(() => {
+      root.render(<HookProbe onUpdate={store => updates.push(store)} />)
+    })
+
+    act(() => {
+      dispatchAlert({ id: 'a1', severity: 'critical', title: 'Leak', detail: 'ATO leak' })
+    })
+    expect(updates.at(-1).alerts[0]).toMatchObject({ id: 'a1', severity: 'critical', acknowledged: false })
+    expect(updates.at(-1).unacknowledgedCount).toBe(1)
+
+    act(() => acknowledgeAlert('a1'))
+    expect(updates.at(-1).alerts[0].acknowledged).toBe(true)
+    expect(updates.at(-1).unacknowledgedCount).toBe(0)
+
+    act(() => dismissAlert('a1'))
+    expect(updates.at(-1).alerts).toEqual([])
+
+    act(() => {
+      updates.at(-1).dispatch({ id: 'a2', message: 'Needs attention' })
+      updates.at(-1).clear()
+    })
+    expect(updates.at(-1).alerts).toEqual([])
+
+    act(() => root.unmount())
+  })
+
+  it('subscribes to EventSource alerts and reconnects on errors', () => {
+    jest.useFakeTimers()
+    const close = jest.fn()
+    const listeners = {}
+    const EventSourceMock = jest.fn(() => ({
+      addEventListener: (name, fn) => { listeners[name] = fn },
+      close
+    }))
+    global.EventSource = EventSourceMock
+
+    const updates = []
+    const container = document.createElement('div')
+    const root = createRoot(container)
+
+    act(() => {
+      root.render(<HookProbe endpoint='/api/alerts' onUpdate={store => updates.push(store)} />)
+    })
+
+    expect(EventSourceMock).toHaveBeenCalledWith('/api/alerts?since=0')
+
+    act(() => {
+      listeners.alert({ data: JSON.stringify({ id: 'sse-1', message: 'From SSE', ts: 42 }) })
+    })
+    expect(updates.at(-1).alerts[0].id).toBe('sse-1')
+
+    act(() => {
+      EventSourceMock.mock.results[0].value.onerror()
+      jest.advanceTimersByTime(5000)
+    })
+    expect(close).toHaveBeenCalled()
+    expect(EventSourceMock).toHaveBeenCalledTimes(2)
+
+    act(() => root.unmount())
+    jest.useRealTimers()
+  })
+})

--- a/front-end/design-system/ui_kits/reef-pi-app/hooks/useTimeSeries.test.js
+++ b/front-end/design-system/ui_kits/reef-pi-app/hooks/useTimeSeries.test.js
@@ -1,0 +1,97 @@
+import React, { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { useTimeSeries } from './useTimeSeries'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const HookProbe = ({ metric, range, maxPoints, onUpdate }) => {
+  const state = useTimeSeries({ metric, range, maxPoints })
+  onUpdate(state)
+  return <span>{state.points.length}</span>
+}
+
+describe('design-system useTimeSeries', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-05-14T12:00:00Z'))
+    global.fetch = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    delete global.fetch
+  })
+
+  it('fetches telemetry and downsamples to max points', async () => {
+    const raw = Array.from({ length: 10 }, (_, i) => ({ t: i, v: i % 2 ? 10 : 1 }))
+    fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(raw) })
+    const updates = []
+    const container = document.createElement('div')
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(<HookProbe metric='temp' range='1h' maxPoints={4} onUpdate={state => updates.push(state)} />)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(fetch).toHaveBeenCalledWith('/api/telemetry/temp?range=1h')
+    expect(updates.at(-1).loading).toBe(false)
+    expect(updates.at(-1).error).toBeNull()
+    expect(updates.at(-1).points).toHaveLength(4)
+    expect(updates.at(-1).points[0]).toEqual(raw[0])
+    expect(updates.at(-1).points.at(-1)).toEqual(raw.at(-1))
+
+    act(() => root.unmount())
+  })
+
+  it('serves cached points for the same metric bucket and supports forced refetch', async () => {
+    fetch
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([{ t: 1, v: 1 }]) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([{ t: 2, v: 2 }]) })
+
+    const updates = []
+    const container = document.createElement('div')
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(<HookProbe metric='cached' range='1d' maxPoints={5} onUpdate={state => updates.push(state)} />)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      root.render(<HookProbe metric='cached' range='1d' maxPoints={5} onUpdate={state => updates.push(state)} />)
+      await Promise.resolve()
+    })
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await updates.at(-1).refetch()
+      await Promise.resolve()
+    })
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(updates.at(-1).points).toEqual([{ t: 2, v: 2 }])
+
+    act(() => root.unmount())
+  })
+
+  it('sets an error when telemetry fetch fails', async () => {
+    fetch.mockResolvedValueOnce({ ok: false, status: 500 })
+    const updates = []
+    const container = document.createElement('div')
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(<HookProbe metric='bad' range='6h' maxPoints={5} onUpdate={state => updates.push(state)} />)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(updates.at(-1).loading).toBe(false)
+    expect(updates.at(-1).error).toBe('HTTP 500')
+
+    act(() => root.unmount())
+  })
+})


### PR DESCRIPTION
## Summary
- add useAlertsStore coverage for local alert actions and SSE subscription/reconnect behavior
- add useTimeSeries coverage for fetch, downsampling, cache reuse, forced refetch, and errors

## Tests
- rtk yarn jest front-end/design-system/ui_kits/reef-pi-app/hooks/useAlertsStore.test.js front-end/design-system/ui_kits/reef-pi-app/hooks/useTimeSeries.test.js --runInBand
- rtk yarn standard
- rtk git diff --check