### PR TITLE
coverage: equipment_form.jsx handleSubmit via RTL form submit

### DIFF
--- a/front-end/src/equipment/equipment.test.js
+++ b/front-end/src/equipment/equipment.test.js
@@ -1,4 +1,5 @@
 import React, { act } from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import Equipment from './equipment'
 import ViewEquipment from './view_equipment'
@@ -391,5 +392,27 @@ describe('Equipment ui', () => {
   it('<Chart />', () => {
     const component = new RawEquipmentChart({ equipment: undefined, fetchEquipment: jest.fn(), height: 200 })
     expect(component.render().type).toBe('div')
+  })
+
+  it('<EquipmentForm /> handleSubmit calls onSubmit with validated values', async () => {
+    const onSubmit = jest.fn()
+    render(
+      <EquipmentForm
+        actionLabel='save'
+        outlets={[{ id: '1', name: 'O1' }]}
+        onSubmit={onSubmit}
+      />
+    )
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('smoke-equipment-name'), { target: { value: 'Heater' } })
+      fireEvent.change(screen.getByTestId('smoke-equipment-outlet'), { target: { value: '1' } })
+    })
+
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId('smoke-equipment-submit').closest('form'))
+    })
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ name: 'Heater', outlet: '1' }))
   })
 })


### PR DESCRIPTION
## Summary
- Adds `@testing-library/react` import to `equipment.test.js`
- Adds RTL test that renders `<EquipmentForm>` with valid name + outlet, submits the form via `fireEvent.submit`, and asserts `onSubmit` is called with the validated values — covering the formik `handleSubmit` config at line 19 of `equipment_form.jsx`

## Test plan
- [ ] `yarn jest "src/equipment/equipment.test.js"` → 23 tests pass

Closes #3008

🤖 Generated with [Claude Code](https://claude.com/claude-code)