### PR TITLE
[codex] add UI audit tracking issues

### DIFF
--- a/docs/superpowers/specs/2026-05-21-ui-audit-design.md
+++ b/docs/superpowers/specs/2026-05-21-ui-audit-design.md
@@ -1,0 +1,132 @@
+# reef-pi UI audit screenshot pipeline design
+
+## Purpose
+
+reef-pi has a generated design-system reference in `front-end/design-system`, but the live module screens are inconsistent across routes and workflows. This project creates a repeatable visual audit lane that captures the current UI during a seeded Playwright run, records objective design-system violations, and produces agent-ready reports for follow-up UI improvement work.
+
+The first version is not a redesign. It is the capture and audit foundation that makes future redesign work systematic.
+
+## Goals
+
+- Capture deterministic screenshots for the major reef-pi modules during a seeded Playwright run.
+- Generate a manifest that maps each screenshot to module, viewport, theme, state, route, and design-system context.
+- Fail CI only on objective, high-confidence issues.
+- Produce structured reports and per-module prompt bundles that Codex or Claude Design can use for focused review.
+- Keep subjective visual judgement out of CI and in the agent/human review report.
+
+## Non-Goals
+
+- Redesigning module screens in this project.
+- Treating subjective aesthetics as CI failures.
+- Capturing every form permutation or every transient state in the first version.
+- Replacing the existing smoke suite.
+- Introducing new visual design rules outside the existing design-system reference.
+
+## Architecture
+
+Add a dedicated Playwright project named `ui-audit-chromium` beside the existing smoke and integration projects. It depends on the existing authenticated setup, uses the seeded reef configuration, and writes artifacts under `test-results/ui-audit`.
+
+The audit lane has three parts:
+
+1. `front-end/e2e/specs/ui-audit.spec.js` drives the browser through the selected route corpus.
+2. `front-end/e2e/fixtures/uiAudit.js` captures screenshots, DOM metrics, browser errors, failed requests, and manifest entries.
+3. `front-end/scripts/ui-audit-report.mjs` reads the manifest, applies deterministic pass/fail policy, and writes human- and agent-readable reports.
+
+Playwright owns browser truth and artifact capture. The Node report script owns aggregation, output formatting, and CI exit behavior.
+
+## Capture Coverage
+
+The first screenshot corpus uses:
+
+- Viewports: desktop `1440x1000` and mobile `390x844`.
+- Theme: current/default theme only.
+- State: `seedFullSmokeConfiguration`.
+- Screens: login/shell sanity, dashboard, configuration drivers, configuration connectors, equipment, timers, lighting, temperature, ATO, pH, doser, and macro.
+
+Each capture includes:
+
+- screenshot path
+- module and screen name
+- viewport name and dimensions
+- theme
+- seed profile
+- current route or selected tab
+- visible page title/current tab where available
+- key visible headings or labels
+- console errors
+- failed app/API requests
+- objective audit findings
+- design-system reference notes
+
+Mobile coverage focuses on shell usability and landing states for major modules. The first version does not exhaustively capture all mobile form workflows.
+
+## CI Failure Policy
+
+CI fails only on objective checks in version one:
+
+- Required screenshot missing or unreadable.
+- Fatal app text is visible, including `Something went wrong`.
+- Console errors or failed app/API requests occur during capture, subject to an explicit allowlist if the app has known benign noise.
+- Visible enabled interactive elements are smaller than the design-system `44px` tap target minimum.
+- Obvious layout overflow is detected through DOM measurements, such as clipped text or visible controls protruding outside their container.
+- Required audit anchors are missing, such as shell, navigation, or module `data-testid` markers needed for stable capture.
+
+CI does not fail on subjective findings such as weak visual hierarchy, inconsistent polish, or distance from the Bento OS reference. Those findings are recorded in the agent-ready report.
+
+Accessibility checks are deferred unless an existing dependency can be used without expanding the first implementation.
+
+## Outputs
+
+The audit writes stable artifacts under `test-results/ui-audit`:
+
+- `screenshots/<viewport>/<module>.png`
+- `manifest.json`
+- `agent-report.json`
+- `agent-report.md`
+- `prompts/<module>.md`
+
+`manifest.json` is the machine-readable source of truth. `agent-report.json` groups findings by module and severity. `agent-report.md` gives a concise human review surface with screenshot links and recommended next actions. Per-module prompts include screenshot paths, current findings, and the relevant design-system references.
+
+## Agent Workflow
+
+Codex should be used for the capture/audit implementation and for applying code fixes because it can inspect the repo, edit components, run tests, and preserve token synchronization rules.
+
+Claude Design can be used for subjective visual critique once the screenshot corpus exists. Its output should be treated as design review input. Codex then applies approved changes in the repo.
+
+Prompt bundles must instruct agents to compare against:
+
+- `front-end/design-system/SKILL.md`
+- `front-end/design-system/colors_and_type.css`
+- `front-end/design-system/ui_kits/reef-pi-app`
+- relevant Bento OS references where applicable
+
+Prompt bundles must also state that agents must not invent new design rules, raw hex colors, or fonts outside the approved design-system constraints.
+
+## Implementation Slices
+
+1. Artifact foundation: add the `ui-audit-chromium` project, output directories, capture helper, screenshot naming, and manifest writing.
+2. Seeded route corpus: add the dedicated audit spec for desktop and mobile using the full smoke seed.
+3. Objective CI checks: collect DOM audit data, add the report script, and make objective violations exit non-zero.
+4. Agent report generation: write Markdown/JSON reports and per-module prompt bundles.
+5. CI integration: add the GitHub Actions step after the local audit lane is stable and upload screenshots/reports as artifacts on failure.
+
+## Testing Strategy
+
+- Run `yarn ui-audit` locally after adding the new script.
+- Keep existing `yarn pw-smoke` behavior unchanged.
+- Unit test pure report helpers if the report script grows enough logic to justify it.
+- Verify at least one intentional objective violation causes `ui-audit-report.mjs` to exit non-zero.
+- Verify generated screenshots, manifest, and reports are present after a successful local run.
+
+## Risks
+
+- Objective DOM checks can be noisy if selectors include hidden, disabled, or offscreen elements. The implementation should filter those cases explicitly.
+- Screenshot paths can become unstable if based on display text. Use stable module IDs instead.
+- CI runtime can grow quickly if coverage expands too fast. Version one keeps the matrix limited to two viewports and default theme.
+- Subjective agent findings can drift unless prompts pin them to the existing design-system references.
+
+## Open Decisions
+
+- Exact GitHub Actions workflow placement will be decided during implementation.
+- The first allowlist for console or request noise will be based on observed local audit output.
+- Dark and actinic theme coverage will be added only after default-theme capture is stable.

--- a/front-end/design-system/github_issues/BACKLOG.md
+++ b/front-end/design-system/github_issues/BACKLOG.md
@@ -42,3 +42,10 @@
 ## E6 · Framework exit (no flag — incremental, one route per PR)
 - [ ] #27 Bootstrap 4.6 exit plan — `issue-27-bootstrap-exit.md`
 - [ ] #28 Material-UI v4 exit plan — `issue-28-mui-exit.md`
+
+## E7 · UI audit screenshot pipeline
+- [ ] #30 UI audit artifact foundation — `issue-30-ui-audit-artifact-foundation.md`
+- [ ] #31 Seeded route screenshot corpus — `issue-31-ui-audit-seeded-route-corpus.md`
+- [ ] #32 Objective UI audit checks — `issue-32-ui-audit-objective-ci-checks.md`
+- [ ] #33 Agent-ready UI audit reports and prompts — `issue-33-ui-audit-agent-reports.md`
+- [ ] #34 GitHub Actions UI audit integration — `issue-34-ui-audit-ci-integration.md`

--- a/front-end/design-system/github_issues/CLAUDE.md
+++ b/front-end/design-system/github_issues/CLAUDE.md
@@ -1,0 +1,61 @@
+# Claude Code execution playbook — reef-pi UI modernization
+
+This package is the operating manual for a Claude Code (or any coding agent) to plan, sequence, and ship the 34 fixes identified in the design review and UI audit plan.
+
+## How an agent should use this folder
+
+1. **Read `STRATEGY.md`** — seven epics, sequencing, rollout flags.
+2. **Read this file** — operating rules, definition of done, file conventions.
+3. **Pick the next unchecked issue** in `BACKLOG.md` (top → bottom).
+4. **Open the matching `issue-NN-*.md`** — every issue is self-contained: API, visual spec, acceptance checklist, dependencies.
+5. **Run the `prompts/<issue-id>.md`** as the system prompt for the implementation pass.
+6. **On completion**: tick the box in `BACKLOG.md`, commit with `git commit -m "[claude design] <issue title>"`, push, and open a PR linking the parent epic.
+
+## Definition of done (every issue)
+
+- [ ] All acceptance items in the issue file are checked.
+- [ ] No new raw hex literals in code (use `var(--reefpi-*)`).
+- [ ] No new fonts introduced (Questrial only).
+- [ ] Tap targets ≥ 44px on every interactive element.
+- [ ] Light + dark + actinic themes render without obvious regressions (manual screenshot in PR).
+- [ ] Storybook entry added for any new primitive.
+- [ ] Commit message and PR title prefixed `[claude design]`.
+
+## File conventions
+
+| Path | What goes there |
+|---|---|
+| `colors_and_type.css` | All tokens. Theme blocks scoped via `[data-theme="…"]`. |
+| `ui_kits/reef-pi-app/primitives/*.jsx` | Shared, route-agnostic components. |
+| `ui_kits/reef-pi-app/hooks/*.js` | Shared hooks (`useTimeSeries`, `useAckMutation`). |
+| `ui_kits/reef-pi-app/<route>/*.jsx` | Route-specific components. |
+| `preview/*.html` | Design-system review cards. Self-contained. |
+| `preview/primitives/*.html` | Storybook entries. Self-contained. |
+| `scripts/*.mjs` | CI scripts (e.g. contrast audit). |
+
+## Sequencing (TL;DR)
+
+```
+E1 (tokens)            ──▶ unlocks E2, E3, E5
+   #1 → #2 → #3 → #4
+E2 (primitives)        ──▶ unlocks E3
+   #5, #6, #7 in parallel · #8 needs API · #9 last
+E3 (dashboard v2)      behind `dashboard_v2` flag
+   #10 → #11 → #12 → #13 → #14 (flip flag)
+E4 (control trust)     parallel with E3
+   #15 → #16 → #17 → #18 → #19
+E5 (shell + theming)   last
+   #2 must land first; then #20 → #21 → #22 → #23 → #24 → #25 → #26
+E6 (framework exit)    parallel after E1/E2
+   #27 → #28 one route per PR
+E7 (UI audit pipeline) before broad route redesign
+   #30 → #31 → #32 → #33 → #34
+```
+
+## Rules of engagement for the agent
+
+- **Stay inside the constraint set in `SKILL.md`.** No new accent colors, no emoji, no new fonts, navbar is the only gradient.
+- **Ship behind a flag** when the issue says so (`dashboard_v2`, `new_shell`, `pending_states`, `alert_center`). Default off until the parent epic's checklist is green.
+- **Atomic PRs.** One PR per issue; never bundle two issues into one PR.
+- **No backend changes** unless the label includes `needs: api`. If you discover one, stop and file a follow-up issue rather than improvising.
+- **Always update the relevant `preview/` card** when you touch a token or component — the design-system tab is the user's source of truth.

--- a/front-end/design-system/github_issues/QUICKSTART.md
+++ b/front-end/design-system/github_issues/QUICKSTART.md
@@ -1,11 +1,11 @@
 # [claude design] artifacts — quickstart
 
-You now have two ways to drive the 26 fixes through Claude Code, plus a script that creates real GitHub issues with `[claude design]` in every title.
+You now have two ways to drive the 34 fixes through Claude Code, plus a script that creates real GitHub issues with `[claude design]` in every title.
 
 ## Path A — Claude Code only (no GitHub)
 Everything an agent needs is in `github_issues/`:
 - `CLAUDE.md` — operating manual: definition of done, file conventions, sequencing rules.
-- `STRATEGY.md` — five epics, parent→child map, rollout flags.
+- `STRATEGY.md` — seven epics, parent→child map, rollout flags.
 - `BACKLOG.md` — checklist; tick rows as PRs merge.
 - `issue-NN-*.md` — full spec for each fix (API, visual, acceptance).
 - `prompts/NN.md` — one-shot system prompt per issue, ready to paste into Claude Code.
@@ -25,7 +25,7 @@ claude code --system "$(cat github_issues/prompts/01.md)" \
 cd github_issues
 # 1. Create labels once
 bash _labels.md          # or copy the gh label create block out
-# 2. Create all 31 issues (5 epics + 26 children) with [claude design] prefix
+# 2. Create all 41 issues (7 epics + 34 children) with [claude design] prefix
 REPO=owner/name bash import-as-claude-design.sh
 ```
 

--- a/front-end/design-system/github_issues/STRATEGY.md
+++ b/front-end/design-system/github_issues/STRATEGY.md
@@ -1,6 +1,6 @@
 # reef-pi UI modernization — shipping plan
 
-Five epics, 26 shippable issues, ordered so each ships standalone behind flags/tweaks without blocking the next.
+Seven epics, 34 shippable issues, ordered so each ships standalone behind flags/tweaks without blocking the next.
 
 ## Sequencing rationale
 - **E1 (Design tokens v2)** first — every later epic inherits from it. Ship alone, no UX visible yet.
@@ -9,6 +9,7 @@ Five epics, 26 shippable issues, ordered so each ships standalone behind flags/t
 - **E4 (Control trust)** is independent of E3 — can run in parallel. Adds pending/error toggle states + alert center.
 - **E5 (Shell + theming)** is the heaviest lift; ship behind a `new_shell` flag and flip when ready.
 - **E6 (Framework exit)** runs in parallel after E1/E2 — one route per PR, no flag. Retires Bootstrap 4.6 and Material-UI v4. **Do not** migrate to Bootstrap 5 or MUI v5; the destination is `var(--reefpi-*)` + E2 primitives + plain CSS.
+- **E7 (UI audit screenshot pipeline)** runs before broad route redesign work. It captures current module screens with Playwright, fails CI on objective design-system violations, and generates agent-ready reports for Codex/Claude Design review.
 
 ## Rollout
 | Epic | Week | User-visible? | Flag |
@@ -19,6 +20,7 @@ Five epics, 26 shippable issues, ordered so each ships standalone behind flags/t
 | E4 Trust + alerts | 3–4 | Yes | `pending_states`, `alert_center` |
 | E5 Shell + dark/actinic | 4–6 | Yes | `new_shell`, theme picker in Settings |
 | E6 Framework exit | 3–8 (parallel) | Indirectly | — |
+| E7 UI audit screenshot pipeline | 1–2 | Dev/CI only | — |
 
 ## Files in this pack
 ```
@@ -30,7 +32,9 @@ github_issues/
   epic-03-dashboard-v2.md
   epic-04-control-trust.md
   epic-05-shell-theming.md
-  issue-*.md                           21 child issues
+  epic-06-framework-exit.md
+  epic-07-ui-audit.md
+  issue-*.md                           34 child issues
 ```
 
 ## Import options
@@ -90,4 +94,11 @@ E5 · shell-theming
 E6 · framework-exit
  ├─ #27 Bootstrap 4.6 exit plan (utilities → controls → JS)
  └─ #28 Material-UI v4 exit plan (Switch + FormControlLabel)
+
+E7 · ui-audit-screenshot-pipeline
+ ├─ #30 UI audit artifact foundation
+ ├─ #31 Seeded route screenshot corpus
+ ├─ #32 Objective UI audit checks
+ ├─ #33 Agent-ready UI audit reports and prompts
+ └─ #34 GitHub Actions UI audit integration
 ```

--- a/front-end/design-system/github_issues/epic-07-ui-audit.md
+++ b/front-end/design-system/github_issues/epic-07-ui-audit.md
@@ -1,0 +1,37 @@
+---
+title: "[EPIC] UI audit screenshot pipeline — Playwright capture + objective CI"
+labels: ["type: epic", "area: testing", "priority: p1", "estimate: L", "needs: design"]
+milestone: "E7 — UI audit screenshot pipeline"
+parent: null
+---
+
+# [EPIC] UI audit screenshot pipeline
+
+## Goal
+Create a dedicated Playwright visual-audit lane that captures deterministic screenshots for reef-pi's major module screens, records objective design-system violations, and produces agent-ready reports for follow-up UI improvement work.
+
+The first release is not a redesign. It is the capture and audit foundation that makes redesign work systematic.
+
+## Design
+See `docs/superpowers/specs/2026-05-21-ui-audit-design.md`.
+
+## Success criteria
+- [ ] `ui-audit-chromium` runs separately from the existing smoke and integration projects.
+- [ ] The audit captures desktop and mobile screenshots for the seeded module corpus.
+- [ ] `manifest.json` maps every screenshot to module, viewport, route/tab, theme, seed profile, and audit findings.
+- [ ] CI fails on objective, high-confidence violations only.
+- [ ] Subjective visual findings are written to agent-ready Markdown/JSON reports, not used as CI truth.
+- [ ] Generated prompts explain when to use Codex for implementation and Claude Design for subjective critique.
+- [ ] GitHub Actions uploads screenshots and reports when the audit job fails.
+
+## Sub-tasks
+- [ ] #30 UI audit artifact foundation
+- [ ] #31 Seeded route screenshot corpus
+- [ ] #32 Objective UI audit checks
+- [ ] #33 Agent-ready report and prompt generation
+- [ ] #34 GitHub Actions UI audit integration
+
+## Dependencies
+- Requires the existing Playwright auth setup and seeded smoke helpers.
+- Uses the design-system constraints in `front-end/design-system/SKILL.md`.
+- Must not change existing `yarn pw-smoke` behavior.

--- a/front-end/design-system/github_issues/issue-29-font-swap.md
+++ b/front-end/design-system/github_issues/issue-29-font-swap.md
@@ -70,7 +70,7 @@ Keep Century Gothic in the stack as a fallback for offline Pis on macOS/Windows 
 ## Dependencies
 - Depends on: #1, #2 (E1 token foundation must exist).
 - Blocks: nothing — but cleaning this up *before* E3 (Bento OS dashboard) ships means the dashboard launches with the right typography from day one.
-- Touches: every `prompts/*.md` boilerplate. Use a one-liner `sed` to make that change; do not hand-edit 26 files.
+- Touches: every `prompts/*.md` boilerplate. Use a one-liner `sed` to make that change; do not hand-edit prompt files one by one.
 
 ## Suggested workflow
 1. Land the design-system project PR first (this folder).

--- a/front-end/design-system/github_issues/issue-30-ui-audit-artifact-foundation.md
+++ b/front-end/design-system/github_issues/issue-30-ui-audit-artifact-foundation.md
@@ -1,0 +1,25 @@
+---
+title: "UI audit artifact foundation"
+labels: ["type: chore", "area: testing", "priority: p1", "estimate: M", "needs: design"]
+parent: "[EPIC] UI audit screenshot pipeline — Playwright capture + objective CI"
+---
+
+# UI audit artifact foundation
+
+Add the dedicated Playwright project, package scripts, capture helper shell, and manifest format for the visual audit lane.
+
+## What to build
+- Add `ui-audit-chromium` to `playwright.config.js`.
+- Add `yarn ui-audit` to `package.json`.
+- Add `make ui-audit` to `Makefile`.
+- Create `front-end/e2e/fixtures/uiAudit.js`.
+- Define a stable artifact layout under `test-results/ui-audit`.
+- Write `manifest.json` entries for screenshots captured by the helper.
+
+## Acceptance
+- [ ] `yarn ui-audit` runs only the `ui-audit-chromium` project.
+- [ ] Existing `yarn pw-smoke` and `make smoke` behavior is unchanged.
+- [ ] `uiAudit.js` exposes a capture helper that accepts module ID, screen name, viewport name, design-system references, and a Playwright page.
+- [ ] Screenshots are named with stable IDs, not visible display text.
+- [ ] A successful local run writes `test-results/ui-audit/manifest.json`.
+- [ ] Manifest entries include screenshot path, module, screen, viewport, theme, seed profile, route/tab, and objective finding arrays.

--- a/front-end/design-system/github_issues/issue-31-ui-audit-seeded-route-corpus.md
+++ b/front-end/design-system/github_issues/issue-31-ui-audit-seeded-route-corpus.md
@@ -1,0 +1,25 @@
+---
+title: "Seeded route screenshot corpus"
+labels: ["type: chore", "area: testing", "priority: p1", "estimate: M", "needs: design"]
+parent: "[EPIC] UI audit screenshot pipeline — Playwright capture + objective CI"
+---
+
+# Seeded route screenshot corpus
+
+Add the dedicated Playwright spec that seeds a configured reef and captures the first stable UI corpus across major modules.
+
+## What to build
+- Create `front-end/e2e/specs/ui-audit.spec.js`.
+- Reuse `createSmokeApi` and `seedFullSmokeConfiguration`.
+- Capture desktop `1440x1000` and mobile `390x844`.
+- Capture default theme only.
+- Traverse dashboard, configuration drivers, configuration connectors, equipment, timers, lighting, temperature, ATO, pH, doser, and macro.
+- Include login/shell sanity capture where useful.
+
+## Acceptance
+- [ ] The spec seeds state once per viewport run using existing smoke helpers.
+- [ ] Desktop screenshots exist for every module in the corpus.
+- [ ] Mobile screenshots exist for shell usability and major module landing states.
+- [ ] Each capture waits for stable module content before screenshotting.
+- [ ] The corpus does not require new backend fixtures.
+- [ ] The first version does not attempt to capture every form branch or transient state.

--- a/front-end/design-system/github_issues/issue-32-ui-audit-objective-ci-checks.md
+++ b/front-end/design-system/github_issues/issue-32-ui-audit-objective-ci-checks.md
@@ -1,0 +1,27 @@
+---
+title: "Objective UI audit checks"
+labels: ["type: chore", "area: testing", "priority: p1", "estimate: M", "needs: design"]
+parent: "[EPIC] UI audit screenshot pipeline — Playwright capture + objective CI"
+---
+
+# Objective UI audit checks
+
+Collect deterministic browser and DOM facts during capture, then fail the audit only for high-confidence objective violations.
+
+## What to build
+- Extend `front-end/e2e/fixtures/uiAudit.js` to collect console errors and failed app/API requests.
+- Collect tap-target metrics for visible enabled interactive elements.
+- Collect obvious overflow metrics for visible text and controls.
+- Detect fatal app text such as `Something went wrong`.
+- Create `front-end/scripts/ui-audit-report.mjs`.
+- Add an explicit allowlist mechanism for known benign console/request noise.
+
+## Acceptance
+- [ ] Missing or unreadable required screenshots fail the report script.
+- [ ] Fatal app text fails the report script.
+- [ ] Unallowlisted console errors and failed app/API requests fail the report script.
+- [ ] Visible enabled interactive elements below `44px` fail the report script.
+- [ ] Obvious visible overflow fails the report script.
+- [ ] Missing required shell/nav/module audit anchors fail the report script.
+- [ ] Subjective visual quality findings do not fail CI.
+- [ ] `ui-audit-report.mjs` exits non-zero for objective violations and zero for a clean manifest.

--- a/front-end/design-system/github_issues/issue-33-ui-audit-agent-reports.md
+++ b/front-end/design-system/github_issues/issue-33-ui-audit-agent-reports.md
@@ -1,0 +1,24 @@
+---
+title: "Agent-ready UI audit reports and prompts"
+labels: ["type: feature", "area: testing", "priority: p1", "estimate: M", "needs: design"]
+parent: "[EPIC] UI audit screenshot pipeline — Playwright capture + objective CI"
+---
+
+# Agent-ready UI audit reports and prompts
+
+Generate structured outputs that let Codex or Claude Design review one reef-pi module at a time without rediscovering context.
+
+## What to build
+- Write `test-results/ui-audit/agent-report.json`.
+- Write `test-results/ui-audit/agent-report.md`.
+- Write per-module prompt bundles under `test-results/ui-audit/prompts/`.
+- Include screenshot paths, objective findings, design-system references, and recommended next actions.
+- Explain tool choice: Codex for repo implementation, Claude Design for subjective visual critique.
+
+## Acceptance
+- [ ] `agent-report.json` groups findings by module, viewport, and severity.
+- [ ] `agent-report.md` links each module to its screenshots and summarizes next actions.
+- [ ] Each prompt names the relevant screenshots and current findings.
+- [ ] Each prompt references `front-end/design-system/SKILL.md`, `colors_and_type.css`, and `ui_kits/reef-pi-app`.
+- [ ] Prompts state that agents must not invent new design rules, raw hex colors, or fonts.
+- [ ] Prompts keep subjective critique separate from objective CI failures.

--- a/front-end/design-system/github_issues/issue-34-ui-audit-ci-integration.md
+++ b/front-end/design-system/github_issues/issue-34-ui-audit-ci-integration.md
@@ -1,0 +1,22 @@
+---
+title: "GitHub Actions UI audit integration"
+labels: ["type: chore", "area: ci", "area: testing", "priority: p1", "estimate: S", "needs: design"]
+parent: "[EPIC] UI audit screenshot pipeline — Playwright capture + objective CI"
+---
+
+# GitHub Actions UI audit integration
+
+Run the UI audit in GitHub Actions after the local lane is stable and upload useful artifacts on failure.
+
+## What to build
+- Add a GitHub Actions job for `yarn ui-audit`.
+- Keep existing smoke jobs unchanged.
+- Upload `test-results/ui-audit/screenshots`, `manifest.json`, `agent-report.json`, `agent-report.md`, and prompt bundles when the job fails.
+- Document local reproduction.
+
+## Acceptance
+- [ ] The workflow installs the same dependencies used by existing Playwright jobs.
+- [ ] The job fails when `ui-audit-report.mjs` reports objective violations.
+- [ ] Existing smoke CI remains a separate check.
+- [ ] Failure artifacts include screenshots, manifest, report files, and prompts.
+- [ ] `docs/ci-reproduction.md` or the frontend test README documents the local `yarn ui-audit` reproduction command.

--- a/front-end/design-system/github_issues/prompts/29.md
+++ b/front-end/design-system/github_issues/prompts/29.md
@@ -39,7 +39,7 @@ Ask the user which mode before starting. If unclear, default to **Mode A** (desi
 - No third font. Two families total.
 - Keep Century Gothic in the fallback stack.
 - No raw `font-family: 'Manrope'` in JSX — go through `var(--reefpi-font-app)` / `var(--reefpi-font-mono)`.
-- For the prompts mass-update, use one `sed`/`find` invocation. Do not hand-edit 26 files.
+- For the prompts mass-update, use one `sed`/`find` invocation. Do not hand-edit prompt files one by one.
 - Pin loaded weights to 400/500/600 (Manrope) and 400/500 (JetBrains Mono). No bringing 200 or 800 along for the ride.
 - Do not change the Bootstrap type scale tokens (`--reefpi-h1` etc.) as part of this issue.
 

--- a/front-end/design-system/github_issues/prompts/30.md
+++ b/front-end/design-system/github_issues/prompts/30.md
@@ -1,0 +1,40 @@
+# Claude Code prompt - Issue #30: UI audit artifact foundation
+
+You are Claude Code, running inside the **reef-pi/reef-pi** codebase.
+
+## Goal
+Add the dedicated Playwright UI audit lane, artifact layout, capture helper, and manifest foundation without changing existing smoke behavior.
+
+## Source of truth
+Open and follow exactly:
+- `front-end/design-system/github_issues/issue-30-ui-audit-artifact-foundation.md` - full spec and acceptance.
+- `front-end/design-system/github_issues/epic-07-ui-audit.md` - parent rationale.
+- `docs/superpowers/specs/2026-05-21-ui-audit-design.md` - architecture and output contract.
+- `front-end/design-system/SKILL.md` - design-system constraints.
+
+## Files to touch
+- `playwright.config.js`
+- `package.json`
+- `Makefile`
+- `front-end/e2e/fixtures/uiAudit.js`
+- Any existing Playwright helper files only if needed for shared setup reuse.
+
+## Constraints
+- Do not change `yarn pw-smoke`, `make smoke`, or existing Playwright project behavior.
+- Screenshots and manifest entries must use stable IDs, not visible display text.
+- Keep generated artifacts under `test-results/ui-audit`.
+- The helper must accept module ID, screen name, viewport name, design-system references, and a Playwright page.
+
+## Plan
+Before editing:
+1. Inspect the existing Playwright config, smoke scripts, and e2e helper patterns.
+2. State the exact new script/project names.
+3. List every file you will touch.
+4. Then implement the smallest working foundation.
+
+## Done
+- All acceptance items in `issue-30-ui-audit-artifact-foundation.md` are checked.
+- `yarn ui-audit` runs only the `ui-audit-chromium` project.
+- A successful local run writes `test-results/ui-audit/manifest.json`.
+- `yarn pw-smoke` behavior is unchanged.
+- Commit message: `[claude design] add UI audit artifact foundation`

--- a/front-end/design-system/github_issues/prompts/31.md
+++ b/front-end/design-system/github_issues/prompts/31.md
@@ -1,0 +1,38 @@
+# Claude Code prompt - Issue #31: Seeded route screenshot corpus
+
+You are Claude Code, running inside the **reef-pi/reef-pi** codebase.
+
+## Goal
+Create the first deterministic UI audit screenshot corpus using the existing seeded smoke configuration.
+
+## Source of truth
+Open and follow exactly:
+- `front-end/design-system/github_issues/issue-31-ui-audit-seeded-route-corpus.md` - route corpus and acceptance.
+- `front-end/design-system/github_issues/issue-30-ui-audit-artifact-foundation.md` - capture helper contract.
+- `front-end/design-system/github_issues/epic-07-ui-audit.md` - parent rationale.
+- `docs/superpowers/specs/2026-05-21-ui-audit-design.md` - capture coverage.
+
+## Files to touch
+- `front-end/e2e/specs/ui-audit.spec.js`
+- `front-end/e2e/fixtures/uiAudit.js` only if the helper needs small extensions.
+- Existing smoke seed helpers only for reuse, not redesign.
+
+## Constraints
+- Reuse `createSmokeApi` and `seedFullSmokeConfiguration`.
+- Capture desktop `1440x1000` and mobile `390x844`.
+- Capture default theme only.
+- Cover dashboard, configuration drivers, configuration connectors, equipment, timers, lighting, temperature, ATO, pH, doser, and macro.
+- Do not add new backend fixtures.
+
+## Plan
+Before editing:
+1. Inspect existing smoke specs for auth, seeding, and route navigation.
+2. State which routes/tabs will be captured for desktop and mobile.
+3. List wait conditions for each module capture.
+4. Then implement the spec.
+
+## Done
+- All acceptance items in `issue-31-ui-audit-seeded-route-corpus.md` are checked.
+- Desktop screenshots exist for every module in the corpus.
+- Mobile screenshots exist for shell usability and major module landing states.
+- Commit message: `[claude design] seed UI audit screenshot corpus`

--- a/front-end/design-system/github_issues/prompts/32.md
+++ b/front-end/design-system/github_issues/prompts/32.md
@@ -1,0 +1,38 @@
+# Claude Code prompt - Issue #32: Objective UI audit checks
+
+You are Claude Code, running inside the **reef-pi/reef-pi** codebase.
+
+## Goal
+Collect deterministic browser and DOM facts during UI audit capture, then fail CI only on high-confidence objective violations.
+
+## Source of truth
+Open and follow exactly:
+- `front-end/design-system/github_issues/issue-32-ui-audit-objective-ci-checks.md` - full acceptance.
+- `front-end/design-system/github_issues/issue-30-ui-audit-artifact-foundation.md` - manifest contract.
+- `docs/superpowers/specs/2026-05-21-ui-audit-design.md` - CI failure policy.
+- `front-end/design-system/SKILL.md` - 44px tap-target and design constraints.
+
+## Files to touch
+- `front-end/e2e/fixtures/uiAudit.js`
+- `front-end/scripts/ui-audit-report.mjs`
+- Any small test fixture files needed for report-script coverage.
+- `package.json` only if the report script must be wired into `yarn ui-audit`.
+
+## Constraints
+- Fatal app text, missing screenshots, unallowlisted console/request failures, tap targets below `44px`, obvious overflow, and missing required anchors are objective failures.
+- Subjective visual quality findings must not fail CI.
+- Hidden, disabled, offscreen, and non-visible elements must be filtered before DOM checks.
+- Add an explicit allowlist mechanism for known benign console/request noise.
+
+## Plan
+Before editing:
+1. Inspect the manifest shape from #30 and screenshot corpus from #31.
+2. Define the objective finding schema.
+3. State how the report script exits non-zero and how allowlists are configured.
+4. Then implement and test the reporter.
+
+## Done
+- All acceptance items in `issue-32-ui-audit-objective-ci-checks.md` are checked.
+- `ui-audit-report.mjs` exits non-zero for objective violations and zero for a clean manifest.
+- At least one intentional objective violation has been verified locally.
+- Commit message: `[claude design] add objective UI audit checks`

--- a/front-end/design-system/github_issues/prompts/33.md
+++ b/front-end/design-system/github_issues/prompts/33.md
@@ -1,0 +1,44 @@
+# Claude Code prompt - Issue #33: Agent-ready UI audit reports and prompts
+
+You are Claude Code, running inside the **reef-pi/reef-pi** codebase.
+
+## Goal
+Generate structured UI audit outputs that let Codex or Claude Design review one module at a time without rediscovering context.
+
+## Source of truth
+Open and follow exactly:
+- `front-end/design-system/github_issues/issue-33-ui-audit-agent-reports.md` - full spec and acceptance.
+- `front-end/design-system/github_issues/issue-32-ui-audit-objective-ci-checks.md` - objective finding schema.
+- `docs/superpowers/specs/2026-05-21-ui-audit-design.md` - agent workflow and outputs.
+- `front-end/design-system/SKILL.md` - design-system constraints.
+
+## Files to touch
+- `front-end/scripts/ui-audit-report.mjs`
+- Any report template/helper files needed by the script.
+- Tests or fixtures for report generation if the script has existing coverage.
+
+## Outputs
+Generate under `test-results/ui-audit`:
+- `agent-report.json`
+- `agent-report.md`
+- `prompts/<module>.md`
+
+## Constraints
+- Reports must group findings by module, viewport, and severity.
+- Prompts must reference screenshot paths and current findings.
+- Prompts must reference `front-end/design-system/SKILL.md`, `colors_and_type.css`, and `ui_kits/reef-pi-app`.
+- Prompts must say agents must not invent new design rules, raw hex colors, or fonts.
+- Keep subjective critique separate from objective CI failures.
+
+## Plan
+Before editing:
+1. Inspect current manifest and objective finding structure.
+2. Sketch the JSON and Markdown output shapes.
+3. List the per-module prompt naming convention.
+4. Then implement report generation.
+
+## Done
+- All acceptance items in `issue-33-ui-audit-agent-reports.md` are checked.
+- Generated Markdown links each module to screenshots and next actions.
+- Prompt bundles clearly distinguish Codex implementation work from Claude Design subjective critique.
+- Commit message: `[claude design] generate agent-ready UI audit reports`

--- a/front-end/design-system/github_issues/prompts/34.md
+++ b/front-end/design-system/github_issues/prompts/34.md
@@ -1,0 +1,38 @@
+# Claude Code prompt - Issue #34: GitHub Actions UI audit integration
+
+You are Claude Code, running inside the **reef-pi/reef-pi** codebase.
+
+## Goal
+Run the UI audit in GitHub Actions after the local lane is stable and upload actionable artifacts when it fails.
+
+## Source of truth
+Open and follow exactly:
+- `front-end/design-system/github_issues/issue-34-ui-audit-ci-integration.md` - full spec and acceptance.
+- `front-end/design-system/github_issues/epic-07-ui-audit.md` - parent rationale.
+- `docs/superpowers/specs/2026-05-21-ui-audit-design.md` - CI and output policy.
+- Existing GitHub Actions workflow files - preserve their structure and dependency install pattern.
+
+## Files to touch
+- Existing `.github/workflows/*` Playwright or frontend test workflow files.
+- `docs/ci-reproduction.md` or the frontend test README for local reproduction docs.
+- `package.json` only if the local command from earlier issues needs final wiring.
+
+## Constraints
+- Keep existing smoke CI as a separate check.
+- Use the same dependency install and Playwright browser setup pattern as existing jobs.
+- Upload `test-results/ui-audit/screenshots`, `manifest.json`, `agent-report.json`, `agent-report.md`, and prompt bundles when the job fails.
+- Do not make subjective visual findings block CI.
+
+## Plan
+Before editing:
+1. Inspect the existing Playwright GitHub Actions jobs.
+2. State where the new UI audit job will run and what it depends on.
+3. List artifact upload paths.
+4. Then wire the workflow and docs.
+
+## Done
+- All acceptance items in `issue-34-ui-audit-ci-integration.md` are checked.
+- CI fails when `ui-audit-report.mjs` reports objective violations.
+- Existing smoke CI remains separate.
+- Local reproduction docs mention `yarn ui-audit`.
+- Commit message: `[claude design] add UI audit CI integration`


### PR DESCRIPTION
## Summary
- add E7 UI audit screenshot pipeline epic and child issue specs
- add execution prompts for issues 30 through 34
- update quickstart/strategy/playbook counts for the expanded issue pack

## Tracking tickets
- Epic: #3053
- Children: #3054, #3055, #3056, #3057, #3058

## Validation
- searched issue pack for stale five-epic / 26-fix wording
- documentation-only change; no runtime tests run