### PR TITLE
[claude design] F13: inline tile alerts for TemperatureTile, PhTile, AtoTile

### DIFF
--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/AtoTile.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/AtoTile.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import MetricTile from './MetricTile'
 
-export default function AtoTile ({ globalRange, targetLevel }) {
+export default function AtoTile ({ globalRange, targetLevel, alert, onAlertClick }) {
   // band only shown when a target is configured
   const band = targetLevel != null ? [targetLevel * 0.95, targetLevel * 1.05] : undefined
 
@@ -15,6 +15,8 @@ export default function AtoTile ({ globalRange, targetLevel }) {
       globalRange={globalRange}
       formatValue={v => v.toFixed(0)}
       trendPrecision={1}
+      alert={alert}
+      onAlertClick={onAlertClick}
     >
       {({ value }) => value !== null && (
         <span style={{
@@ -23,7 +25,8 @@ export default function AtoTile ({ globalRange, targetLevel }) {
           color: value < 20
             ? 'var(--reefpi-color-warn)'
             : 'var(--reefpi-color-text-muted)'
-        }}>
+        }}
+        >
           {value < 20 ? 'low — refill soon' : 'reservoir OK'}
         </span>
       )}
@@ -33,5 +36,7 @@ export default function AtoTile ({ globalRange, targetLevel }) {
 
 AtoTile.propTypes = {
   globalRange: PropTypes.string,
-  targetLevel: PropTypes.number
+  targetLevel: PropTypes.number,
+  alert: PropTypes.shape({ severity: PropTypes.string, message: PropTypes.string, at: PropTypes.number }),
+  onAlertClick: PropTypes.func
 }

--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.jsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import SystemStrip from './SystemStrip'
 import TemperatureTile from './TemperatureTile'
 import PhTile from './PhTile'
 import AtoTile from './AtoTile'
 import EquipmentStrip from './EquipmentStrip'
+import { useAlertsStore } from '../hooks/useAlertsStore'
 
 /*
  * Composed dashboard layout for the dashboard_v2 flag.
@@ -20,6 +21,29 @@ import EquipmentStrip from './EquipmentStrip'
  * Removal ticket: schedule for 2 releases after QA sign-off (flag flipped to true).
  */
 
+// Maps tile metric keys → alert store title keywords for matching
+const METRIC_KEYWORDS = {
+  'temperature.display': ['temperature', 'temp'],
+  'ph.display': ['ph'],
+  'ato.reservoir': ['ato', 'reservoir', 'water level']
+}
+
+function firstAlertFor (alerts, metric) {
+  const keys = METRIC_KEYWORDS[metric] ?? []
+  return alerts.find(a =>
+    !a.acknowledged &&
+    keys.some(k => {
+      const haystack = ((a.title ?? '') + ' ' + (a.detail ?? '')).toLowerCase()
+      return haystack.includes(k)
+    })
+  ) ?? null
+}
+
+function toTileAlert (a) {
+  if (!a) return undefined
+  return { severity: a.severity, message: a.detail || a.title, at: a.ts }
+}
+
 export default function DashboardV2 ({
   equipment,
   onToggle,
@@ -28,9 +52,15 @@ export default function DashboardV2 ({
   targetAtoLevel,
   children
 }) {
+  const { alerts } = useAlertsStore({ sseEndpoint })
+
   if (!window.FEATURE_FLAGS?.dashboard_v2) {
     return children ?? null
   }
+
+  const tempAlert = toTileAlert(firstAlertFor(alerts, 'temperature.display'))
+  const phAlert = toTileAlert(firstAlertFor(alerts, 'ph.display'))
+  const atoAlert = toTileAlert(firstAlertFor(alerts, 'ato.reservoir'))
 
   return (
     <div style={{
@@ -39,24 +69,25 @@ export default function DashboardV2 ({
       gap: '1rem',
       padding: '1rem',
       fontFamily: 'var(--reefpi-font-app)'
-    }}>
+    }}
+    >
       {/* System strip — full width */}
       <SystemStrip sseEndpoint={sseEndpoint} />
 
       {/* Primary metric row */}
       <div className='row' style={{ margin: 0, gap: '1rem', display: 'flex', flexWrap: 'wrap' }}>
         <div style={{ flex: '2 1 300px', minWidth: 0 }}>
-          <TemperatureTile globalRange={globalRange} />
+          <TemperatureTile globalRange={globalRange} alert={tempAlert} />
         </div>
         <div style={{ flex: '1 1 200px', minWidth: 0 }}>
-          <PhTile globalRange={globalRange} />
+          <PhTile globalRange={globalRange} alert={phAlert} />
         </div>
       </div>
 
       {/* Secondary metric row */}
       <div className='row' style={{ margin: 0 }}>
         <div style={{ flex: '1 1 200px', minWidth: 0 }}>
-          <AtoTile globalRange={globalRange} targetLevel={targetAtoLevel} />
+          <AtoTile globalRange={globalRange} targetLevel={targetAtoLevel} alert={atoAlert} />
         </div>
       </div>
 

--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js
@@ -1,5 +1,10 @@
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
+
+jest.mock('../hooks/useAlertsStore', () => ({
+  useAlertsStore: () => ({ alerts: [] })
+}))
+
 import DashboardV2 from './DashboardV2'
 import AtoTile from './AtoTile'
 import EquipmentStrip from './EquipmentStrip'

--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/PhTile.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/PhTile.jsx
@@ -4,7 +4,7 @@ import MetricTile from './MetricTile'
 
 const PH_BAND = [8.1, 8.4]
 
-export default function PhTile ({ globalRange }) {
+export default function PhTile ({ globalRange, alert, onAlertClick }) {
   return (
     <MetricTile
       metric='ph.display'
@@ -14,6 +14,8 @@ export default function PhTile ({ globalRange }) {
       globalRange={globalRange}
       formatValue={v => v.toFixed(2)}
       trendPrecision={2}
+      alert={alert}
+      onAlertClick={onAlertClick}
     >
       {({ value }) => value !== null && (
         <span style={{
@@ -22,7 +24,8 @@ export default function PhTile ({ globalRange }) {
           color: value >= PH_BAND[0] && value <= PH_BAND[1]
             ? 'var(--reefpi-color-brand)'
             : 'var(--reefpi-color-warn)'
-        }}>
+        }}
+        >
           {value >= PH_BAND[0] && value <= PH_BAND[1] ? 'within safe range' : 'outside safe range'}
         </span>
       )}
@@ -30,4 +33,8 @@ export default function PhTile ({ globalRange }) {
   )
 }
 
-PhTile.propTypes = { globalRange: PropTypes.string }
+PhTile.propTypes = {
+  globalRange: PropTypes.string,
+  alert: PropTypes.shape({ severity: PropTypes.string, message: PropTypes.string, at: PropTypes.number }),
+  onAlertClick: PropTypes.func
+}

--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/TemperatureTile.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/TemperatureTile.jsx
@@ -5,9 +5,9 @@ import Sparkline from '../primitives/Sparkline'
 import RangeSelector from '../primitives/RangeSelector'
 import { useTimeSeries } from '../hooks/useTimeSeries'
 
-const SAFE  = [76, 80]
-const WARN  = [74, 82]
-const CRIT  = [70, 86]
+const SAFE = [76, 80]
+const WARN = [74, 82]
+const CRIT = [70, 86]
 
 function delta (points) {
   if (!points || points.length < 2) return null
@@ -16,15 +16,29 @@ function delta (points) {
   return (now - hour).toFixed(1)
 }
 
-export default function TemperatureTile ({ metric = 'temperature.display', unit = '°F' }) {
-  const [range, setRange]         = useState('1d')
+const ALERT_BORDER = {
+  critical: 'var(--reefpi-color-error)',
+  warn: 'var(--reefpi-color-warn)'
+}
+
+function alertRelTime (ts) {
+  const s = Math.floor((Date.now() - ts) / 1000)
+  if (s < 60) return s + 's'
+  if (s < 3600) return Math.floor(s / 60) + 'm'
+  return Math.floor(s / 3600) + 'h'
+}
+
+export default function TemperatureTile ({ metric = 'temperature.display', unit = '°F', alert, onAlertClick }) {
+  const [range, setRange] = useState('1d')
   const [hoverValue, setHoverValue] = useState(null)
 
   const { points, loading, error, refetch } = useTimeSeries({ metric, range, maxPoints: 120 })
 
-  const latest  = points.length ? points[points.length - 1].v : null
+  const latest = points.length ? points[points.length - 1].v : null
   const display = hoverValue !== null ? hoverValue : latest
-  const diff    = delta(points)
+  const diff = delta(points)
+
+  const alertBorder = alert ? (ALERT_BORDER[alert.severity] ?? ALERT_BORDER.warn) : null
 
   return (
     <div
@@ -32,6 +46,7 @@ export default function TemperatureTile ({ metric = 'temperature.display', unit 
       style={{
         background: 'var(--reefpi-color-surface-elevated)',
         border: '1px solid var(--reefpi-color-border)',
+        borderTop: alertBorder ? `3px solid ${alertBorder}` : '1px solid var(--reefpi-color-border)',
         borderRadius: 'var(--reefpi-radius-md)',
         display: 'flex',
         flexDirection: 'column',
@@ -48,7 +63,8 @@ export default function TemperatureTile ({ metric = 'temperature.display', unit 
         padding: '0.75rem 1rem',
         borderBottom: '1px solid var(--reefpi-color-border)',
         flexShrink: 0
-      }}>
+      }}
+      >
         <span style={{ fontSize: '0.75rem', fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--reefpi-color-text-muted)' }}>
           Temperature
         </span>
@@ -82,7 +98,8 @@ export default function TemperatureTile ({ metric = 'temperature.display', unit 
                 lineHeight: 1,
                 color: 'var(--reefpi-color-text)',
                 fontVariantNumeric: 'tabular-nums'
-              }}>
+              }}
+              >
                 {display !== null ? display.toFixed(1) : '—'}
               </span>
               <span style={{ fontSize: '1rem', color: 'var(--reefpi-color-text-muted)' }}>{unit}</span>
@@ -91,7 +108,8 @@ export default function TemperatureTile ({ metric = 'temperature.display', unit 
                   fontSize: '0.8rem',
                   color: parseFloat(diff) >= 0 ? 'var(--reefpi-color-warn)' : 'var(--reefpi-color-brand)',
                   fontVariantNumeric: 'tabular-nums'
-                }}>
+                }}
+                >
                   {parseFloat(diff) >= 0 ? '+' : ''}{diff} vs 1h ago
                 </span>
               )}
@@ -117,6 +135,36 @@ export default function TemperatureTile ({ metric = 'temperature.display', unit 
           </>
         )}
       </div>
+
+      {/* Inline alert footer */}
+      {alert && (
+        <button
+          onClick={onAlertClick}
+          aria-live='polite'
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.375rem',
+            padding: '0.375rem 0.875rem',
+            background: 'transparent',
+            border: 'none',
+            borderTop: `1px solid ${alertBorder}`,
+            width: '100%',
+            cursor: onAlertClick ? 'pointer' : 'default',
+            fontFamily: 'var(--reefpi-font-app)',
+            flexShrink: 0
+          }}
+        >
+          <span style={{ fontSize: '0.72rem', color: alertBorder, flex: '1 1 auto', textAlign: 'left', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {alert.message}
+          </span>
+          {alert.at && (
+            <span style={{ fontSize: '0.65rem', color: 'var(--reefpi-color-text-muted)', fontFamily: 'var(--reefpi-font-mono)', flexShrink: 0 }}>
+              {alertRelTime(alert.at)}
+            </span>
+          )}
+        </button>
+      )}
     </div>
   )
 }
@@ -131,7 +179,7 @@ function LoadingSkeleton () {
   })
   return (
     <>
-      <style>{`@keyframes reefpi-shimmer{0%{background-position:200% 0}100%{background-position:-200% 0}}`}</style>
+      <style>{'@keyframes reefpi-shimmer{0%{background-position:200% 0}100%{background-position:-200% 0}}'}</style>
       <div style={bar('14px')} />
       <div style={{ ...bar('3rem'), width: '45%' }} />
       <div style={{ ...bar('120px'), flex: '1 1 auto' }} />
@@ -148,7 +196,8 @@ function ErrorState ({ message, onRetry }) {
       alignItems: 'center',
       justifyContent: 'center',
       gap: '0.75rem'
-    }}>
+    }}
+    >
       <div style={{
         padding: '0.5rem 0.75rem',
         background: 'var(--reefpi-color-error-bg)',
@@ -157,7 +206,8 @@ function ErrorState ({ message, onRetry }) {
         color: 'var(--reefpi-color-error)',
         fontSize: '0.8rem',
         textAlign: 'center'
-      }}>
+      }}
+      >
         {message}
       </div>
       {onRetry && (
@@ -184,5 +234,7 @@ function ErrorState ({ message, onRetry }) {
 
 TemperatureTile.propTypes = {
   metric: PropTypes.string,
-  unit: PropTypes.string
+  unit: PropTypes.string,
+  alert: PropTypes.shape({ severity: PropTypes.string, message: PropTypes.string, at: PropTypes.number }),
+  onAlertClick: PropTypes.func
 }


### PR DESCRIPTION
## Summary
- `TemperatureTile`: add `alert` prop → colored top-border + inline alert footer with `aria-live="polite"` and relative timestamp
- `PhTile` / `AtoTile`: accept and pass `alert` + `onAlertClick` through to `MetricTile` (which already renders the alert banner)
- `DashboardV2`: subscribe to `useAlertsStore`, match unacknowledged alerts to metric keywords, pass matched alert to each tile

## Approach
Alert matching is keyword-based (`temperature`/`temp`, `ph`, `ato`/`reservoir`) against the alert `title` + `detail` fields. First unacknowledged match wins.

Closes #2834

🤖 Generated with [Claude Code](https://claude.ai/claude-code)