### PR TITLE
Test dashboard alert mapping

### DIFF
--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 
+let mockAlerts = []
 jest.mock('../hooks/useAlertsStore', () => ({
-  useAlertsStore: () => ({ alerts: [] })
+  useAlertsStore: () => ({ alerts: mockAlerts })
 }))
 
 import DashboardV2 from './DashboardV2'
@@ -13,6 +14,10 @@ import SystemStrip from './SystemStrip'
 import TemperatureTile from './TemperatureTile'
 
 describe('design-system DashboardV2', () => {
+  beforeEach(() => {
+    mockAlerts = []
+  })
+
   afterEach(() => {
     window.FEATURE_FLAGS = {}
   })
@@ -49,5 +54,47 @@ describe('design-system DashboardV2', () => {
     expect(rows[3].type).toBe(EquipmentStrip)
     expect(rows[3].props.items).toBe(equipment)
     expect(rows[3].props.onToggle).toBe(onToggle)
+  })
+
+  it('maps unacknowledged alert-center messages to matching tiles', () => {
+    window.FEATURE_FLAGS = { dashboard_v2: true }
+    mockAlerts = [
+      { title: 'Temperature high', detail: 'Water temperature exceeded limit', severity: 'critical', ts: 101 },
+      { title: 'pH warning', detail: '', severity: 'warn', ts: 102 },
+      { title: 'ATO reservoir', detail: 'Water level low', severity: 'warn', ts: 103 },
+      { title: 'Temperature old', detail: 'acknowledged alert', severity: 'critical', ts: 104, acknowledged: true }
+    ]
+
+    const tree = DashboardV2({ equipment: [], sseEndpoint: '/api/alerts' })
+    const rows = tree.props.children
+
+    expect(rows[1].props.children[0].props.children.props.alert).toEqual({
+      severity: 'critical',
+      message: 'Water temperature exceeded limit',
+      at: 101
+    })
+    expect(rows[1].props.children[1].props.children.props.alert).toEqual({
+      severity: 'warn',
+      message: 'pH warning',
+      at: 102
+    })
+    expect(rows[2].props.children.props.children.props.alert).toEqual({
+      severity: 'warn',
+      message: 'Water level low',
+      at: 103
+    })
+  })
+
+  it('leaves tile alerts unset when no alert keywords match', () => {
+    window.FEATURE_FLAGS = { dashboard_v2: true }
+    mockAlerts = [
+      { title: 'Camera offline', detail: 'No recent images', severity: 'critical', ts: 105 }
+    ]
+
+    const rows = DashboardV2({ equipment: [] }).props.children
+
+    expect(rows[1].props.children[0].props.children.props.alert).toBeUndefined()
+    expect(rows[1].props.children[1].props.children.props.alert).toBeUndefined()
+    expect(rows[2].props.children.props.children.props.alert).toBeUndefined()
   })
 })


### PR DESCRIPTION
Adds focused coverage for DashboardV2 alert matching and tile alert props.\n\nTests:\n- rtk yarn jest front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js --runInBand\n- rtk yarn standard\n- rtk git diff --check