### PR TITLE
coverage: redux/actions/ui.js switch cases for all capabilities

### DIFF
--- a/front-end/src/redux/actions/ui.test.js
+++ b/front-end/src/redux/actions/ui.test.js
@@ -64,4 +64,43 @@ describe('ui actions', () => {
       }))
     })
   })
+
+  it('fetchUIData dispatches all capability-gated fetches when all flags are true', () => {
+    const caps = {
+      ato: true,
+      ph: true,
+      temperature: true,
+      lighting: true,
+      equipment: true,
+      doser: true,
+      timers: true,
+      macro: true,
+      journal: true
+    }
+    fetchMock.getOnce('/api/capabilities', caps)
+    fetchMock.getOnce('/api/info', {})
+    fetchMock.getOnce('/api/atos', [])
+    fetchMock.getOnce('/api/phprobes', [])
+    fetchMock.getOnce('/api/tcs', [])
+    fetchMock.getOnce('/api/lights', [])
+    fetchMock.getOnce('/api/equipment', [])
+    fetchMock.getOnce('/api/doser/pumps', [])
+    fetchMock.getOnce('/api/timers', [])
+    fetchMock.getOnce('/api/macros', [])
+    fetchMock.getOnce('/api/journal', [])
+    fetchMock.getOnce('/api/inlets', [])
+    fetchMock.getOnce('/api/jacks', [])
+    fetchMock.getOnce('/api/drivers', [])
+    fetchMock.getOnce('/api/analog_inputs', [])
+    fetchMock.getOnce('/api/outlets', [])
+    fetchMock.getOnce('/api/errors', [])
+    const store = mockStore()
+    return store.dispatch(fetchUIData()).then(() => {
+      expect(fetchMock.called('/api/equipment')).toBe(true)
+      expect(fetchMock.called('/api/doser/pumps')).toBe(true)
+      expect(fetchMock.called('/api/timers')).toBe(true)
+      expect(fetchMock.called('/api/macros')).toBe(true)
+      expect(fetchMock.called('/api/journal')).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- Adds a `fetchUIData` test with all capability flags set to `true`, mocking all relevant API endpoints
- Covers the previously unreachable `case 'equipment'`, `case 'doser'`, `case 'timers'`, `case 'macro'`, and `case 'journal'` branches in `fetchControllerData` (lines 47–61 of `ui.js`)

## Test plan
- [ ] `yarn jest "src/redux/actions/ui.test.js"` → 3 tests pass

Closes #3009

🤖 Generated with [Claude Code](https://claude.com/claude-code)