### PR TITLE
Test auth edge paths

### DIFF
--- a/controller/utils/auth_test.go
+++ b/controller/utils/auth_test.go
@@ -2,13 +2,41 @@ package utils
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
 
+	"github.com/gorilla/sessions"
 	"github.com/reef-pi/reef-pi/controller/storage"
 )
+
+func testAuthStore(t *testing.T, dbPath string, creds Credentials) (storage.Store, Auth) {
+	t.Helper()
+	os.Remove(dbPath)
+	store, err := storage.NewStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateBucket("reef-pi"); err != nil {
+		store.Close()
+		os.Remove(dbPath)
+		t.Fatal(err)
+	}
+	if err := store.Update("reef-pi", "credentials", creds); err != nil {
+		store.Close()
+		os.Remove(dbPath)
+		t.Fatal(err)
+	}
+	a, err := NewAuth("reef-pi", store)
+	if err != nil {
+		store.Close()
+		os.Remove(dbPath)
+		t.Fatal(err)
+	}
+	return store, a
+}
 
 func TestAuthDefaultCredentials(t *testing.T) {
 	dbPath := "auth-default-test.db"
@@ -30,19 +58,8 @@ func TestAuthDefaultCredentials(t *testing.T) {
 }
 
 func TestAuthenticate(t *testing.T) {
-	dbPath := "auth-middleware-test.db"
-	os.Remove(dbPath)
-	store, err := storage.NewStore(dbPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { store.Close(); os.Remove(dbPath) }()
-	store.CreateBucket("reef-pi")
-	store.Update("reef-pi", "credentials", Credentials{User: "reef-pi", Password: "reef-pi"})
-	a, err := NewAuth("reef-pi", store)
-	if err != nil {
-		t.Fatal(err)
-	}
+	store, a := testAuthStore(t, "auth-middleware-test.db", Credentials{User: "reef-pi", Password: "reef-pi"})
+	defer func() { store.Close(); os.Remove("auth-middleware-test.db") }()
 
 	called := false
 	handler := a.Authenticate(func(w http.ResponseWriter, r *http.Request) {
@@ -61,20 +78,63 @@ func TestAuthenticate(t *testing.T) {
 	}
 }
 
+func TestAuthenticateAllowsSignedInSession(t *testing.T) {
+	store, authHandler := testAuthStore(t, "auth-middleware-success-test.db", Credentials{User: "reef-pi", Password: "reef-pi"})
+	defer func() { store.Close(); os.Remove("auth-middleware-success-test.db") }()
+
+	a := authHandler.(*auth)
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	rr := httptest.NewRecorder()
+	session, err := a.cookiejar.Get(req, "auth")
+	if err != nil {
+		t.Fatal(err)
+	}
+	session.Values["user"] = "reef-pi"
+	if err := session.Save(req, rr); err != nil {
+		t.Fatal(err)
+	}
+
+	req = httptest.NewRequest("GET", "/api/test", nil)
+	req.Header.Set("Cookie", rr.Header().Get("Set-Cookie"))
+	rr = httptest.NewRecorder()
+	called := false
+	a.Authenticate(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusAccepted)
+	})(rr, req)
+
+	if !called {
+		t.Fatal("expected authenticated handler to run")
+	}
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("expected status %d, got %d", http.StatusAccepted, rr.Code)
+	}
+}
+
+func TestAuthenticateRejectsInvalidSessionCookie(t *testing.T) {
+	store, a := testAuthStore(t, "auth-middleware-bad-cookie-test.db", Credentials{User: "reef-pi", Password: "reef-pi"})
+	defer func() { store.Close(); os.Remove("auth-middleware-bad-cookie-test.db") }()
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: "not-a-valid-session"})
+	rr := httptest.NewRecorder()
+	called := false
+
+	a.Authenticate(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})(rr, req)
+
+	if called {
+		t.Fatal("handler should not be called for an invalid session cookie")
+	}
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, rr.Code)
+	}
+}
+
 func TestSignInFailure(t *testing.T) {
-	dbPath := "auth-signin-fail-test.db"
-	os.Remove(dbPath)
-	store, err := storage.NewStore(dbPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { store.Close(); os.Remove(dbPath) }()
-	store.CreateBucket("reef-pi")
-	store.Update("reef-pi", "credentials", Credentials{User: "reef-pi", Password: "reef-pi"})
-	a, err := NewAuth("reef-pi", store)
-	if err != nil {
-		t.Fatal(err)
-	}
+	store, a := testAuthStore(t, "auth-signin-fail-test.db", Credentials{User: "reef-pi", Password: "reef-pi"})
+	defer func() { store.Close(); os.Remove("auth-signin-fail-test.db") }()
 
 	tr := NewTestRouter()
 	tr.Router.HandleFunc("/sign_in", a.SignIn).Methods("POST")
@@ -91,19 +151,8 @@ func TestSignInFailure(t *testing.T) {
 }
 
 func TestSignInEmptyBody(t *testing.T) {
-	dbPath := "auth-signin-empty-test.db"
-	os.Remove(dbPath)
-	store, err := storage.NewStore(dbPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { store.Close(); os.Remove(dbPath) }()
-	store.CreateBucket("reef-pi")
-	store.Update("reef-pi", "credentials", Credentials{User: "reef-pi", Password: "reef-pi"})
-	a, err := NewAuth("reef-pi", store)
-	if err != nil {
-		t.Fatal(err)
-	}
+	store, a := testAuthStore(t, "auth-signin-empty-test.db", Credentials{User: "reef-pi", Password: "reef-pi"})
+	defer func() { store.Close(); os.Remove("auth-signin-empty-test.db") }()
 
 	tr := NewTestRouter()
 	tr.Router.HandleFunc("/sign_in", a.SignIn).Methods("POST")
@@ -114,6 +163,81 @@ func TestSignInEmptyBody(t *testing.T) {
 	tr.Router.ServeHTTP(rr, req)
 	if rr.Code != 400 {
 		t.Errorf("Sign-in with nil body should return 400, got %d", rr.Code)
+	}
+}
+
+func TestSignInInvalidJSON(t *testing.T) {
+	store, a := testAuthStore(t, "auth-signin-invalid-json-test.db", Credentials{User: "reef-pi", Password: "reef-pi"})
+	defer func() { store.Close(); os.Remove("auth-signin-invalid-json-test.db") }()
+
+	req := httptest.NewRequest("POST", "/sign_in", bytes.NewBufferString("{"))
+	rr := httptest.NewRecorder()
+	a.SignIn(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+}
+
+func TestSignInAlreadyLoggedIn(t *testing.T) {
+	store, authHandler := testAuthStore(t, "auth-signin-existing-session-test.db", Credentials{User: "reef-pi", Password: "reef-pi"})
+	defer func() { store.Close(); os.Remove("auth-signin-existing-session-test.db") }()
+
+	a := authHandler.(*auth)
+	req := httptest.NewRequest("POST", "/sign_in", bytes.NewBufferString(`{"user":"reef-pi","password":"reef-pi"}`))
+	rr := httptest.NewRecorder()
+	session, err := a.cookiejar.Get(req, "auth")
+	if err != nil {
+		t.Fatal(err)
+	}
+	session.Values["user"] = "reef-pi"
+	if err := session.Save(req, rr); err != nil {
+		t.Fatal(err)
+	}
+
+	req = httptest.NewRequest("POST", "/sign_in", bytes.NewBufferString(`{"user":"reef-pi","password":"reef-pi"}`))
+	req.Header.Set("Cookie", rr.Header().Get("Set-Cookie"))
+	rr = httptest.NewRecorder()
+	a.SignIn(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rr.Code)
+	}
+	var payload interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("expected json response, got %q: %v", rr.Body.String(), err)
+	}
+}
+
+func TestSignInCredentialsLookupError(t *testing.T) {
+	store, err := storage.NewStore("auth-signin-lookup-error-test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { store.Close(); os.Remove("auth-signin-lookup-error-test.db") }()
+	a := &auth{
+		credentialsManager: NewCredentialsManager(store, "missing-bucket"),
+		cookiejar:          sessions.NewCookieStore([]byte("reef-pi-key")),
+	}
+
+	req := httptest.NewRequest("POST", "/sign_in", bytes.NewBufferString(`{"user":"reef-pi","password":"reef-pi"}`))
+	rr := httptest.NewRecorder()
+	a.SignIn(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status %d, got %d", http.StatusInternalServerError, rr.Code)
+	}
+}
+
+func TestNewAuthReturnsDefaultCredentialsError(t *testing.T) {
+	store, err := storage.NewStore("auth-default-error-test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { store.Close(); os.Remove("auth-default-error-test.db") }()
+
+	if _, err := NewAuth("missing-bucket", store); err == nil {
+		t.Fatal("expected NewAuth to fail when default credentials cannot be saved")
 	}
 }
 


### PR DESCRIPTION
Closes #2995.\n\nAdds focused auth utility coverage for authenticated sessions, invalid cookies, sign-in JSON/session/error branches, and NewAuth default credential errors.\n\nValidation:\n- go test ./controller/utils\n- go test -cover ./controller/utils: 78.3% statements