### PR TITLE
Coverage: EquipmentCtrlPanel pending_states branch and PendingEquipmentToggle

### DIFF
--- a/front-end/src/equipment/ctrl_panel.test.js
+++ b/front-end/src/equipment/ctrl_panel.test.js
@@ -1,6 +1,12 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
 import Switch from 'react-toggle-switch'
 import EquipmentCtrlPanel, { RawEquipmentCtrlPanel, mapDispatchToProps, mapStateToProps } from './ctrl_panel'
 import 'isomorphic-fetch'
+
+jest.mock('../../design-system/ui_kits/reef-pi-app/hooks/useEquipmentToggle', () => ({
+  useEquipmentToggle: jest.fn(() => ({ mutate: jest.fn(), state: 'idle', retry: jest.fn() }))
+}))
 
 const equipment = [
   { id: '1', name: 'Heater', on: true, outlet: '1', stay_off_on_boot: false },
@@ -91,5 +97,41 @@ describe('<EquipmentCtrlPanel />', () => {
     props.fetchEquipment()
     props.updateEquipment(1, { on: false })
     expect(dispatch).toHaveBeenCalledTimes(2)
+  })
+
+  it('renders ToggleSwitch per item when pending_states flag is enabled', () => {
+    window.FEATURE_FLAGS = { pending_states: true }
+    const dispatch = jest.fn()
+    render(
+      <RawEquipmentCtrlPanel
+        equipment={equipment}
+        outlets={outlets}
+        fetchEquipment={jest.fn()}
+        updateEquipment={jest.fn()}
+        dispatch={dispatch}
+      />
+    )
+    const switches = screen.getAllByRole('switch')
+    expect(switches).toHaveLength(2)
+    window.FEATURE_FLAGS = {}
+  })
+
+  it('PendingEquipmentToggle receives id and name from useEquipmentToggle', () => {
+    const { useEquipmentToggle } = require('../../design-system/ui_kits/reef-pi-app/hooks/useEquipmentToggle')
+    window.FEATURE_FLAGS = { pending_states: true }
+    const dispatch = jest.fn()
+    render(
+      <RawEquipmentCtrlPanel
+        equipment={[equipment[0]]}
+        outlets={outlets}
+        fetchEquipment={jest.fn()}
+        updateEquipment={jest.fn()}
+        dispatch={dispatch}
+      />
+    )
+    expect(useEquipmentToggle).toHaveBeenCalledWith(
+      expect.objectContaining({ id: equipment[0].id, name: equipment[0].name })
+    )
+    window.FEATURE_FLAGS = {}
   })
 })


### PR DESCRIPTION
## Summary
- Mocks `useEquipmentToggle` at module level to allow RTL rendering of `PendingEquipmentToggle`
- Adds two RTL tests: one verifies `ToggleSwitch` (role=switch) renders per equipment item when `pending_states` flag is on; the other verifies `useEquipmentToggle` is called with the correct `id` and `name` props
- Existing class-instantiation tests continue to work (mock is inert when `pending_states` is off)

## Test plan
- All 8 ctrl_panel tests pass
- `yarn jest "src/equipment/ctrl_panel.test"` green

Closes #2980

🤖 Generated with [Claude Code](https://claude.com/claude-code)