### PR TITLE
[claude design] enable all feature flags by default

### DIFF
--- a/front-end/assets/home.html
+++ b/front-end/assets/home.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="main-panel"></div>
-    <script>window.FEATURE_FLAGS = window.FEATURE_FLAGS || {};</script>
+    <script>window.FEATURE_FLAGS = Object.assign({ pending_states: true, alert_center: true, dashboard_v2: true, new_shell: true }, window.FEATURE_FLAGS);</script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
All 5 design system epics (E1–E5, 26 issues) are shipped and CI-green. This PR promotes all four feature flags from opt-in to default-on so users see the new UI without any config change.

**Flags enabled:**
| Flag | What it gates | Epic |
|---|---|---|
| `pending_states` | Pending/error states on equipment toggles | E4 |
| `alert_center` | AlertCenterBell in navbar + AlertCenter slide-over | E4 |
| `dashboard_v2` | Bento OS tiles for temperature/pH/ATO/doser pages | E3 |
| `new_shell` | Collapsible sidebar (≥992px) + mobile bottom nav | E5 |

**Implementation:** `Object.assign({ ...defaults }, window.FEATURE_FLAGS)` preserves any server-injected overrides, so emergency rollback can still inject `window.FEATURE_FLAGS = { new_shell: false }` before the script tag.

## Test plan
- [x] `yarn jest front-end/src/main_panel.test.js` passes (12/12)
- [x] Tests that assert flag-gated behavior still pass (they set the flag explicitly and reset in `afterEach`)

Closes #2971

🤖 Generated with [Claude Code](https://claude.com/claude-code)