### PR TITLE
Test lighting usage and disable paths

### DIFF
--- a/controller/modules/lighting/controller_test.go
+++ b/controller/modules/lighting/controller_test.go
@@ -1,12 +1,16 @@
 package lighting
 
 import (
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/reef-pi/reef-pi/controller"
+	"github.com/reef-pi/reef-pi/controller/device_manager/connectors"
+	"github.com/reef-pi/reef-pi/controller/device_manager/drivers"
 	"github.com/reef-pi/reef-pi/controller/storage"
 	"github.com/reef-pi/reef-pi/controller/telemetry"
+	"github.com/reef-pi/reef-pi/controller/utils"
 )
 
 func TestLightingController(t *testing.T) {
@@ -95,5 +99,64 @@ func TestLightingUsageRollupBefore(t *testing.T) {
 	}
 	if u2.Before(u1) {
 		t.Error("Expected u2.Before(u1) to be false")
+	}
+}
+
+func TestLightingUsageAndDisable(t *testing.T) {
+	con, err := controller.TestController()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer con.Store().Close()
+
+	driver := drivers.Driver{
+		Name:   "lighting",
+		Type:   "pca9685",
+		Config: []byte(`{"address":64, "frequency":1000}`),
+	}
+	if err := con.DM().Drivers().Create(driver); err != nil {
+		t.Fatal(err)
+	}
+	jacks := con.DM().Jacks()
+	if err := jacks.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	if err := jacks.Create(connectors.Jack{Name: "J1", Pins: []int{3}, Driver: "1"}); err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := New(Config{Interval: time.Hour}, con)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Create(Light{
+		Name:   "Refugium",
+		Jack:   "1",
+		Enable: true,
+		Channels: map[int]*Channel{
+			3: {Name: "white", Manual: true, Value: 42},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	c.Stop()
+
+	tr := utils.NewTestRouter()
+	c.LoadAPI(tr.Router)
+	if err := tr.Do("GET", "/api/lights/1/usage", strings.NewReader("{}"), nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.On("1", false); err != nil {
+		t.Fatal(err)
+	}
+	l, err := c.Get("1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if l.Enable {
+		t.Fatal("expected light to be disabled")
 	}
 }


### PR DESCRIPTION
## Summary
- add coverage for lighting usage API path
- cover disabling an enabled light and persisted state

## Test
- go test -cover ./controller/modules/lighting

Closes #3015