### PR TITLE
Test temperature error and calibration branches

### DIFF
--- a/controller/modules/temperature/api_test.go
+++ b/controller/modules/temperature/api_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/reef-pi/hal"
 	"github.com/reef-pi/reef-pi/controller"
 	"github.com/reef-pi/reef-pi/controller/device_manager/connectors"
 	"github.com/reef-pi/reef-pi/controller/modules/equipment"
@@ -135,4 +136,36 @@ func TestTemperatureAPI(t *testing.T) {
 		t.Fatal("Failed to delete temperature controller config using api")
 	}
 	c.Stop()
+}
+
+func TestTemperatureCalibrateAPI(t *testing.T) {
+	c := setupTempController(t)
+	defer c.c.Store().Close()
+
+	tc := &TC{
+		Name:   "Water",
+		Period: 1,
+		Sensor: "28-api-calibration",
+	}
+	if err := c.Create(tc); err != nil {
+		t.Fatal(err)
+	}
+
+	tr := utils.NewTestRouter()
+	c.LoadAPI(tr.Router)
+
+	measurements := []hal.Measurement{
+		{Expected: 77, Observed: 76},
+		{Expected: 82, Observed: 80},
+	}
+	body := new(bytes.Buffer)
+	if err := json.NewEncoder(body).Encode(measurements); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.Do("POST", "/api/tcs/1/calibrate", body, nil); err != nil {
+		t.Fatal("failed to calibrate temperature controller using api:", err)
+	}
+	if _, ok := c.calibrators[tc.Sensor]; !ok {
+		t.Fatal("expected calibrator to be registered")
+	}
 }

--- a/controller/modules/temperature/sensor_test.go
+++ b/controller/modules/temperature/sensor_test.go
@@ -123,6 +123,7 @@ func TestReadMissingDevice(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer con.Store().Close()
 	c, err := New(false, con)
 	if err != nil {
 		t.Fatal(err)
@@ -130,6 +131,25 @@ func TestReadMissingDevice(t *testing.T) {
 
 	if v, err := c.Read(&TC{Sensor: "28-missing"}); err == nil {
 		t.Fatalf("expected missing sensor read to fail, got value %v", v)
+	}
+}
+
+func TestReadMissingAnalogInput(t *testing.T) {
+	con, err := controller.TestController()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer con.Store().Close()
+	if err := con.DM().AnalogInputs().Setup(); err != nil {
+		t.Fatal(err)
+	}
+	c, err := New(false, con)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v, err := c.Read(&TC{AnalogInput: "missing"}); err == nil {
+		t.Fatalf("expected missing analog input read to fail, got value %v", v)
 	}
 }
 

--- a/controller/modules/temperature/tc_test.go
+++ b/controller/modules/temperature/tc_test.go
@@ -3,6 +3,7 @@ package temperature
 import (
 	"testing"
 
+	"github.com/reef-pi/hal"
 	"github.com/reef-pi/reef-pi/controller"
 	"github.com/reef-pi/reef-pi/controller/device_manager/connectors"
 	"github.com/reef-pi/reef-pi/controller/modules/equipment"
@@ -96,6 +97,7 @@ func TestTCNotifyIfNeeded(t *testing.T) {
 
 func TestTCCalibrate(t *testing.T) {
 	c := setupTempController(t)
+	defer c.c.Store().Close()
 
 	tc := &TC{
 		Name:   "Water",
@@ -111,5 +113,157 @@ func TestTCCalibrate(t *testing.T) {
 	// Calibrate with empty measurement set should fail
 	if err := c.Calibrate("1", nil); err == nil {
 		t.Error("Calibrate with nil measurements should fail")
+	}
+}
+
+func TestTCSetupLoadsCalibrations(t *testing.T) {
+	con, err := controller.TestController()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer con.Store().Close()
+
+	c, err := New(true, con)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	tc := &TC{Name: "Calibrated", Period: 1, Sensor: "28-setup-calibration"}
+	if err := c.repo.Create(tc); err != nil {
+		t.Fatal(err)
+	}
+	measurements := []hal.Measurement{
+		{Expected: 77, Observed: 76},
+		{Expected: 82, Observed: 80},
+	}
+	if err := c.repo.UpdateCalibration(tc.Sensor, measurements); err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded, err := New(true, con)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reloaded.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := reloaded.calibrators[tc.Sensor]; !ok {
+		t.Fatal("expected setup to load calibrator")
+	}
+}
+
+func TestTCSetupReturnsCalibrationError(t *testing.T) {
+	con, err := controller.TestController()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer con.Store().Close()
+
+	c, err := New(true, con)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	tc := &TC{Name: "BadCalibration", Period: 1, Sensor: "28-bad-calibration"}
+	if err := c.repo.Create(tc); err != nil {
+		t.Fatal(err)
+	}
+	measurements := []hal.Measurement{
+		{Expected: 77, Observed: 80},
+		{Expected: 80, Observed: 80},
+		{Expected: 82, Observed: 81},
+	}
+	if err := c.repo.UpdateCalibration(tc.Sensor, measurements); err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded, err := New(true, con)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reloaded.Setup(); err == nil {
+		t.Fatal("expected setup to fail on invalid calibration")
+	}
+}
+
+func TestTCOnErrorAndOneShot(t *testing.T) {
+	c := setupTempController(t)
+	defer c.c.Store().Close()
+
+	if err := c.On("missing", true); err == nil {
+		t.Fatal("expected On to fail for unknown temperature controller")
+	}
+
+	tc := &TC{
+		Name:    "OneShot",
+		Period:  1,
+		Enable:  false,
+		OneShot: true,
+		Min:     24,
+		Max:     26,
+	}
+	if err := c.Create(tc); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.On(tc.ID, true); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := c.Get(tc.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Enable {
+		t.Fatal("expected one-shot controller to disable itself after an in-range read")
+	}
+}
+
+func TestTCCheckBranches(t *testing.T) {
+	c := setupTempController(t)
+	defer c.c.Store().Close()
+
+	if reading, err := c.Check(&TC{Enable: false}); err != nil || reading != 0 {
+		t.Fatalf("disabled check = %v, %v; expected 0, nil", reading, err)
+	}
+
+	c.devMode = false
+	tc := &TC{
+		ID:       "sensor-error",
+		Name:     "SensorError",
+		Enable:   true,
+		Control:  true,
+		FailSafe: true,
+		Heater:   "1",
+		Sensor:   "28-missing",
+	}
+	if reading, err := c.Check(tc); err == nil || reading != -1 {
+		t.Fatalf("missing sensor check = %v, %v; expected -1 and error", reading, err)
+	}
+
+	c.devMode = true
+	tc = &TC{
+		ID:      "calibrated-check",
+		Name:    "CalibratedCheck",
+		Enable:  false,
+		Period:  1,
+		Sensor:  "28-check-calibration",
+		Notify:  Notify{Enable: true, Min: 70, Max: 90},
+		Control: false,
+	}
+	if err := c.Calibrate(tc.ID, []hal.Measurement{{Expected: 70, Observed: 70}, {Expected: 90, Observed: 90}}); err == nil {
+		t.Fatal("expected calibrating an unknown controller to fail")
+	}
+	if err := c.Create(tc); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Calibrate(tc.ID, []hal.Measurement{{Expected: 70, Observed: 70}, {Expected: 90, Observed: 90}}); err != nil {
+		t.Fatal(err)
+	}
+	tc.Enable = true
+	if reading, err := c.Check(tc); err != nil || reading <= 0 {
+		t.Fatalf("calibrated check = %v, %v; expected positive reading and no error", reading, err)
 	}
 }


### PR DESCRIPTION
## Summary
- add coverage for temperature calibrate API and calibration loading/setup paths
- cover sensor read errors and analog input lookup failure
- exercise Check disabled/read-error/failsafe/calibrated branches and On behavior

## Test
- go test ./controller/modules/temperature
- go test -cover ./controller/modules/temperature

Closes #3027