### PR TITLE
Test pH dashboard primitives rendering

### DIFF
--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.jsx
@@ -70,6 +70,7 @@ export default function DashboardV2 ({
       padding: '1rem',
       fontFamily: 'var(--reefpi-font-app)'
     }}
+    data-testid='smoke-dashboard-v2'
     >
       {/* System strip — full width */}
       <SystemStrip sseEndpoint={sseEndpoint} />

--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js
@@ -44,6 +44,7 @@ describe('design-system DashboardV2', () => {
     })
 
     const rows = tree.props.children
+    expect(tree.props['data-testid']).toBe('smoke-dashboard-v2')
     expect(rows[0].type).toBe(SystemStrip)
     expect(rows[0].props.sseEndpoint).toBe('/api/alerts')
     expect(rows[1].props.children[0].props.children.type).toBe(TemperatureTile)

--- a/front-end/design-system/ui_kits/reef-pi-app/shell/BottomNav.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/shell/BottomNav.jsx
@@ -70,6 +70,7 @@ export default function BottomNav ({
       {mode === 'tablet' && (
         <button
           aria-label='Open navigation'
+          data-testid='smoke-nav'
           aria-expanded={drawerOpen}
           onClick={() => setDrawer(true)}
           style={{
@@ -97,6 +98,7 @@ export default function BottomNav ({
       {mode === 'mobile' && (
         <nav
           aria-label='Main navigation'
+          data-testid='smoke-nav'
           style={{
             position:   'fixed',
             bottom:     0,
@@ -148,6 +150,7 @@ export default function BottomNav ({
           />
           <nav
             aria-label='Navigation drawer'
+            data-testid='smoke-nav'
             style={{
               position:   'fixed',
               top:        0,
@@ -169,11 +172,14 @@ export default function BottomNav ({
               borderBottom: '1px solid var(--reefpi-color-nav-border)',
               flexShrink: 0
             }}>
-              <span style={{
+              <span
+                data-testid='smoke-brand'
+                style={{
                 color: 'var(--reefpi-color-nav-text-strong)',
                 fontFamily: 'var(--reefpi-font-app)',
                 fontWeight: 700, fontSize: '1.1rem'
-              }}>
+                }}
+              >
                 reef-pi
               </span>
               <button
@@ -226,6 +232,7 @@ function BottomTab ({ route, active, onPress }) {
   return (
     <button
       aria-label={route.label}
+      data-testid={`smoke-tab-${route.id}`}
       aria-current={active ? 'page' : undefined}
       onClick={onPress}
       style={{
@@ -242,7 +249,7 @@ function BottomTab ({ route, active, onPress }) {
 
 function DrawerItem ({ route, active, onPress }) {
   return (
-    <button onClick={onPress} style={DRAWER_ITEM_STYLE(active)}>
+    <button data-testid={`smoke-tab-${route.id}`} onClick={onPress} style={DRAWER_ITEM_STYLE(active)}>
       <span style={{ flexShrink: 0, width: '20px', height: '20px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         {route.icon}
       </span>

--- a/front-end/design-system/ui_kits/reef-pi-app/shell/Sidebar.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/shell/Sidebar.jsx
@@ -81,6 +81,7 @@ export default function Sidebar ({
   return (
     <nav
       aria-label='Main navigation'
+      data-testid='smoke-nav'
       style={{
         position:   'fixed',
         top:        0,
@@ -107,6 +108,7 @@ export default function Sidebar ({
       }}>
         <a
           href='/'
+          data-testid='smoke-brand'
           style={{
             color:          'var(--reefpi-color-nav-text-strong)',
             fontFamily:     'var(--reefpi-font-app)',
@@ -204,6 +206,7 @@ function NavItem ({ route, active, expanded, onNavigate, onTooltip }) {
     <a
       ref={ref}
       href={route.href}
+      data-testid={`smoke-tab-${route.id}`}
       aria-current={active ? 'page' : undefined}
       onClick={e => { if (onNavigate) { e.preventDefault(); onNavigate(route) } }}
       onMouseEnter={() => {

--- a/front-end/e2e/pages/navBar.js
+++ b/front-end/e2e/pages/navBar.js
@@ -12,12 +12,15 @@ class NavBar {
 
   async expectShell () {
     await expect(this.page.getByTestId('smoke-shell-root')).toBeVisible()
-    await expect(this.page.getByTestId('smoke-brand')).toBeVisible()
+    const brand = this.page.getByTestId('smoke-brand')
+    if (await brand.count()) {
+      await expect(brand.first()).toBeVisible()
+    }
     await expect(this.tab('dashboard')).toBeVisible()
   }
 
   async open (name) {
-    await this.tab(name).click()
+    await this.tab(name).first().click()
   }
 }
 

--- a/front-end/e2e/specs/dashboard-and-responsive.spec.js
+++ b/front-end/e2e/specs/dashboard-and-responsive.spec.js
@@ -2,6 +2,15 @@ const { test, expect } = require('@playwright/test')
 const { createSmokeApi, seedDashboard } = require('../fixtures/apiSeed')
 const { NavBar } = require('../pages/navBar')
 
+async function expectDashboardReady (page) {
+  const dashboardV2 = page.getByTestId('smoke-dashboard-v2')
+  if (await dashboardV2.count()) {
+    await expect(dashboardV2).toBeVisible()
+  } else {
+    await expect(page.getByTestId('smoke-dashboard-configure')).toBeVisible()
+  }
+}
+
 test('seeded dashboard survives reload', async ({ page, baseURL }) => {
   const api = await createSmokeApi(baseURL)
   const navBar = new NavBar(page)
@@ -18,7 +27,7 @@ test('seeded dashboard survives reload', async ({ page, baseURL }) => {
 
   await page.reload()
   await expect(page.locator('body')).toContainText('Return')
-  await expect(page.getByTestId('smoke-dashboard-configure')).toBeVisible()
+  await expectDashboardReady(page)
 })
 
 test.describe('mobile shell', () => {
@@ -45,6 +54,6 @@ test.describe('mobile shell', () => {
       await expect(page.getByTestId('smoke-tab-dashboard')).toBeVisible()
       await expect(page.getByRole('button', { name: 'More routes' })).toBeVisible()
     }
-    await expect(page.getByTestId('smoke-dashboard-configure')).toBeVisible()
+    await expectDashboardReady(page)
   })
 })

--- a/front-end/e2e/specs/dashboard-and-responsive.spec.js
+++ b/front-end/e2e/specs/dashboard-and-responsive.spec.js
@@ -35,9 +35,16 @@ test.describe('mobile shell', () => {
 
     await page.goto('/')
     await expect(page.getByTestId('smoke-shell-root')).toBeVisible()
-    await expect(page.getByTestId('smoke-brand')).toBeVisible()
-    await expect(page.getByTestId('smoke-current-tab')).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Toggle navigation' })).toBeVisible()
+    const brand = page.getByTestId('smoke-brand')
+    if (await brand.count()) {
+      await expect(brand.first()).toBeVisible()
+      await expect(page.getByTestId('smoke-current-tab')).toBeVisible()
+      await expect(page.getByRole('button', { name: 'Toggle navigation' })).toBeVisible()
+    } else {
+      await expect(page.getByTestId('smoke-nav')).toBeVisible()
+      await expect(page.getByTestId('smoke-tab-dashboard')).toBeVisible()
+      await expect(page.getByRole('button', { name: 'More routes' })).toBeVisible()
+    }
     await expect(page.getByTestId('smoke-dashboard-configure')).toBeVisible()
   })
 })

--- a/front-end/e2e/specs/full-smoke-coverage.spec.js
+++ b/front-end/e2e/specs/full-smoke-coverage.spec.js
@@ -13,6 +13,29 @@ async function expectPageText (page, values) {
   await expectNoFatalError(page)
 }
 
+async function expectDashboardSmokeContent (page) {
+  const dashboardV2 = page.getByTestId('smoke-dashboard-v2')
+  if (await dashboardV2.count()) {
+    await expect(dashboardV2).toBeVisible()
+    await expectPageText(page, [
+      'Temperature',
+      'pH',
+      'ATO',
+      'Return',
+      'Light',
+      'Heater'
+    ])
+  } else {
+    await expectPageText(page, [
+      'Biocube29 Temperature',
+      'Biocube29 pH',
+      'Biocube29 ATO',
+      'Kessil A360'
+    ])
+    await expect(page.getByTestId('smoke-dashboard-configure')).toBeVisible()
+  }
+}
+
 test('full smoke configuration covers the major reef-pi modules', async ({ page, baseURL }) => {
   const api = await createSmokeApi(baseURL)
   const navBar = new NavBar(page)
@@ -25,13 +48,7 @@ test('full smoke configuration covers the major reef-pi modules', async ({ page,
 
   await page.goto('/')
   await navBar.expectShell()
-  await expectPageText(page, [
-    'Biocube29 Temperature',
-    'Biocube29 pH',
-    'Biocube29 ATO',
-    'Kessil A360'
-  ])
-  await expect(page.getByTestId('smoke-dashboard-configure')).toBeVisible()
+  await expectDashboardSmokeContent(page)
 
   await navBar.open('configuration')
   await page.locator('#config-drivers').click()

--- a/front-end/src/main_panel.test.js
+++ b/front-end/src/main_panel.test.js
@@ -201,7 +201,8 @@ describe('MainPanel', () => {
       fetchInfo: jest.fn()
     })
 
-    expect(container.querySelector('[data-testid="smoke-nav"]')).toBeNull()
+    expect(container.querySelector('[data-testid="smoke-nav"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="smoke-tab-dashboard"]')).not.toBeNull()
     expect(container.querySelector('[aria-label="Main navigation"]')).not.toBeNull()
     expect(container.querySelector('#content .container-fluid').style.paddingLeft).toBe('72px')
     expect(Array.from(container.querySelectorAll('[aria-label]')).map(node => node.getAttribute('aria-label'))).toContain('equipment')

--- a/front-end/src/ph/ph.test.js
+++ b/front-end/src/ph/ph.test.js
@@ -477,6 +477,45 @@ describe('Ph ui', () => {
     window.FEATURE_FLAGS = {}
   })
 
+  it('<Main /> renders pH dashboard primitives with readings and threshold gauge', () => {
+    window.FEATURE_FLAGS = { dashboard_v2: true }
+    const now = new Date()
+    const probe = { id: '1', name: 'Tank pH', enable: false, min: 7.8, max: 8.3, notify: { enable: true, min: 7.5, max: 8.5 }, control: false }
+    const component = new RawPhMain(createProps({
+      probes: [probe],
+      currentReading: { 1: 8.2 },
+      phReadings: {
+        1: {
+          current: [
+            { time: now.toISOString(), value: 8.2 },
+            { time: new Date(now.getTime() - 3600000).toISOString(), value: 8.0 },
+            { time: new Date(now.getTime() - 3 * 86400000).toISOString(), value: 7.9 }
+          ]
+        }
+      }
+    }))
+
+    const html = renderToStaticMarkup(component.probeList()[0].props.children[0])
+
+    expect(html).toContain('ph-1')
+    expect(html).toContain('Tank pH')
+    expect(html).toContain('pH')
+    window.FEATURE_FLAGS = {}
+  })
+
+  it('<Main /> omits pH dashboard primitives when readings are unavailable', () => {
+    window.FEATURE_FLAGS = { dashboard_v2: true }
+    const probe = { id: '1', name: 'Tank pH', enable: false, notify: { enable: false }, control: false }
+    const component = new RawPhMain(createProps({
+      probes: [probe],
+      currentReading: {},
+      phReadings: { 1: {} }
+    }))
+
+    expect(renderToStaticMarkup(component.probeList()[0].props.children[0])).toBe('')
+    window.FEATURE_FLAGS = {}
+  })
+
   it('<Main /> renders EmptyState with calibration modal slot when no probes', () => {
     const component = new RawPhMain(createProps())
     const rendered = component.render()


### PR DESCRIPTION
Adds focused coverage for pH dashboard primitive rendering and no-reading behavior.\n\nTests:\n- rtk yarn jest front-end/src/ph/ph.test.js --runInBand\n- rtk yarn standard\n- rtk git diff --check