### PR TITLE
coverage: add dashboard_v2, EmptyState, new_shell, alert_center tests

### DIFF
--- a/front-end/src/main_panel.test.js
+++ b/front-end/src/main_panel.test.js
@@ -248,4 +248,38 @@ describe('MainPanel', () => {
     expect(routeNavigationPath(mainPanelRoutes[0])).toBe('')
     expect(routeNavigationPath(mainPanelRoutes[12])).toBe('/configuration')
   })
+
+  it('renders NewShellNav instead of navbar when new_shell flag is on', () => {
+    window.FEATURE_FLAGS = { new_shell: true }
+    const panel = new RawMainPanel({
+      info: { name: 'reef-pi' },
+      errors: [],
+      capabilities: { dashboard: true, equipment: true },
+      fetchUIData: jest.fn(),
+      fetchInfo: jest.fn()
+    })
+    const rendered = panel.render()
+    const newShellNav = findAll(rendered, node => node.type && node.type.name === 'NewShellNav')[0]
+    expect(newShellNav).toBeDefined()
+    expect(newShellNav.props.capabilities).toEqual({ dashboard: true, equipment: true })
+    expect(countByType(rendered, node => node.type === 'nav')).toBe(0)
+    window.FEATURE_FLAGS = {}
+  })
+
+  it('renders AlertCenterBell instead of NotificationAlert when alert_center flag is on', () => {
+    window.FEATURE_FLAGS = { alert_center: true }
+    const panel = new RawMainPanel({
+      info: { name: 'reef-pi' },
+      errors: [],
+      capabilities: { dashboard: true },
+      fetchUIData: jest.fn(),
+      fetchInfo: jest.fn()
+    })
+    const rendered = panel.render()
+    const bell = findAll(rendered, node => node.type && node.type.name === 'AlertCenterBell')[0]
+    const legacyNotify = findAll(rendered, node => node.type && node.type.name === 'NotificationAlert')[0]
+    expect(bell).toBeDefined()
+    expect(legacyNotify).toBeUndefined()
+    window.FEATURE_FLAGS = {}
+  })
 })

--- a/front-end/src/ph/ph.test.js
+++ b/front-end/src/ph/ph.test.js
@@ -446,4 +446,43 @@ describe('Ph ui', () => {
     expect(historical).toEqual(originalHistorical)
     instance.componentWillUnmount()
   })
+
+  it('<Main /> fetches probe readings and renders primitives under dashboard_v2 flag', () => {
+    window.FEATURE_FLAGS = { dashboard_v2: true }
+    const fetchProbeReadings = jest.fn()
+    const probe = { id: '1', name: 'Tank pH', enable: false, min: 7.8, max: 8.3, notify: { enable: true, min: 7.5, max: 8.5 }, notify_enable: false, control: false }
+    const now = new Date()
+    const component = new RawPhMain(createProps({
+      probes: [probe],
+      currentReading: { 1: 8.1 },
+      phReadings: {
+        1: {
+          current: [
+            { time: now.toISOString(), value: 8.1 },
+            { time: new Date(now.getTime() - 3600000).toISOString(), value: 8.0 }
+          ]
+        }
+      },
+      fetchProbeReadings
+    }))
+
+    component.componentDidMount()
+    const probeListItem = component.probeList()[0]
+    const primitives = probeListItem.props.children[0]
+
+    expect(fetchProbeReadings).toHaveBeenCalledWith('1')
+    expect(primitives.props.probe).toBe(probe)
+    expect(primitives.props.readings.current).toHaveLength(2)
+    expect(primitives.props.currentReading).toBe(8.1)
+    window.FEATURE_FLAGS = {}
+  })
+
+  it('<Main /> renders EmptyState with calibration modal slot when no probes', () => {
+    const component = new RawPhMain(createProps())
+    const rendered = component.render()
+    expect(rendered.type).toBe('div')
+    const children = rendered.props.children
+    expect(children[0]).toBeNull()
+    expect(children[1].type.name).toBe('EmptyState')
+  })
 })


### PR DESCRIPTION
## Summary
- Add test for `dashboard_v2` flag in `ph/ph.test.js`: verifies `fetchProbeReadings` is called and `PhPrimitives` receives correct props
- Add test for EmptyState path in `ph/ph.test.js`: verifies render when no probes exist
- Add test for `new_shell` flag in `main_panel.test.js`: verifies `NewShellNav` is rendered and no `<nav>` element appears
- Add test for `alert_center` flag in `main_panel.test.js`: verifies `AlertCenterBell` is rendered and `NotificationAlert` is not

## Test plan
- [x] `yarn jest src/ph/ph.test.js src/main_panel.test.js --runInBand` passes (35 tests, 0 failures)

Closes #2878

🤖 Generated with [Claude Code](https://claude.com/claude-code)