### PR TITLE
Test temperature sensor read paths

### DIFF
--- a/controller/modules/temperature/sensor_test.go
+++ b/controller/modules/temperature/sensor_test.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/reef-pi/reef-pi/controller"
 )
 
 func Test_ReadTemperature(t *testing.T) {
@@ -43,6 +45,92 @@ func Test_InvalidTemperature(t *testing.T) {
 		t.Error("value is out of range and should be an error")
 	}
 
+}
+
+func TestReadTemperatureInvalidPayloads(t *testing.T) {
+	tc := TC{}
+
+	tests := []struct {
+		name string
+		data string
+	}{
+		{
+			name: "missing first line",
+			data: "",
+		},
+		{
+			name: "crc not ready",
+			data: "76 01 4b 46 7f ff 0a 10 79 : crc=79 NO\n76 01 4b 46 7f ff 0a 10 79 t=23375",
+		},
+		{
+			name: "missing second line",
+			data: "76 01 4b 46 7f ff 0a 10 79 : crc=79 YES\n",
+		},
+		{
+			name: "missing temperature separator",
+			data: "76 01 4b 46 7f ff 0a 10 79 : crc=79 YES\n76 01 4b 46 7f ff 0a 10 79 t23375",
+		},
+		{
+			name: "non numeric temperature",
+			data: "76 01 4b 46 7f ff 0a 10 79 : crc=79 YES\n76 01 4b 46 7f ff 0a 10 79 t=warm",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := tc.readTemperature(strings.NewReader(tt.data)); err == nil {
+				t.Fatal("expected invalid payload to return an error")
+			}
+		})
+	}
+}
+
+func TestReadTemperatureCelsius(t *testing.T) {
+	data := `76 01 4b 46 7f ff 0a 10 79 : crc=79 YES
+76 01 4b 46 7f ff 0a 10 79 t=23375`
+	tc := TC{}
+	v, err := tc.readTemperature(strings.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != 23.38 {
+		t.Fatalf("expected 23.38, got %v", v)
+	}
+}
+
+func TestReadDevMode(t *testing.T) {
+	c := setupTempController(t)
+
+	v, err := c.Read(&TC{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v < 24.4 || v > 25.9 {
+		t.Fatalf("expected celsius dev reading in range, got %v", v)
+	}
+
+	v, err = c.Read(&TC{Fahrenheit: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v < 78 || v > 81 {
+		t.Fatalf("expected fahrenheit dev reading in range, got %v", v)
+	}
+}
+
+func TestReadMissingDevice(t *testing.T) {
+	con, err := controller.TestController()
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := New(false, con)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v, err := c.Read(&TC{Sensor: "28-missing"}); err == nil {
+		t.Fatalf("expected missing sensor read to fail, got value %v", v)
+	}
 }
 
 func readFromFile(path string) (float32, error) {


### PR DESCRIPTION
Closes #2993.\n\nAdds focused temperature sensor read coverage for invalid payloads, celsius parsing, dev-mode reads, and missing device failures.\n\nValidation:\n- go test ./controller/modules/temperature\n- go test -cover ./controller/modules/temperature: 75.5% statements