### PR TITLE
Coverage: ATO EmptyState + Doser componentDidMount, EmptyState, DoserPrimitives

### DIFF
--- a/front-end/src/ato/main.test.js
+++ b/front-end/src/ato/main.test.js
@@ -209,4 +209,10 @@ describe('ATO Main', () => {
     expect(renderToStaticMarkup(component.probeList()[0].props.children[0])).toBe('')
     window.FEATURE_FLAGS = {}
   })
+
+  it('render shows EmptyState when atos list is empty', () => {
+    const component = new RawATOMain(makeProps({ atos: [] }))
+    const tree = component.render()
+    expect(tree.props.title).toBe('No ATO configured')
+  })
 })

--- a/front-end/src/doser/doser.test.js
+++ b/front-end/src/doser/doser.test.js
@@ -1,3 +1,5 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 import Main, { RawDoser } from './main'
 import 'isomorphic-fetch'
 import DoserForm, { mapDoserPropsToValues, submitDoserForm } from './doser_form'
@@ -289,5 +291,58 @@ describe('Doser ui', () => {
     component.setState({ addDoser: true })
     const tree = component.render()
     expect(tree).not.toBeNull()
+  })
+
+  it('<Main /> componentDidMount fetches usage per doser when dashboard_v2 flag is on', () => {
+    window.FEATURE_FLAGS = { dashboard_v2: true }
+    const fetchDoserUsage = jest.fn()
+    const component = makeComponent({ fetchDoserUsage })
+    component.componentDidMount()
+    expect(fetchDoserUsage).toHaveBeenCalledWith('1')
+    window.FEATURE_FLAGS = {}
+  })
+
+  it('<Main /> componentDidMount skips usage fetch when dashboard_v2 flag is off', () => {
+    window.FEATURE_FLAGS = {}
+    const fetchDoserUsage = jest.fn()
+    const component = makeComponent({ fetchDoserUsage })
+    component.componentDidMount()
+    expect(fetchDoserUsage).not.toHaveBeenCalled()
+  })
+
+  it('<Main /> render returns EmptyState when dosers list is empty', () => {
+    const component = makeComponent({ dosers: [] })
+    const tree = component.render()
+    expect(tree.props.title).toBe('No dosing pumps yet')
+  })
+
+  it('<Main /> DoserPrimitives renders sparkline with usage data', () => {
+    window.FEATURE_FLAGS = { dashboard_v2: true }
+    const now = new Date()
+    const dosers = [makeDoser()]
+    const component = makeComponent({
+      dosers,
+      doserUsage: {
+        1: { historical: [{ time: now.toISOString(), pump: 1 }] }
+      },
+      fetchDoserUsage: jest.fn()
+    })
+    const items = component.doserList()
+    const primitives = items[0].props.children[0]
+    const html = renderToStaticMarkup(primitives)
+    expect(html).toContain('doser-1')
+    expect(html).toContain('reefpi-range-selector')
+    window.FEATURE_FLAGS = {}
+  })
+
+  it('<Main /> DoserPrimitives returns null when usage history is absent', () => {
+    window.FEATURE_FLAGS = { dashboard_v2: true }
+    const component = makeComponent({
+      doserUsage: { 1: {} },
+      fetchDoserUsage: jest.fn()
+    })
+    const primitives = component.doserList()[0].props.children[0]
+    expect(renderToStaticMarkup(primitives)).toBe('')
+    window.FEATURE_FLAGS = {}
   })
 })


### PR DESCRIPTION
## Summary
- ATO: adds `render shows EmptyState when atos list is empty` test covering the empty-list render branch
- Doser: adds tests for `componentDidMount` with `dashboard_v2` flag, empty-list `EmptyState` render, and `DoserPrimitives` functional component (both with and without usage history)

## Test plan
- All 14 ATO tests pass
- All 17 Doser tests pass
- `yarn jest "src/ato/main.test"` and `yarn jest "src/doser/doser.test"` both green

Closes #2978

🤖 Generated with [Claude Code](https://claude.com/claude-code)