### PR TITLE
enforce: block execution skills (subagent-driven-development, executing-plans) on main

### DIFF
--- a/.claude/hooks/block-commit-on-main.sh
+++ b/.claude/hooks/block-commit-on-main.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Blocks git commit when on main/master branch.
+# Reads Claude Code PreToolUse JSON from stdin.
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(printf '%s' "$INPUT" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d.get('tool_input', {}).get('command', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+
+# Only act on commands where git commit is actually invoked.
+# Match lines where git commit appears as the command (possibly after && / ; / newline),
+# but not merely mentioned inside a string (e.g. in an echo or a comment).
+if ! printf '%s' "$COMMAND" | grep -qP '(?:^|&&|\||;|\n)\s*git\s+commit\b'; then
+    exit 0
+fi
+
+BRANCH=$(git -C "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+    echo "BLOCKED: direct commit to '$BRANCH' is not allowed."
+    echo "Create a feature branch first:  git checkout -b <your-feature-name>"
+    exit 2
+fi
+
+exit 0

--- a/.claude/hooks/block-execution-on-main.sh
+++ b/.claude/hooks/block-execution-on-main.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Blocks subagent-driven-development and executing-plans Skill invocations
+# when the working branch is main/master. Forces a feature branch first.
+# Reads Claude Code PreToolUse JSON from stdin.
+set -euo pipefail
+
+INPUT=$(cat)
+SKILL=$(printf '%s' "$INPUT" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d.get('tool_input', {}).get('skill', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+
+# Only act on execution skills
+case "$SKILL" in
+    *subagent-driven-development*|*executing-plans*)
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+
+BRANCH=$(git -C "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+    echo "BLOCKED: '$SKILL' cannot run on '$BRANCH'."
+    echo "This skill executes implementation plans and commits code."
+    echo "Create a feature branch first:  git checkout -b <your-feature-name>"
+    exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,15 +9,6 @@
             "command": "bash .claude/hooks/block-commit-on-main.sh"
           }
         ]
-      },
-      {
-        "matcher": "Skill",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash .claude/hooks/block-execution-on-main.sh"
-          }
-        ]
       }
     ]
   }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,15 @@
             "command": "bash .claude/hooks/block-commit-on-main.sh"
           }
         ]
+      },
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/block-execution-on-main.sh"
+          }
+        ]
       }
     ]
   }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/block-commit-on-main.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/block-execution-on-main.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ test-data
 playwright-report
 test-results
 front-end/e2e/.auth
+
+# Explicitly track Claude Code project configuration
+# (overrides global gitignore which blocks these by default)
+!.claude/
+!CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# reef-pi · Claude Code rules
+
+Read these in order before doing anything:
+1. front-end/design-system/SKILL.md  — design constraints
+2. front-end/design-system/github_issues/CLAUDE.md  — operating manual
+3. front-end/design-system/github_issues/STRATEGY.md  — sequencing
+4. front-end/design-system/github_issues/BACKLOG.md  — what to pick next
+
+Hard rules:
+- Tokens live in front-end/assets/sass/_tokens.scss and mirror
+  front-end/design-system/colors_and_type.css.
+- No raw hex literals in new code. Use var(--reefpi-*).
+- One PR per issue. Commit prefix: [claude design]
+- Ship behind a flag when the issue says so.
+- Before any implementation work: create a feature branch.
+  Never commit implementation code directly to main.
+  Use: git checkout -b <feature-name> before first commit.


### PR DESCRIPTION
## Summary

- Adds `.claude/hooks/block-execution-on-main.sh` — a PreToolUse hook that intercepts `Skill` tool calls for `subagent-driven-development` and `executing-plans` and exits with code 2 (blocked) when the working branch is `main` or `master`
- Adds a `Skill` matcher entry to `.claude/settings.json` to wire the hook

**Why:** The `subagent-driven-development` skill dispatches multiple implementation subagents that each commit code. Without a branch guard at the skill invocation point, the entire execution run lands on `main` before any individual commit guard fires. This hook stops the run at the entry point — you must be on a feature branch before invoking these skills.

**Depends on:** #3045 (commit guard) — this PR builds on that branch and inherits the Bash commit guard too.

## Test plan

- [ ] Verify hook fires: on `main`, invoke `subagent-driven-development` or `executing-plans` skill via Claude Code → should see BLOCKED message
- [ ] Verify hook passes: on a feature branch, skill invocation proceeds normally
- [ ] Verify unrelated skills (brainstorming, writing-plans) are not blocked on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)