### PR TITLE
[codex] expand playwright integration smoke coverage

### DIFF
--- a/front-end/e2e/pages/dashboardPage.js
+++ b/front-end/e2e/pages/dashboardPage.js
@@ -25,20 +25,35 @@ class DashboardPage {
     await expect(this.page.locator('#to-row-row')).toBeVisible({ timeout: 5000 })
     await this.page.locator('#to-row-row').fill('3')
     await this.page.locator('#to-row-column').fill('2')
-    await this.page.locator('#db-0-0').click()
-    await this.page.locator('#temp_current-0-0').click()
-    await this.page.locator('#db-0-1').click()
-    await this.page.locator('#ph_current-0-1').click()
-    await this.page.locator('#db-1-0').click()
-    await this.page.locator('#ato-1-0').click()
-    await this.page.locator('#db-1-1').click()
-    await this.page.locator('#equipment_ctrlpanel-1-1').click()
-    await this.page.locator('#db-2-0').click()
-    await this.page.locator('#lights-2-0').click()
-    await this.page.locator('#db-2-1').click()
-    await this.page.locator('#health-2-1').click()
+    await expect(this.page.locator('#to-row-row')).toHaveValue('3')
+    await expect(this.page.locator('#to-row-column')).toHaveValue('2')
+    await expect(this.page.locator('#db-2-1')).toBeVisible()
+
+    await this.selectGridType(0, 0, 'temp_current', /Temperature/i)
+    await this.selectGridType(0, 1, 'ph_current', /pH/i)
+    await this.selectGridType(1, 0, 'ato', /ATO/i)
+    await this.selectGridType(1, 1, 'equipment_ctrlpanel', /Equipment/i)
+    await this.selectGridType(2, 0, 'lights', /Lights/i)
+    await this.selectGridType(2, 1, 'health', /Health/i)
     await this.page.getByTestId('smoke-dashboard-save').click()
     await expect(this.page.getByTestId('smoke-dashboard-configure')).toBeVisible()
+  }
+
+  async selectGridType (row, column, type, label) {
+    const cell = this.page.locator(`#db-${row}-${column}`)
+    await cell.click()
+    await this.page.locator(`#${type}-${row}-${column}`).click()
+    await expect(cell).toHaveText(label)
+  }
+
+  async expectSavedLayoutIncludes (types) {
+    const response = await this.page.request.get('/api/dashboard')
+    await expect(response).toBeOK()
+    const dashboard = await response.json()
+    const savedTypes = (dashboard.grid_details || []).flat().map(cell => cell.type)
+    for (const type of types) {
+      expect(savedTypes).toContain(type)
+    }
   }
 }
 

--- a/front-end/e2e/pages/macrosPage.js
+++ b/front-end/e2e/pages/macrosPage.js
@@ -18,11 +18,29 @@ class MacrosPage {
     await expectValidationVisible(this.page)
   }
 
-  async createEquipmentWaitMacro (name, equipmentName) {
+  async openAddForm () {
     const nameInput = this.page.locator('.add-macro [name="name"]')
     if (!await nameInput.isVisible()) {
       await this.page.getByTestId('smoke-macro-add-toggle').click()
     }
+    await expect(nameInput).toBeVisible({ timeout: 5000 })
+    return nameInput
+  }
+
+  async submitMacro (name, nameInput) {
+    await this.page.getByTestId('smoke-macro-submit').click()
+    await expect(this.page.locator('body')).toContainText(name)
+    await expect(nameInput).toBeHidden({ timeout: 5000 })
+  }
+
+  async resetInvalidForm () {
+    await this.page.goto('/')
+    await this.open()
+    await expect(this.page.getByTestId('smoke-macro-add-toggle')).toBeVisible({ timeout: 5000 })
+  }
+
+  async createEquipmentWaitMacro (name, equipmentName) {
+    const nameInput = await this.openAddForm()
     await nameInput.fill(name)
     await this.page.getByTestId('smoke-macro-add-step').click()
     await selectByLabelOrValue(this.page.locator('[name="steps.0.type"]'), 'equipment')
@@ -31,8 +49,44 @@ class MacrosPage {
     await this.page.getByTestId('smoke-macro-add-step').click()
     await selectByLabelOrValue(this.page.locator('[name="steps.1.type"]'), 'wait')
     await this.page.locator('[name="steps.1.duration"]').fill('300')
+    await this.submitMacro(name, nameInput)
+  }
+
+  async createReversibleMixedMacro (name, equipmentName) {
+    const nameInput = await this.openAddForm()
+    await nameInput.fill(name)
+    await selectByLabelOrValue(this.page.locator('[name="reversible"]'), 'true')
+    await this.page.getByTestId('smoke-macro-add-step').click()
+    await selectByLabelOrValue(this.page.locator('[name="steps.0.type"]'), 'equipment')
+    await selectByLabelOrValue(this.page.locator('[name="steps.0.id"]'), equipmentName)
+    await selectByLabelOrValue(this.page.locator('[name="steps.0.on"]'), 'Turn On')
+    await this.page.getByTestId('smoke-macro-add-step').click()
+    await selectByLabelOrValue(this.page.locator('[name="steps.1.type"]'), 'wait')
+    await this.page.locator('[name="steps.1.duration"]').fill('120')
+    await this.page.getByTestId('smoke-macro-add-step').click()
+    await selectByLabelOrValue(this.page.locator('[name="steps.2.type"]'), 'alert')
+    await this.page.locator('[name="steps.2.title"]').fill('Feed complete')
+    await this.page.locator('[name="steps.2.message"]').fill('Resume normal equipment schedule.')
+    await this.submitMacro(name, nameInput)
+  }
+
+  async expectMissingStepValidation () {
+    const nameInput = await this.openAddForm()
+    await nameInput.fill('Missing Step Macro')
+    await this.page.getByTestId('smoke-macro-add-step').click()
     await this.page.getByTestId('smoke-macro-submit').click()
-    await expect(this.page.locator('body')).toContainText(name)
+    await expectValidationVisible(this.page)
+    await this.resetInvalidForm()
+  }
+
+  async expectMissingTargetValidation () {
+    const nameInput = await this.openAddForm()
+    await nameInput.fill('Missing Target Macro')
+    await this.page.getByTestId('smoke-macro-add-step').click()
+    await selectByLabelOrValue(this.page.locator('[name="steps.0.type"]'), 'equipment')
+    await this.page.getByTestId('smoke-macro-submit').click()
+    await expectValidationVisible(this.page)
+    await this.resetInvalidForm()
   }
 }
 

--- a/front-end/e2e/pages/timersPage.js
+++ b/front-end/e2e/pages/timersPage.js
@@ -33,6 +33,11 @@ class TimersPage {
     await expect(nameInput).toBeHidden({ timeout: 5000 })
   }
 
+  async submitInvalidTimer () {
+    await this.page.getByTestId('smoke-timer-submit').click()
+    await expectValidationVisible(this.page)
+  }
+
   async fillSchedule (hour, minute, second) {
     await this.page.getByTestId('smoke-cron-hour').fill(hour)
     await this.page.getByTestId('smoke-cron-minute').fill(minute)
@@ -65,6 +70,32 @@ class TimersPage {
     await selectByLabelOrValue(this.page.locator('[name="target.id"]'), macroName)
     await this.fillSchedule('12', '30', '0')
     await this.submitTimer(name, nameInput)
+  }
+
+  async createModuleTimer (name, type, targetName, schedule = ['6', '45', '0']) {
+    const nameInput = await this.openAddForm()
+    await nameInput.fill(name)
+    await this.page.getByTestId('smoke-timer-type').selectOption(type)
+    await selectByLabelOrValue(this.page.locator('[name="target.id"]'), targetName)
+    await this.fillSchedule(...schedule)
+    await this.submitTimer(name, nameInput)
+  }
+
+  async expectMissingTargetValidation () {
+    const nameInput = await this.openAddForm()
+    await nameInput.fill('Missing Target Timer')
+    await this.page.getByTestId('smoke-timer-type').selectOption('equipment')
+    await this.fillSchedule('7', '0', '0')
+    await this.submitInvalidTimer()
+  }
+
+  async expectMissingCronValidation (equipmentName) {
+    const nameInput = await this.openAddForm()
+    await nameInput.fill('Missing Cron Timer')
+    await this.page.getByTestId('smoke-timer-type').selectOption('equipment')
+    await selectByLabelOrValue(this.page.locator('[name="target.id"]'), equipmentName)
+    await this.fillSchedule('7', '15', '')
+    await this.submitInvalidTimer()
   }
 }
 

--- a/front-end/e2e/specs/full-smoke-coverage.spec.js
+++ b/front-end/e2e/specs/full-smoke-coverage.spec.js
@@ -2,6 +2,16 @@ const { test, expect } = require('@playwright/test')
 const { createSmokeApi, seedFullSmokeConfiguration } = require('../fixtures/apiSeed')
 const { NavBar } = require('../pages/navBar')
 
+async function expectSavedDashboardTypes (page, types) {
+  const response = await page.request.get('/api/dashboard')
+  await expect(response).toBeOK()
+  const dashboard = await response.json()
+  const savedTypes = (dashboard.grid_details || []).flat().map(cell => cell.type)
+  for (const type of types) {
+    expect(savedTypes).toContain(type)
+  }
+}
+
 async function expectNoFatalError (page) {
   await expect(page.getByText('Something went wrong')).toHaveCount(0)
 }
@@ -49,6 +59,7 @@ test('full smoke configuration covers the major reef-pi modules', async ({ page,
   await page.goto('/')
   await navBar.expectShell()
   await expectDashboardSmokeContent(page)
+  await expectSavedDashboardTypes(page, ['lights', 'health'])
 
   await navBar.open('configuration')
   await page.locator('#config-drivers').click()

--- a/front-end/e2e/specs/integration/brand-new-user-setup.spec.js
+++ b/front-end/e2e/specs/integration/brand-new-user-setup.spec.js
@@ -27,85 +27,99 @@ test('brand-new user can configure reef-pi through the UI', async ({ page, baseU
     await api.dispose()
   }
 
-  const navBar = new NavBar(page)
-  const configurationPage = new ConfigurationPage(page, navBar)
-  const driversPage = new DriversPage(page, configurationPage)
-  const connectorsPage = new ConnectorsPage(page, configurationPage)
-  const equipmentPage = new EquipmentPage(page, navBar)
-  const lightingPage = new LightingPage(page, navBar)
-  const phPage = new PhPage(page, navBar)
-  const atoPage = new AtoPage(page, navBar)
-  const doserPage = new DoserPage(page, navBar)
-  const temperaturePage = new TemperaturePage(page, navBar)
-  const timersPage = new TimersPage(page, navBar)
-  const macrosPage = new MacrosPage(page, navBar)
-  const dashboardPage = new DashboardPage(page, navBar)
+  try {
+    const navBar = new NavBar(page)
+    const configurationPage = new ConfigurationPage(page, navBar)
+    const driversPage = new DriversPage(page, configurationPage)
+    const connectorsPage = new ConnectorsPage(page, configurationPage)
+    const equipmentPage = new EquipmentPage(page, navBar)
+    const lightingPage = new LightingPage(page, navBar)
+    const phPage = new PhPage(page, navBar)
+    const atoPage = new AtoPage(page, navBar)
+    const doserPage = new DoserPage(page, navBar)
+    const temperaturePage = new TemperaturePage(page, navBar)
+    const timersPage = new TimersPage(page, navBar)
+    const macrosPage = new MacrosPage(page, navBar)
+    const dashboardPage = new DashboardPage(page, navBar)
 
-  await page.goto('/')
-  await navBar.expectShell()
+    await page.goto('/')
+    await navBar.expectShell()
 
-  await driversPage.open()
-  await driversPage.expectValidation()
-  await driversPage.create(drivers.pwm)
-  await driversPage.create(drivers.ph)
-  await driversPage.create(drivers.hs103)
+    await driversPage.open()
+    await driversPage.expectValidation()
+    await driversPage.create(drivers.pwm)
+    await driversPage.create(drivers.ph)
+    await driversPage.create(drivers.hs103)
 
-  await connectorsPage.open()
-  await connectorsPage.expectValidation()
-  for (const outlet of connectors.outlets) await connectorsPage.createOutlet(outlet)
-  for (const inlet of connectors.inlets) await connectorsPage.createInlet(inlet)
-  for (const jack of connectors.jacks) await connectorsPage.createJack(jack)
-  for (const input of connectors.analogInputs) await connectorsPage.createAnalogInput(input)
+    await connectorsPage.open()
+    await connectorsPage.expectValidation()
+    for (const outlet of connectors.outlets) await connectorsPage.createOutlet(outlet)
+    for (const inlet of connectors.inlets) await connectorsPage.createInlet(inlet)
+    for (const jack of connectors.jacks) await connectorsPage.createJack(jack)
+    for (const input of connectors.analogInputs) await connectorsPage.createAnalogInput(input)
 
-  await equipmentPage.open()
-  await equipmentPage.expectValidation()
-  for (const item of equipment) await equipmentPage.create(item)
+    await equipmentPage.open()
+    await equipmentPage.expectValidation()
+    for (const item of equipment) await equipmentPage.create(item)
 
-  await lightingPage.open()
-  await lightingPage.expectValidation()
-  for (const light of modules.lights) await lightingPage.create(light)
+    await lightingPage.open()
+    await lightingPage.expectValidation()
+    for (const light of modules.lights) await lightingPage.create(light)
 
-  await phPage.open()
-  await phPage.expectValidation()
-  await phPage.create(modules.ph)
+    await phPage.open()
+    await phPage.expectValidation()
+    await phPage.create(modules.ph)
 
-  await atoPage.open()
-  await atoPage.expectValidation()
-  await atoPage.create(modules.ato)
+    await atoPage.open()
+    await atoPage.expectValidation()
+    await atoPage.create(modules.ato)
 
-  await doserPage.open()
-  await doserPage.expectValidation()
-  await doserPage.createDcPump(modules.doser)
+    await doserPage.open()
+    await doserPage.expectValidation()
+    await doserPage.createDcPump(modules.doser)
 
-  await temperaturePage.open()
-  await temperaturePage.expectValidation()
-  await temperaturePage.create(modules.temperature)
+    await temperaturePage.open()
+    await temperaturePage.expectValidation()
+    await temperaturePage.create(modules.temperature)
 
-  await timersPage.open()
-  await timersPage.expectValidation()
-  await timersPage.createEquipmentTimer('Nightly Skimmer Run', 'Skimmer')
-  await timersPage.createReminderTimer('Maintenance Reminder')
+    await timersPage.open()
+    await timersPage.expectValidation()
+    await timersPage.expectMissingTargetValidation()
+    await timersPage.expectMissingCronValidation('Skimmer')
+    await timersPage.createEquipmentTimer('Nightly Skimmer Run', 'Skimmer')
+    await timersPage.createReminderTimer('Maintenance Reminder')
+    await timersPage.createModuleTimer('ATO Safety Check', 'ato', modules.ato.name, ['5', '30', '0'])
+    await timersPage.createModuleTimer('Doser Prime', 'doser', modules.doser.name, ['6', '0', '0'])
+    await timersPage.createModuleTimer('Light Ramp Audit', 'lightings', modules.lights[0].name, ['7', '0', '0'])
+    await timersPage.createModuleTimer('pH Control Audit', 'phprobes', modules.ph.name, ['8', '0', '0'])
+    await timersPage.createModuleTimer('Temperature Control Audit', 'temperature', modules.temperature.name, ['9', '0', '0'])
 
-  await macrosPage.open()
-  await macrosPage.expectValidation()
-  await macrosPage.createEquipmentWaitMacro('Feed Start', 'Return')
-  await macrosPage.createEquipmentWaitMacro('Water Change', 'Return')
+    await macrosPage.open()
+    await macrosPage.expectValidation()
+    await macrosPage.expectMissingStepValidation()
+    await macrosPage.expectMissingTargetValidation()
+    await macrosPage.createEquipmentWaitMacro('Feed Start', 'Return')
+    await macrosPage.createEquipmentWaitMacro('Water Change', 'Return')
+    await macrosPage.createReversibleMixedMacro('Maintenance Resume', 'Return')
 
-  await timersPage.open()
-  await timersPage.createMacroTimer('Feed Timer', 'Feed Start')
+    await timersPage.open()
+    await timersPage.createMacroTimer('Feed Timer', 'Feed Start')
 
-  await dashboardPage.open()
-  await dashboardPage.configureStandardDashboard()
+    await dashboardPage.open()
+    await dashboardPage.configureStandardDashboard()
+    await dashboardPage.expectSavedLayoutIncludes(['lights', 'health'])
 
-  await page.reload()
-  await expectBodyText(page, [
-    'Temperature',
-    'pH',
-    'ATO',
-    'Return',
-    'ATO Pump'
-  ])
-  await expectNoFatalError(page)
-
-  await capture.stop()
+    await page.reload()
+    await expectBodyText(page, [
+      'Temperature',
+      'pH',
+      'ATO',
+      'Return',
+      'Light',
+      'ATO Pump'
+    ])
+    await expectNoFatalError(page)
+  } finally {
+    await capture.stop()
+  }
 })

--- a/front-end/src/macro/generic_step.jsx
+++ b/front-end/src/macro/generic_step.jsx
@@ -44,7 +44,7 @@ export const RawGenericStep = ({ type, name, readOnly, touched, errors, ...props
           component={BooleanSelect}
           disabled={readOnly}
           className={classNames('form-control custom-select', {
-            'is-invalid': ShowError(`${name}.id`, touched, errors)
+            'is-invalid': ShowError(`${name}.on`, touched, errors)
           })}
         >
           <option value='' className='d-none'>-- {i18n.t('select')} --</option>


### PR DESCRIPTION
## Summary
- Adds deeper brand-new-user Playwright coverage for module timers across ATO, doser, lighting, pH, and temperature.
- Adds validation/error cases for timers and macros, plus a reversible mixed macro scenario.
- Adds API-backed dashboard layout assertions for persisted lights and health tiles and keeps fast smoke aligned with that contract.
- Fixes the macro step action validation class so the correct field displays invalid state.

## Validation
- rtk proxy /home/ranjib/workspace/reef-pi/node_modules/.bin/standard front-end/e2e/pages/macrosPage.js front-end/e2e/pages/timersPage.js front-end/e2e/pages/dashboardPage.js front-end/e2e/specs/integration/brand-new-user-setup.spec.js front-end/e2e/specs/full-smoke-coverage.spec.js front-end/src/macro/generic_step.jsx
- rtk proxy /home/ranjib/workspace/reef-pi/node_modules/.bin/webpack --mode=production
- rtk proxy /home/ranjib/workspace/reef-pi/node_modules/.bin/playwright test --project=integration-chromium front-end/e2e/specs/integration/brand-new-user-setup.spec.js
- rtk yarn smoke

## Notes
- True invalid cron syntax/range cases remain outside this slice because the current frontend schema only validates required cron fields.
- Lighting profile editing and doser stepper-specific UI coverage remain tracked separately.