### PR TITLE
Test utils command and JSON branches

### DIFF
--- a/controller/utils/command_test.go
+++ b/controller/utils/command_test.go
@@ -20,3 +20,48 @@ func TestCommand(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestCommandRecordsBinaryAndArguments(t *testing.T) {
+	c := Command("reef-pi", "daemon", "-config", "config.yml")
+
+	if c.bin != "reef-pi" {
+		t.Fatalf("expected command binary reef-pi, got %q", c.bin)
+	}
+	if len(c.args) != 3 {
+		t.Fatalf("expected three args, got %#v", c.args)
+	}
+	if c.args[0] != "daemon" || c.args[1] != "-config" || c.args[2] != "config.yml" {
+		t.Fatalf("unexpected command args: %#v", c.args)
+	}
+}
+
+func TestCommandWithDevModeReturnsSameCommand(t *testing.T) {
+	c := Command("doesnotexist")
+
+	if got := c.WithDevMode(true); got != c {
+		t.Fatal("expected WithDevMode to return the same command")
+	}
+	if !c.DevMode {
+		t.Fatal("expected DevMode to be enabled")
+	}
+	if err := c.Run(); err != nil {
+		t.Fatalf("expected dev mode Run to skip execution: %v", err)
+	}
+}
+
+func TestCommandErrorsForMissingBinary(t *testing.T) {
+	missingBinary := "/path/to/reef-pi-missing-command"
+
+	if err := Command(missingBinary).Run(); err == nil {
+		t.Fatal("expected Run to fail for missing binary")
+	}
+	if output, err := Command(missingBinary).CombinedOutput(); err == nil {
+		t.Fatalf("expected CombinedOutput to fail for missing binary, output %q", string(output))
+	}
+}
+
+func TestCommandRunDetachedErrorsForMissingBinary(t *testing.T) {
+	if err := Command("/path/to/reef-pi-missing-command").RunDetached(); err == nil {
+		t.Fatal("expected RunDetached to fail for missing binary")
+	}
+}

--- a/controller/utils/http_json_test.go
+++ b/controller/utils/http_json_test.go
@@ -305,6 +305,14 @@ type testDoer struct{}
 
 func (t *testDoer) Do(_ func(interface{})) {}
 
+type usageDoer []interface{}
+
+func (u usageDoer) Do(fn func(interface{})) {
+	for _, item := range u {
+		fn(item)
+	}
+}
+
 func Test_JSONGetUsage(t *testing.T) {
 	d := &testDoer{}
 	fn := JSONGetUsage(d)
@@ -315,4 +323,57 @@ func Test_JSONGetUsage(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(fn)
 	handler.ServeHTTP(rr, req)
+}
+
+func TestJSONResponseEncoderErrorWritesInternalServerError(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/test", strings.NewReader("{}"))
+	rr := httptest.NewRecorder()
+
+	JSONResponse(make(chan int), rr, req)
+
+	assertJSONError(t, rr, http.StatusInternalServerError, "Failed to json decode. Error: json: unsupported type: chan int")
+}
+
+func TestJSONResponseWithStatusEncoderErrorKeepsInitialStatus(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/test", strings.NewReader("{}"))
+	rr := httptest.NewRecorder()
+
+	JSONResponseWithStatus(http.StatusAccepted, make(chan int), rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("expected initial status %d, got %d", http.StatusAccepted, rr.Code)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("expected JSON error response, got %q: %v", rr.Body.String(), err)
+	}
+	if payload["error"] != "Failed to json decode. Error: json: unsupported type: chan int" {
+		t.Fatalf("unexpected error payload: %#v", payload)
+	}
+}
+
+func TestJSONGetUsageFiltersNilItems(t *testing.T) {
+	fn := JSONGetUsage(usageDoer{
+		map[string]string{"name": "temperature"},
+		nil,
+		map[string]string{"name": "heater"},
+	})
+	req := httptest.NewRequest("GET", "/api/usage", strings.NewReader("{}"))
+	rr := httptest.NewRecorder()
+
+	http.HandlerFunc(fn).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rr.Code)
+	}
+	var payload []map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("expected usage JSON array, got %q: %v", rr.Body.String(), err)
+	}
+	if len(payload) != 2 {
+		t.Fatalf("expected nil usage items to be filtered, got %#v", payload)
+	}
+	if payload[0]["name"] != "temperature" || payload[1]["name"] != "heater" {
+		t.Fatalf("unexpected usage payload: %#v", payload)
+	}
 }


### PR DESCRIPTION
## Summary
- add coverage for command wrapper success and missing-binary error paths
- add safe RunDetached failure coverage
- cover JSON response encoder errors and JSONGetUsage nil filtering

## Test
- go test ./controller/utils
- go test -cover ./controller/utils

Closes #3025