### PR TITLE
[codex] add UI audit artifact foundation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,10 @@ api-doc:
 smoke:
 	yarn run smoke
 
+.PHONY: ui-audit
+ui-audit:
+	yarn run ui-audit
+
 .PHONY: integration-smoke
 integration-smoke:
 	yarn run integration

--- a/front-end/e2e/fixtures/uiAudit.js
+++ b/front-end/e2e/fixtures/uiAudit.js
@@ -1,0 +1,136 @@
+const fs = require('fs').promises
+const path = require('path')
+
+const artifactRoot = path.join(process.cwd(), 'test-results', 'ui-audit')
+const screenshotRoot = path.join(artifactRoot, 'screenshots')
+const manifestPath = path.join(artifactRoot, 'manifest.json')
+
+function stableId (value) {
+  const id = String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  return id || 'unknown'
+}
+
+function emptyObjectiveFindings () {
+  return {
+    requiredScreenshots: [],
+    fatalText: [],
+    consoleErrors: [],
+    failedRequests: [],
+    tapTargets: [],
+    overflow: [],
+    missingAnchors: []
+  }
+}
+
+function normalizeObjectiveFindings (findings = {}) {
+  const normalized = emptyObjectiveFindings()
+  for (const key of Object.keys(normalized)) {
+    normalized[key] = Array.isArray(findings[key]) ? findings[key] : []
+  }
+  return normalized
+}
+
+async function resetUiAuditArtifacts () {
+  await fs.rm(artifactRoot, { recursive: true, force: true })
+  await fs.mkdir(screenshotRoot, { recursive: true })
+  await writeManifest([])
+}
+
+async function readManifest () {
+  try {
+    return JSON.parse(await fs.readFile(manifestPath, 'utf8'))
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error
+    }
+
+    return {
+      version: 1,
+      generatedAt: null,
+      entries: []
+    }
+  }
+}
+
+async function writeManifest (entries) {
+  await fs.mkdir(artifactRoot, { recursive: true })
+  await fs.writeFile(manifestPath, `${JSON.stringify({
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    entries
+  }, null, 2)}\n`)
+}
+
+async function appendManifestEntry (entry) {
+  const manifest = await readManifest()
+  manifest.entries.push(entry)
+  await writeManifest(manifest.entries)
+}
+
+async function captureUiAuditScreenshot ({
+  page,
+  moduleId,
+  screenName,
+  viewportName,
+  designSystemReferences,
+  theme = 'default',
+  seedProfile = 'none',
+  route = null,
+  tab = null,
+  viewport = null,
+  objectiveFindings = emptyObjectiveFindings()
+}) {
+  if (!page) {
+    throw new Error('captureUiAuditScreenshot requires a Playwright page')
+  }
+
+  const moduleSlug = stableId(moduleId)
+  const screenSlug = stableId(screenName)
+  const viewportSlug = stableId(viewportName)
+  const screenshotDir = path.join(screenshotRoot, viewportSlug)
+  const screenshotFile = `${moduleSlug}-${screenSlug}.png`
+  const screenshotPath = path.join(screenshotDir, screenshotFile)
+  const relativeScreenshotPath = path.relative(process.cwd(), screenshotPath)
+
+  await fs.mkdir(screenshotDir, { recursive: true })
+  await page.screenshot({
+    path: screenshotPath,
+    fullPage: true
+  })
+
+  const entry = {
+    id: `${viewportSlug}-${moduleSlug}-${screenSlug}`,
+    screenshotPath: relativeScreenshotPath,
+    module: moduleSlug,
+    screen: screenSlug,
+    viewport: {
+      name: viewportSlug,
+      size: viewport || page.viewportSize()
+    },
+    theme,
+    seedProfile,
+    route: route || page.url(),
+    tab,
+    designSystemReferences: designSystemReferences || [],
+    objectiveFindings: normalizeObjectiveFindings(objectiveFindings)
+  }
+
+  await appendManifestEntry(entry)
+  return entry
+}
+
+module.exports = {
+  artifactRoot,
+  manifestPath,
+  screenshotRoot,
+  captureUiAuditScreenshot,
+  emptyObjectiveFindings,
+  normalizeObjectiveFindings,
+  resetUiAuditArtifacts,
+  stableId
+}

--- a/front-end/e2e/specs/ui-audit/artifact-foundation.spec.js
+++ b/front-end/e2e/specs/ui-audit/artifact-foundation.spec.js
@@ -1,0 +1,29 @@
+const { test, expect } = require('@playwright/test')
+const { NavBar } = require('../../pages/navBar')
+const {
+  captureUiAuditScreenshot
+} = require('../../fixtures/uiAudit')
+
+const designSystemReferences = [
+  'front-end/design-system/SKILL.md',
+  'front-end/design-system/colors_and_type.css',
+  'front-end/design-system/ui_kits/reef-pi-app'
+]
+
+test('captures the authenticated shell audit baseline', async ({ page }) => {
+  const navBar = new NavBar(page)
+
+  await page.goto('/')
+  await navBar.expectShell()
+  await expect(page.getByTestId('smoke-shell-root')).toBeVisible()
+
+  await captureUiAuditScreenshot({
+    page,
+    moduleId: 'shell',
+    screenName: 'authenticated-shell',
+    viewportName: 'desktop',
+    seedProfile: 'auth-only',
+    route: '/',
+    designSystemReferences
+  })
+})

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "smoke": "playwright test --project=smoke-chromium",
     "pw-smoke": "playwright test --project=smoke-chromium",
     "pw-smoke:headed": "playwright test --project=smoke-chromium --headed",
+    "ui-audit": "node -e \"require('./front-end/e2e/fixtures/uiAudit').resetUiAuditArtifacts()\" && playwright test --project=ui-audit-chromium",
     "integration": "playwright test --project=integration-chromium",
     "integration:headed": "playwright test --project=integration-chromium --headed"
   },

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -39,6 +39,17 @@ module.exports = defineConfig({
       }
     },
     {
+      name: 'ui-audit-chromium',
+      dependencies: ['setup'],
+      testMatch: /specs\/ui-audit\/.*\.spec\.js/,
+      outputDir: 'test-results/ui-audit/playwright',
+      use: {
+        browserName: 'chromium',
+        storageState: 'front-end/e2e/.auth/user.json',
+        viewport: { width: 1440, height: 1000 }
+      }
+    },
+    {
       name: 'integration-chromium',
       dependencies: ['setup'],
       testMatch: /specs\/integration\/.*\.spec\.js/,


### PR DESCRIPTION
## Summary
- add a dedicated ui-audit-chromium Playwright project isolated from smoke and integration projects
- add yarn/make ui-audit entrypoints
- add a UI audit capture helper that writes stable screenshots plus test-results/ui-audit/manifest.json
- add an authenticated shell baseline capture under front-end/e2e/specs/ui-audit

Fixes #3054

## Validation
- yarn ui-audit
- make ui-audit
- yarn pw-smoke --list
- ./node_modules/.bin/standard front-end/e2e/fixtures/uiAudit.js front-end/e2e/specs/ui-audit/artifact-foundation.spec.js
- inspected test-results/ui-audit/manifest.json for one desktop 1440x1000 shell entry