### PR TITLE
Test doser startup branches

### DIFF
--- a/controller/modules/doser/pump_test.go
+++ b/controller/modules/doser/pump_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	cron "github.com/robfig/cron/v3"
+
 	"github.com/reef-pi/reef-pi/controller"
 	"github.com/reef-pi/reef-pi/controller/device_manager/connectors"
 	"github.com/reef-pi/reef-pi/controller/device_manager/drivers"
@@ -156,6 +158,93 @@ func TestControllerOnRejectsEnabledPumpBeforeControl(t *testing.T) {
 	}
 }
 
+func TestControllerStartRegistersEnabledPumps(t *testing.T) {
+	con, err := controller.TestController()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer con.Store().Close()
+
+	ctrl, err := New(true, con)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ctrl.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	defer ctrl.Stop()
+
+	pumps := []Pump{
+		{
+			Name: "disabled",
+			Jack: "missing-jack",
+			Pin:  1,
+			Regiment: DosingRegiment{
+				Enable: false,
+				Schedule: Schedule{
+					Second: "0",
+					Minute: "0",
+					Hour:   "0",
+					Day:    "1",
+					Month:  "1",
+					Week:   "*",
+				},
+			},
+		},
+		{
+			Name: "scheduled",
+			Jack: "missing-jack",
+			Pin:  1,
+			Regiment: DosingRegiment{
+				Enable: true,
+				Schedule: Schedule{
+					Second: "0",
+					Minute: "0",
+					Hour:   "0",
+					Day:    "1",
+					Month:  "1",
+					Week:   "*",
+				},
+			},
+		},
+		{
+			Name: "continuous",
+			Jack: "missing-jack",
+			Pin:  1,
+			Regiment: DosingRegiment{
+				Enable:     true,
+				Continuous: true,
+				Speed:      25,
+			},
+		},
+	}
+	for _, p := range pumps {
+		if err := ctrl.Create(p); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ctrl.Stop()
+
+	ctrl.cronIDs = make(map[string]cron.EntryID)
+	ctrl.quitters = make(map[string]chan struct{})
+	ctrl.runner = cron.New(cron.WithParser(cron.NewParser(_cronParserSpec)))
+
+	ctrl.Start()
+
+	if _, ok := ctrl.cronIDs["2"]; !ok {
+		t.Fatalf("expected scheduled pump to be registered in cron, got %v", ctrl.cronIDs)
+	}
+	if _, ok := ctrl.cronIDs["1"]; ok {
+		t.Fatalf("disabled pump should not be registered in cron, got %v", ctrl.cronIDs)
+	}
+	if _, ok := ctrl.quitters["3"]; !ok {
+		t.Fatalf("expected continuous pump quitter, got %v", ctrl.quitters)
+	}
+	if _, ok := ctrl.quitters["1"]; ok {
+		t.Fatalf("disabled pump should not have a quitter, got %v", ctrl.quitters)
+	}
+}
+
 func TestDRV8825IsValid(t *testing.T) {
 	t.Parallel()
 
@@ -236,6 +325,50 @@ func TestDRV8825StepperOperationErrors(t *testing.T) {
 	}
 	if err := d.Dose(outlets, 1); err == nil {
 		t.Fatal("expected dose with missing pins to fail")
+	}
+}
+
+func TestDRV8825StepMicrosteppingModes(t *testing.T) {
+	con, err := controller.TestController()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer con.Store().Close()
+
+	outlets := con.DM().Outlets()
+	if err := outlets.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	outletPins := []struct {
+		name string
+		pin  int
+	}{
+		{name: "step", pin: 21},
+		{name: "direction", pin: 22},
+		{name: "micro-a", pin: 23},
+		{name: "micro-b", pin: 24},
+		{name: "micro-c", pin: 25},
+	}
+	for _, outlet := range outletPins {
+		if err := outlets.Create(connectors.Outlet{Name: outlet.name, Pin: outlet.pin, Driver: "rpi"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, mode := range []string{"Full", "Half", "1/4", "1/8", "1/16", "1/32", "unknown"} {
+		d := &DRV8825{
+			StepPin:       "1",
+			DirectionPin:  "2",
+			MSPinA:        "3",
+			MSPinB:        "4",
+			MSPinC:        "5",
+			Direction:     true,
+			Delay:         32,
+			MicroStepping: mode,
+		}
+		if err := d.Step(outlets, 0); err != nil {
+			t.Fatalf("Step failed for microstepping mode %q: %v", mode, err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- add coverage for doser controller startup branches
- cover enabled/disabled continuous dosing and cron registration paths
- exercise stepper Step microstepping branches without sleeps or host side effects

## Test
- go test ./controller/modules/doser
- go test -cover ./controller/modules/doser

Closes #3024