### PR TITLE
Make command dispatch testable

### DIFF
--- a/commands/db_test.go
+++ b/commands/db_test.go
@@ -504,6 +504,69 @@ func TestMainUnknownCommand(t *testing.T) {
 	}
 }
 
+func TestRunResetPasswordDispatch(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "reef-pi.yml")
+	if err := os.WriteFile(configPath, []byte("database: /tmp/reef-pi-test.db\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := runResetPassword
+	t.Cleanup(func() { runResetPassword = orig })
+	var gotDB, gotUser, gotPassword string
+	runResetPassword = func(db, user, password string) {
+		gotDB = db
+		gotUser = user
+		gotPassword = password
+	}
+
+	if err := run([]string{"reset-password", "-user", "reef", "-password", "secret", "-config", configPath}); err != nil {
+		t.Fatal(err)
+	}
+	if gotDB != "/tmp/reef-pi-test.db" || gotUser != "reef" || gotPassword != "secret" {
+		t.Fatalf("unexpected reset-password dispatch: db=%q user=%q password=%q", gotDB, gotUser, gotPassword)
+	}
+}
+
+func TestRunRestoreDbDispatch(t *testing.T) {
+	orig := runRestoreDb
+	t.Cleanup(func() { runRestoreDb = orig })
+	var gotCurrent, gotBackup, gotNext string
+	runRestoreDb = func(current, backup, next string) {
+		gotCurrent = current
+		gotBackup = backup
+		gotNext = next
+	}
+
+	if err := run([]string{"restore-db", "-current", "current.db", "-backup", "backup.db", "-new", "new.db"}); err != nil {
+		t.Fatal(err)
+	}
+	if gotCurrent != "current.db" || gotBackup != "backup.db" || gotNext != "new.db" {
+		t.Fatalf("unexpected restore-db dispatch: current=%q backup=%q new=%q", gotCurrent, gotBackup, gotNext)
+	}
+}
+
+func TestRunInstallError(t *testing.T) {
+	wantErr := errors.New("download failed")
+	orig := runInstall
+	t.Cleanup(func() { runInstall = orig })
+	runInstall = func(version string) error {
+		if version != "v1.2.3" {
+			t.Fatalf("unexpected install version: %q", version)
+		}
+		return wantErr
+	}
+
+	if err := run([]string{"install", "-version", "v1.2.3"}); !errors.Is(err, wantErr) {
+		t.Fatalf("expected install error %v, got %v", wantErr, err)
+	}
+}
+
+func TestRunDaemonConfigError(t *testing.T) {
+	if err := run([]string{"daemon", "-config", filepath.Join(t.TempDir(), "missing.yml")}); err == nil {
+		t.Fatal("expected daemon config load to fail")
+	}
+}
+
 func TestResetPassword(t *testing.T) {
 	dbPath, cleanup := setupTestDB(t)
 	defer cleanup()

--- a/commands/main.go
+++ b/commands/main.go
@@ -11,10 +11,24 @@ import (
 
 var Version string
 
-func main() {
+var (
+	runDaemonize     = daemonize
+	runResetPassword = resetPassword
+	runRestoreDb     = restoreDb
+	runInstall       = install
+)
 
-	version := flag.Bool("version", false, "Print version information")
-	flag.Usage = func() {
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func run(argv []string) error {
+	flags := flag.NewFlagSet("reef-pi", flag.ContinueOnError)
+	version := flags.Bool("version", false, "Print version information")
+	flags.Usage = func() {
 		text := `
     Usage: reef-pi [command] [OPTIONS]
 
@@ -32,31 +46,32 @@ func main() {
     `
 		fmt.Println(strings.TrimSpace(text))
 	}
-	flag.Parse()
+	if err := flags.Parse(argv); err != nil {
+		return err
+	}
 	if *version {
 		fmt.Println(Version)
-		return
+		return nil
 	}
 	var v string
 	args := []string{}
-	if len(os.Args) > 1 {
-		v = os.Args[1]
+	parsedArgs := flags.Args()
+	if len(parsedArgs) > 0 {
+		v = parsedArgs[0]
 	}
-	if len(os.Args) > 2 {
-		args = os.Args[2:]
+	if len(parsedArgs) > 1 {
+		args = parsedArgs[1:]
 	}
 	switch v {
 	case "db":
 		cmd, err := NewDBCmd(args)
 		if err != nil {
-			fmt.Println("Failed to parse command line flags. Error:", err)
-			os.Exit(1)
-		}
-		if err := cmd.Execute(); err != nil {
-			fmt.Println("Failed due to error:", err)
-			os.Exit(1)
+			return fmt.Errorf("Failed to parse command line flags. Error: %w", err)
 		}
 		defer cmd.Close()
+		if err := cmd.Execute(); err != nil {
+			return fmt.Errorf("Failed due to error: %w", err)
+		}
 	case "reset-password":
 		cmd := flag.NewFlagSet("reset-password", flag.ExitOnError)
 		user := cmd.String("user", "", "New reef-pi web ui username")
@@ -74,10 +89,9 @@ func main() {
 		cmd.Parse(args)
 		config, err := loadConfig(*configFile)
 		if err != nil {
-			fmt.Println("Failed to load config file. Error:", err)
-			os.Exit(1)
+			return fmt.Errorf("Failed to load config file. Error: %w", err)
 		}
-		resetPassword(config.Database, *user, *password)
+		runResetPassword(config.Database, *user, *password)
 	case "restore-db":
 		cmd := flag.NewFlagSet("restore-db", flag.ExitOnError)
 		cPath := cmd.String("current", "/var/lib/reef-pi/reef-pi.db", "Current database file path")
@@ -93,7 +107,7 @@ func main() {
 			cmd.PrintDefaults()
 		}
 		cmd.Parse(args)
-		restoreDb(*cPath, *oPath, *nPath)
+		runRestoreDb(*cPath, *oPath, *nPath)
 	case "install":
 		cmd := flag.NewFlagSet("install", flag.ExitOnError)
 		version := cmd.String("version", "", "Version to be installed")
@@ -107,9 +121,8 @@ func main() {
 			cmd.PrintDefaults()
 		}
 		cmd.Parse(args)
-		if err := install(*version); err != nil {
-			fmt.Println("reef-pi installed failed. Error:", err)
-			os.Exit(1)
+		if err := runInstall(*version); err != nil {
+			return fmt.Errorf("reef-pi installed failed. Error: %w", err)
 		}
 	case "", "daemon":
 		cmd := flag.NewFlagSet("daemon", flag.ExitOnError)
@@ -127,14 +140,13 @@ func main() {
 		cmd.Parse(args)
 		config, err := loadConfig(*configFile)
 		if err != nil {
-			fmt.Println("Failed to load config file. Error:", err)
-			os.Exit(1)
+			return fmt.Errorf("Failed to load config file. Error: %w", err)
 		}
-		daemonize(config.Database)
+		runDaemonize(config.Database)
 	default:
-		fmt.Println("Unknown command: '", v, "'")
-		os.Exit(1)
+		return fmt.Errorf("Unknown command: '%s'", v)
 	}
+	return nil
 }
 
 func loadConfig(file string) (daemon.Config, error) {


### PR DESCRIPTION
## Summary
- extract command dispatch into a testable run(argv) helper
- keep main responsible for printing errors and exiting
- add in-process dispatch coverage for reset-password, restore-db, install error, and daemon config errors

## Test
- go test ./commands
- go test -cover ./commands

Closes #3014