### PR TITLE
coverage: display.jsx and camera/config.jsx render paths

### DIFF
--- a/front-end/src/camera/camera.test.js
+++ b/front-end/src/camera/camera.test.js
@@ -223,6 +223,24 @@ describe('Camera module', () => {
     expect(config.state.config).not.toBe(previousConfig)
   })
 
+  it('<Config /> render returns loading div when enable is undefined', () => {
+    const config = new Config({ config: { tick_interval: 1 }, update: jest.fn() })
+    const rendered = config.render()
+    expect(rendered.type).toBe('div')
+    expect(rendered.props.className).toBe('container')
+    expect(rendered.props.children).toBeTruthy()
+  })
+
+  it('<Config /> render shows danger save button when updated is true', () => {
+    const config = new Config({ config: { tick_interval: 1, enable: true }, update: jest.fn() })
+    config.setState = jest.fn(next => {
+      config.state = { ...config.state, ...next }
+    })
+    config.state.updated = true
+    const saveButton = config.render().props.children[5].props.children
+    expect(saveButton.props.className).toContain('btn-outline-danger')
+  })
+
   it('<Config /> saves parsed config without mutating state config', () => {
     const update = jest.fn()
     const config = new Config({ config: { tick_interval: '5', enable: true }, update })

--- a/front-end/src/configuration/configuration.test.js
+++ b/front-end/src/configuration/configuration.test.js
@@ -130,6 +130,21 @@ describe('Configuration ui', () => {
     expect(RawDisplay.getDerivedStateFromProps({ config: undefined }, {})).toBeNull()
   })
 
+  it('<Display /> getDerivedStateFromProps returns null for empty config object', () => {
+    expect(RawDisplay.getDerivedStateFromProps({ config: {} }, {})).toBeNull()
+  })
+
+  it('<Display /> render applies danger style when state.on is true', () => {
+    const component = new RawDisplay({
+      config: { brightness: 50, on: true },
+      fetchDisplay: jest.fn(),
+      switchDisplay: jest.fn(),
+      setBrightness: jest.fn()
+    })
+    const button = component.render().props.children[0].props.children[0]
+    expect(button.props.className).toBe('btn btn-outline-danger')
+  })
+
   it('<Errors /> fetches, renders alert/count badges, deletes, and clears', () => {
     const props = {
       errors: [


### PR DESCRIPTION
## Summary
- Adds `getDerivedStateFromProps` test for empty config object (`config: {}` → returns null, line 22 in display.jsx)
- Adds render test with `state.on=true` to cover the danger-style branch (lines 52–54 in display.jsx)
- Adds render test for loading div when `config.enable === undefined` (lines 57–62 in camera/config.jsx)
- Adds render test with `updated=true` to cover the danger save-button class (lines 64–67 in camera/config.jsx)

## Test plan
- [ ] `yarn jest "src/configuration/configuration.test.js" "src/camera/camera.test.js"` → 53 tests pass

Closes #2998

🤖 Generated with [Claude Code](https://claude.com/claude-code)