### PR TITLE
Coverage: Timers EmptyState render path

### DIFF
--- a/front-end/src/timers/timers.test.js
+++ b/front-end/src/timers/timers.test.js
@@ -284,4 +284,18 @@ describe('Timer ui', () => {
     expect(html).toContain('value="name"')
     expect(html).toContain('name="target.duration"')
   })
+
+  it('<Main /> render returns EmptyState when timers list is empty and form is hidden', () => {
+    const component = new RawTimersMain(makeProps({ timers: [] }))
+    const tree = component.render()
+    expect(tree.props.title).toBe('No timers yet')
+  })
+
+  it('<Main /> EmptyState action calls handleToggleAddTimerDiv', () => {
+    const component = new RawTimersMain(makeProps({ timers: [] }))
+    component.setState = update => { component.state = { ...component.state, ...update } }
+    const tree = component.render()
+    tree.props.action.onClick()
+    expect(component.state.addTimer).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary
- Adds two tests for `RawTimersMain.render()` when the timer list is empty and the add form is hidden: verifies the `EmptyState` is returned with the correct title, and that its action callback correctly triggers `handleToggleAddTimerDiv`.

## Test plan
- All 14 timer tests pass
- `yarn jest "src/timers/timers.test"` green

Closes #2979

🤖 Generated with [Claude Code](https://claude.com/claude-code)