### PR TITLE
Expand Playwright integration smoke coverage

### DIFF
--- a/controller/api/impl.go
+++ b/controller/api/impl.go
@@ -1441,7 +1441,11 @@ func (s *ReefPiServer) ListTemperatureSensors(_ context.Context, _ gen.ListTempe
 	if s.temperature == nil {
 		return gen.ListTemperatureSensors401JSONResponse{Message: "temperature subsystem not loaded"}, nil
 	}
-	return gen.ListTemperatureSensors200JSONResponse{}, nil
+	sensors, err := s.temperature.Sensors()
+	if err != nil {
+		return gen.ListTemperatureSensors401JSONResponse{Message: err.Error()}, nil
+	}
+	return gen.ListTemperatureSensors200JSONResponse(sensors), nil
 }
 
 func (s *ReefPiServer) GetCurrentTemperature(_ context.Context, request gen.GetCurrentTemperatureRequestObject) (gen.GetCurrentTemperatureResponseObject, error) {

--- a/controller/api/impl_test.go
+++ b/controller/api/impl_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reef-pi/reef-pi/controller"
+	"github.com/reef-pi/reef-pi/controller/api/gen"
+	temperatureModule "github.com/reef-pi/reef-pi/controller/modules/temperature"
+)
+
+func TestListTemperatureSensors(t *testing.T) {
+	t.Parallel()
+	con, err := controller.TestController()
+	if err != nil {
+		t.Fatal(err)
+	}
+	temperature, err := temperatureModule.New(true, con)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := NewReefPiServer(ServerConfig{Temperature: temperature})
+
+	response, err := server.ListTemperatureSensors(context.Background(), gen.ListTemperatureSensorsRequestObject{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sensors, ok := response.(gen.ListTemperatureSensors200JSONResponse)
+	if !ok {
+		t.Fatalf("expected 200 response, got %T", response)
+	}
+	if len(sensors) != 2 {
+		t.Fatalf("expected dev mode sensors, got %#v", sensors)
+	}
+	if sensors[0] != "28-devmodeenable" || sensors[1] != "10-devmodeenable" {
+		t.Fatalf("unexpected sensors: %#v", sensors)
+	}
+}

--- a/controller/modules/temperature/api.go
+++ b/controller/modules/temperature/api.go
@@ -61,25 +61,29 @@ func (c *Controller) list(w http.ResponseWriter, r *http.Request) {
 
 func (t *Controller) sensors(w http.ResponseWriter, r *http.Request) {
 	fn := func(id string) (interface{}, error) {
-		fs := mockSensors
-		if !t.devMode {
-			files28, err := filepath.Glob("/sys/bus/w1/devices/28-*")
-			if err != nil {
-				return nil, err
-			}
-			files10, err := filepath.Glob("/sys/bus/w1/devices/10-*")
-			if err != nil {
-				return nil, err
-			}
-			fs = append(files28, files10...)
-		}
-		sensors := []string{}
-		for _, f := range fs {
-			sensors = append(sensors, filepath.Base(f))
-		}
-		return sensors, nil
+		return t.Sensors()
 	}
 	utils.JSONGetResponse(fn, w, r)
+}
+
+func (t *Controller) Sensors() ([]string, error) {
+	fs := mockSensors
+	if !t.devMode {
+		files28, err := filepath.Glob("/sys/bus/w1/devices/28-*")
+		if err != nil {
+			return nil, err
+		}
+		files10, err := filepath.Glob("/sys/bus/w1/devices/10-*")
+		if err != nil {
+			return nil, err
+		}
+		fs = append(files28, files10...)
+	}
+	sensors := []string{}
+	for _, f := range fs {
+		sensors = append(sensors, filepath.Base(f))
+	}
+	return sensors, nil
 }
 
 func (c *Controller) create(w http.ResponseWriter, r *http.Request) {

--- a/front-end/e2e/fixtures/integrationData.js
+++ b/front-end/e2e/fixtures/integrationData.js
@@ -93,6 +93,23 @@ const modules = {
     duration: '15',
     speed: '50'
   },
+  stepperDoser: {
+    name: 'Stepper Alk',
+    volume: '5',
+    hour: '2',
+    minute: '15',
+    second: '0',
+    stepPin: 'O1',
+    directionPin: 'O2',
+    msPinA: 'O3',
+    msPinB: 'O4',
+    msPinC: 'O5',
+    spr: '200',
+    vpr: '1.5',
+    delay: '1000',
+    direction: 'true',
+    microstepping: 'Full'
+  },
   temperature: {
     name: 'Biocube29 Temperature',
     sensor: '28-devmodeenable',

--- a/front-end/e2e/pages/doserPage.js
+++ b/front-end/e2e/pages/doserPage.js
@@ -35,6 +35,31 @@ class DoserPage {
     await this.page.getByTestId('smoke-doser-submit').click()
     await expect(this.page.locator('body')).toContainText(doser.name)
   }
+
+  async createStepper (doser) {
+    const name = this.page.getByTestId('smoke-doser-name')
+    if (!await name.isVisible()) {
+      await this.page.getByTestId('smoke-doser-add-toggle').click()
+    }
+    await name.fill(doser.name)
+    await this.page.getByTestId('smoke-doser-type').selectOption('stepper')
+    await this.page.locator('[name="volume"]').fill(doser.volume)
+    await selectByLabelOrValue(this.page.locator('[name="stepper.step_pin"]'), doser.stepPin)
+    await selectByLabelOrValue(this.page.locator('[name="stepper.direction_pin"]'), doser.directionPin)
+    await selectByLabelOrValue(this.page.locator('[name="stepper.ms_pin_a"]'), doser.msPinA)
+    await selectByLabelOrValue(this.page.locator('[name="stepper.ms_pin_b"]'), doser.msPinB)
+    await selectByLabelOrValue(this.page.locator('[name="stepper.ms_pin_c"]'), doser.msPinC)
+    await this.page.locator('[name="stepper.spr"]').fill(doser.spr)
+    await this.page.locator('[name="stepper.vpr"]').fill(doser.vpr)
+    await this.page.locator('[name="stepper.delay"]').fill(doser.delay)
+    await this.page.locator('[name="stepper.direction"]').selectOption(doser.direction)
+    await this.page.locator('[name="stepper.microstepping"]').selectOption(doser.microstepping)
+    await this.page.getByTestId('smoke-cron-hour').fill(doser.hour)
+    await this.page.getByTestId('smoke-cron-minute').fill(doser.minute)
+    await this.page.getByTestId('smoke-cron-second').fill(doser.second)
+    await this.page.getByTestId('smoke-doser-submit').click()
+    await expect(this.page.locator('body')).toContainText(doser.name)
+  }
 }
 
 module.exports = {

--- a/front-end/e2e/pages/lightingPage.js
+++ b/front-end/e2e/pages/lightingPage.js
@@ -31,6 +31,44 @@ class LightingPage {
     await selectLightJack(this.page, light.jack)
     await this.page.getByTestId('smoke-light-submit').click()
     await expect(this.page.locator('body')).toContainText(light.name)
+    await this.configureProfile(light)
+  }
+
+  async configureProfile (light) {
+    const savedLight = await this.findLight(light.name)
+    const channelKey = Object.keys(savedLight.channels)[0]
+    const form = this.page.locator(`#form-light-${savedLight.id}`)
+
+    await this.page.locator(`#edit-light-${savedLight.id}`).click()
+    await expect(form).toBeVisible()
+    await form.locator(`input[type="radio"][value="${light.profile}"]`).check()
+    await form.locator(`[name="config.channels.${channelKey}.profile.config.start"]`).fill(light.start)
+    await form.locator(`[name="config.channels.${channelKey}.profile.config.end"]`).fill(light.end)
+
+    if (light.profile === 'fixed') {
+      await form.locator(`[name="config.channels.${channelKey}.profile.config.value"]`).first().fill(light.value)
+    }
+    if (light.profile === 'interval') {
+      const removePoint = form.locator('.btn-remove-point')
+      while (await removePoint.count() > light.values.length) {
+        await removePoint.first().click()
+      }
+      for (let i = 0; i < light.values.length; i++) {
+        await form.locator(`[name="config.channels.${channelKey}.profile.config.values.${i}"]`).fill(light.values[i])
+      }
+    }
+
+    await this.page.locator(`#save-light-${savedLight.id}`).click()
+    await expect(this.page.locator('body')).toContainText(light.name)
+  }
+
+  async findLight (name) {
+    const response = await this.page.request.get('/api/lights')
+    await expect(response).toBeOK()
+    const lights = await response.json()
+    const light = lights.find(item => item.name === name)
+    expect(light).toBeTruthy()
+    return light
   }
 }
 

--- a/front-end/e2e/specs/integration/brand-new-user-setup.spec.js
+++ b/front-end/e2e/specs/integration/brand-new-user-setup.spec.js
@@ -1,4 +1,4 @@
-const { test } = require('@playwright/test')
+const { test, expect } = require('@playwright/test')
 const { createSmokeApi, resetSmokeState } = require('../../fixtures/apiSeed')
 const { startApiCapture } = require('../../fixtures/apiCapture')
 const { expectBodyText, expectNoFatalError } = require('../../fixtures/e2eAssertions')
@@ -16,6 +16,39 @@ const { TemperaturePage } = require('../../pages/temperaturePage')
 const { TimersPage } = require('../../pages/timersPage')
 const { MacrosPage } = require('../../pages/macrosPage')
 const { DashboardPage } = require('../../pages/dashboardPage')
+
+async function expectLightProfiles (page, expectedLights) {
+  const response = await page.request.get('/api/lights')
+  await expect(response).toBeOK()
+  const lights = await response.json()
+
+  for (const expected of expectedLights) {
+    const light = lights.find(item => item.name === expected.name)
+    expect(light).toBeTruthy()
+    const channel = Object.values(light.channels)[0]
+    expect(channel.profile.type).toBe(expected.profile)
+    expect(channel.profile.config.start).toBe(expected.start)
+    expect(channel.profile.config.end).toBe(expected.end)
+    if (expected.value !== undefined) {
+      expect(String(channel.profile.config.value)).toBe(expected.value)
+    }
+    if (expected.values !== undefined) {
+      expect(channel.profile.config.values.map(String)).toEqual(expected.values)
+    }
+  }
+}
+
+async function expectDoserTypes (page, expectedDosers) {
+  const response = await page.request.get('/api/doser/pumps')
+  await expect(response).toBeOK()
+  const dosers = await response.json()
+
+  for (const expected of expectedDosers) {
+    const doser = dosers.find(item => item.name === expected.name)
+    expect(doser).toBeTruthy()
+    expect(doser.type).toBe(expected.type)
+  }
+}
 
 test('brand-new user can configure reef-pi through the UI', async ({ page, baseURL }) => {
   const api = await createSmokeApi(baseURL)
@@ -65,6 +98,7 @@ test('brand-new user can configure reef-pi through the UI', async ({ page, baseU
     await lightingPage.open()
     await lightingPage.expectValidation()
     for (const light of modules.lights) await lightingPage.create(light)
+    await expectLightProfiles(page, modules.lights)
 
     await phPage.open()
     await phPage.expectValidation()
@@ -77,6 +111,11 @@ test('brand-new user can configure reef-pi through the UI', async ({ page, baseU
     await doserPage.open()
     await doserPage.expectValidation()
     await doserPage.createDcPump(modules.doser)
+    await doserPage.createStepper(modules.stepperDoser)
+    await expectDoserTypes(page, [
+      { name: modules.doser.name, type: 'dcpump' },
+      { name: modules.stepperDoser.name, type: 'stepper' }
+    ])
 
     await temperaturePage.open()
     await temperaturePage.expectValidation()

--- a/front-end/src/doser/doser_schema.jsx
+++ b/front-end/src/doser/doser_schema.jsx
@@ -17,26 +17,35 @@ const Stepperchema = Yup.object().shape({
 const DoserSchema = Yup.object().shape({
   name: Yup.string()
     .required(i18n.t('validation:name_required')),
-  type: Yup.string(),
+  type: Yup.string()
+    .required(i18n.t('validation:selection_required')),
   jack: Yup.string(),
   pin: Yup.string(),
   stepper: Stepperchema,
   enable: Yup.bool()
     .required(i18n.t('validation:selection_required')),
   continuous: Yup.bool(),
+  volume: Yup.number()
+    .typeError(i18n.t('validation:number_required'))
+    .when('type', {
+      is: 'stepper',
+      then: schema => schema.required(i18n.t('validation:number_required')).min(1, i18n.t('validation:integer_min_required'))
+    }),
   soft_start: Yup.number()
     .typeError(i18n.t('validation:number_required'))
     .min(0, i18n.t('validation:integer_min_required')),
   duration: Yup.number()
     .typeError(i18n.t('validation:number_required'))
-    .when('continuous', {
-      is: false,
+    .when(['type', 'continuous'], {
+      is: (type, continuous) => type !== 'stepper' && continuous === false,
       then: schema => schema.min(1, i18n.t('validation:integer_min_required'))
     }),
   speed: Yup.number()
     .typeError(i18n.t('validation:number_required'))
-    .min(1, i18n.t('validation:integer_min_required'))
-    .max(100, i18n.t('validation:integer_max_required')),
+    .when('type', {
+      is: type => type !== 'stepper',
+      then: schema => schema.min(1, i18n.t('validation:integer_min_required')).max(100, i18n.t('validation:integer_max_required'))
+    }),
   month: Yup.string()
     .when('continuous', { is: false, then: schema => schema.required(i18n.t('validation:cron_required')) }),
   week: Yup.string()

--- a/front-end/src/doser/doser_schema.test.js
+++ b/front-end/src/doser/doser_schema.test.js
@@ -6,7 +6,7 @@ describe('DoserValidation', () => {
   beforeEach(() => {
     basicDoser = {
       name: 'dosername',
-      type: '',
+      type: 'dcpump',
       jack: '',
       pin: '',
 
@@ -23,18 +23,20 @@ describe('DoserValidation', () => {
         microstepping: ''
       },
       enable: true,
+      continuous: false,
+      duration: 1,
       speed: 2,
       month: '1',
       week: '1',
       day: '1',
       hour: '1',
       minute: '1',
-      second: '1',
+      second: '1'
     }
   })
 
   it('should be valid', () => {
-    DoserSchema.validate(basicDoser, {abortEarly: false})
+    return DoserSchema.validate(basicDoser, { abortEarly: false })
   })
 
   it('allows for some complicated invocations', () => {
@@ -44,16 +46,16 @@ describe('DoserValidation', () => {
       day: 'L',
       hour: '4',
       minute: '49',
-      second: '0',
+      second: '0'
     }
     const repeatedDoser = { ...basicDoser, doserUpdates }
-    DoserSchema.validate(repeatedDoser, {abortEarly: false})
+    DoserSchema.validate(repeatedDoser, { abortEarly: false })
 
     const doserUpdateWithW = { ...repeatedDoser, day: '12W' }
-    DoserSchema.validate(doserUpdateWithW, {abortEarly: false})
+    DoserSchema.validate(doserUpdateWithW, { abortEarly: false })
 
-    const doserUpdateWithMultiComplicated = { ...repeatedDoser,  day: '1,12W' }
-    DoserSchema.validate(doserUpdateWithMultiComplicated, {abortEarly: false})
+    const doserUpdateWithMultiComplicated = { ...repeatedDoser, day: '1,12W' }
+    DoserSchema.validate(doserUpdateWithMultiComplicated, { abortEarly: false })
   })
 
   it('allows * for timings', () => {
@@ -63,11 +65,11 @@ describe('DoserValidation', () => {
       day: '1',
       hour: '0',
       minute: '0',
-      second: '0',
+      second: '0'
     }
     const repeatedDoser = { ...basicDoser, ...doserUpdates }
 
-    DoserSchema.validate(repeatedDoser, {abortEarly: false})
+    DoserSchema.validate(repeatedDoser, { abortEarly: false })
   })
 
   it('allows */N interval notation (regression #1978)', () => {
@@ -79,7 +81,7 @@ describe('DoserValidation', () => {
       hour: '*',
       day: '*',
       month: '*',
-      week: '*',
+      week: '*'
     }
     return DoserSchema.isValid(doser).then(valid => expect(valid).toBe(true))
   })
@@ -137,6 +139,30 @@ describe('DoserValidation', () => {
         'duration',
         'speed'
       ])))
+  })
+
+  it('allows a stepper doser without dc pump duration and speed', () => {
+    expect.assertions(1)
+    const doser = {
+      ...basicDoser,
+      type: 'stepper',
+      volume: 5,
+      duration: 0,
+      speed: 0,
+      stepper: {
+        direction_pin: '2',
+        step_pin: '1',
+        ms_pin_a: '3',
+        ms_pin_b: '4',
+        ms_pin_c: '5',
+        spr: 200,
+        delay: 1000,
+        vpr: 1.5,
+        direction: true,
+        microstepping: 'Full'
+      }
+    }
+    return DoserSchema.isValid(doser).then(valid => expect(valid).toBe(true))
   })
 
 })

--- a/front-end/src/doser/edit_doser.jsx
+++ b/front-end/src/doser/edit_doser.jsx
@@ -93,6 +93,7 @@ const EditDoser = ({
             <label htmlFor='volume'>{i18next.t('doser:volume')}</label>
             <Field
               name='volume'
+              data-testid='smoke-doser-volume'
               readOnly={readOnly}
               type='number'
               className={classNames('form-control', {

--- a/front-end/src/doser/edit_stepper.jsx
+++ b/front-end/src/doser/edit_stepper.jsx
@@ -34,6 +34,7 @@ const EditStepper = ({
           <label htmlFor='step_pin'>{i18n.t('doser:step_pin')}</label>
           <Field
             name='stepper.step_pin'
+            data-testid='smoke-doser-step-pin'
             disabled={readOnly}
             component='select'
             className={classNames('custom-select', {
@@ -52,6 +53,7 @@ const EditStepper = ({
           <label htmlFor='direction_pin'>{i18n.t('doser:direction_pin')}</label>
           <Field
             name='stepper.direction_pin'
+            data-testid='smoke-doser-direction-pin'
             disabled={readOnly}
             component='select'
             className={classNames('custom-select', {
@@ -70,6 +72,7 @@ const EditStepper = ({
           <label htmlFor='ms_pin_a'>{i18n.t('doser:ms_pin_a')}</label>
           <Field
             name='stepper.ms_pin_a'
+            data-testid='smoke-doser-ms-pin-a'
             disabled={readOnly}
             component='select'
             className={classNames('custom-select', {
@@ -88,6 +91,7 @@ const EditStepper = ({
           <label htmlFor='ms_pin_b'>{i18n.t('doser:ms_pin_b')}</label>
           <Field
             name='stepper.ms_pin_b'
+            data-testid='smoke-doser-ms-pin-b'
             disabled={readOnly}
             component='select'
             className={classNames('custom-select', {
@@ -106,6 +110,7 @@ const EditStepper = ({
           <label htmlFor='ms_pin_c'>{i18n.t('doser:ms_pin_c')}</label>
           <Field
             name='stepper.ms_pin_c'
+            data-testid='smoke-doser-ms-pin-c'
             disabled={readOnly}
             component='select'
             className={classNames('custom-select', {
@@ -124,6 +129,7 @@ const EditStepper = ({
           <label htmlFor='spr'>{i18n.t('doser:spr')}</label>
           <Field
             name='stepper.spr'
+            data-testid='smoke-doser-spr'
             disabled={readOnly}
             type='number'
             className={classNames('form-control', {
@@ -139,6 +145,7 @@ const EditStepper = ({
           <label htmlFor='vpr'>{i18n.t('doser:vpr')}</label>
           <Field
             name='stepper.vpr'
+            data-testid='smoke-doser-vpr'
             disabled={readOnly}
             type='number'
             className={classNames('form-control', {
@@ -154,13 +161,14 @@ const EditStepper = ({
           <label htmlFor='delay'>{i18n.t('doser:delay')}</label>
           <Field
             name='stepper.delay'
+            data-testid='smoke-doser-delay'
             disabled={readOnly}
             type='number'
             className={classNames('form-control', {
               'is-invalid': ShowError('stepper.delay', touched, errors)
             })}
           />
-          <ErrorFor errors={errors} touched={touched} name='stepper.vpr' />
+          <ErrorFor errors={errors} touched={touched} name='stepper.delay' />
         </div>
       </div>
 
@@ -169,6 +177,7 @@ const EditStepper = ({
           <label htmlFor='direction'>{i18n.t('doser:direction')}</label>
           <Field
             name='stepper.direction'
+            data-testid='smoke-doser-direction'
             disabled={readOnly}
             component={BooleanSelect}
             className={classNames('custom-select', {
@@ -187,6 +196,7 @@ const EditStepper = ({
           <label htmlFor='microstepping'>{i18n.t('doser:microstepping')}</label>
           <Field
             name='stepper.microstepping'
+            data-testid='smoke-doser-microstepping'
             disabled={readOnly}
             component='select'
             className={classNames('custom-select', {


### PR DESCRIPTION
## Summary
- configure and assert fixed, interval, and diurnal lighting profiles in the brand-new-user Playwright integration
- add stepper doser UI coverage alongside the existing DC pump path, including schema coverage for stepper-specific validation
- restore OA3 temperature sensor listing so the integration can select dev-mode sensors through the generated API route

## Verification
- rtk go test ./controller/api ./controller/modules/temperature
- rtk make go
- rtk proxy /home/ranjib/workspace/reef-pi/node_modules/.bin/standard front-end/e2e/pages/lightingPage.js front-end/e2e/pages/doserPage.js front-end/e2e/fixtures/integrationData.js front-end/e2e/specs/integration/brand-new-user-setup.spec.js front-end/src/doser/edit_doser.jsx front-end/src/doser/edit_stepper.jsx front-end/src/doser/doser_schema.jsx
- rtk yarn jest front-end/src/doser/doser_schema.test.js --runInBand
- rtk proxy /home/ranjib/workspace/reef-pi/node_modules/.bin/webpack --mode=production
- rtk proxy /home/ranjib/workspace/reef-pi/node_modules/.bin/playwright test --project=integration-chromium front-end/e2e/specs/integration/brand-new-user-setup.spec.js
- rtk yarn smoke

Tracks #3039
Part of #3033