### PR TITLE
[codex] seed UI audit screenshot corpus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,10 @@ api-doc:
 smoke:
 	yarn run smoke
 
+.PHONY: ui-audit
+ui-audit:
+	yarn run ui-audit
+
 .PHONY: integration-smoke
 integration-smoke:
 	yarn run integration

--- a/front-end/e2e/fixtures/uiAudit.js
+++ b/front-end/e2e/fixtures/uiAudit.js
@@ -1,0 +1,136 @@
+const fs = require('fs').promises
+const path = require('path')
+
+const artifactRoot = path.join(process.cwd(), 'test-results', 'ui-audit')
+const screenshotRoot = path.join(artifactRoot, 'screenshots')
+const manifestPath = path.join(artifactRoot, 'manifest.json')
+
+function stableId (value) {
+  const id = String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  return id || 'unknown'
+}
+
+function emptyObjectiveFindings () {
+  return {
+    requiredScreenshots: [],
+    fatalText: [],
+    consoleErrors: [],
+    failedRequests: [],
+    tapTargets: [],
+    overflow: [],
+    missingAnchors: []
+  }
+}
+
+function normalizeObjectiveFindings (findings = {}) {
+  const normalized = emptyObjectiveFindings()
+  for (const key of Object.keys(normalized)) {
+    normalized[key] = Array.isArray(findings[key]) ? findings[key] : []
+  }
+  return normalized
+}
+
+async function resetUiAuditArtifacts () {
+  await fs.rm(artifactRoot, { recursive: true, force: true })
+  await fs.mkdir(screenshotRoot, { recursive: true })
+  await writeManifest([])
+}
+
+async function readManifest () {
+  try {
+    return JSON.parse(await fs.readFile(manifestPath, 'utf8'))
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error
+    }
+
+    return {
+      version: 1,
+      generatedAt: null,
+      entries: []
+    }
+  }
+}
+
+async function writeManifest (entries) {
+  await fs.mkdir(artifactRoot, { recursive: true })
+  await fs.writeFile(manifestPath, `${JSON.stringify({
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    entries
+  }, null, 2)}\n`)
+}
+
+async function appendManifestEntry (entry) {
+  const manifest = await readManifest()
+  manifest.entries.push(entry)
+  await writeManifest(manifest.entries)
+}
+
+async function captureUiAuditScreenshot ({
+  page,
+  moduleId,
+  screenName,
+  viewportName,
+  designSystemReferences,
+  theme = 'default',
+  seedProfile = 'none',
+  route = null,
+  tab = null,
+  viewport = null,
+  objectiveFindings = emptyObjectiveFindings()
+}) {
+  if (!page) {
+    throw new Error('captureUiAuditScreenshot requires a Playwright page')
+  }
+
+  const moduleSlug = stableId(moduleId)
+  const screenSlug = stableId(screenName)
+  const viewportSlug = stableId(viewportName)
+  const screenshotDir = path.join(screenshotRoot, viewportSlug)
+  const screenshotFile = `${moduleSlug}-${screenSlug}.png`
+  const screenshotPath = path.join(screenshotDir, screenshotFile)
+  const relativeScreenshotPath = path.relative(process.cwd(), screenshotPath)
+
+  await fs.mkdir(screenshotDir, { recursive: true })
+  await page.screenshot({
+    path: screenshotPath,
+    fullPage: true
+  })
+
+  const entry = {
+    id: `${viewportSlug}-${moduleSlug}-${screenSlug}`,
+    screenshotPath: relativeScreenshotPath,
+    module: moduleSlug,
+    screen: screenSlug,
+    viewport: {
+      name: viewportSlug,
+      size: viewport || page.viewportSize()
+    },
+    theme,
+    seedProfile,
+    route: route || page.url(),
+    tab,
+    designSystemReferences: designSystemReferences || [],
+    objectiveFindings: normalizeObjectiveFindings(objectiveFindings)
+  }
+
+  await appendManifestEntry(entry)
+  return entry
+}
+
+module.exports = {
+  artifactRoot,
+  manifestPath,
+  screenshotRoot,
+  captureUiAuditScreenshot,
+  emptyObjectiveFindings,
+  normalizeObjectiveFindings,
+  resetUiAuditArtifacts,
+  stableId
+}

--- a/front-end/e2e/specs/ui-audit/artifact-foundation.spec.js
+++ b/front-end/e2e/specs/ui-audit/artifact-foundation.spec.js
@@ -1,0 +1,29 @@
+const { test, expect } = require('@playwright/test')
+const { NavBar } = require('../../pages/navBar')
+const {
+  captureUiAuditScreenshot
+} = require('../../fixtures/uiAudit')
+
+const designSystemReferences = [
+  'front-end/design-system/SKILL.md',
+  'front-end/design-system/colors_and_type.css',
+  'front-end/design-system/ui_kits/reef-pi-app'
+]
+
+test('captures the authenticated shell audit baseline', async ({ page }) => {
+  const navBar = new NavBar(page)
+
+  await page.goto('/')
+  await navBar.expectShell()
+  await expect(page.getByTestId('smoke-shell-root')).toBeVisible()
+
+  await captureUiAuditScreenshot({
+    page,
+    moduleId: 'shell',
+    screenName: 'authenticated-shell',
+    viewportName: 'desktop',
+    seedProfile: 'auth-only',
+    route: '/',
+    designSystemReferences
+  })
+})

--- a/front-end/e2e/specs/ui-audit/seeded-corpus.spec.js
+++ b/front-end/e2e/specs/ui-audit/seeded-corpus.spec.js
@@ -1,0 +1,145 @@
+const { test, expect } = require('@playwright/test')
+const { createSmokeApi, seedFullSmokeConfiguration } = require('../../fixtures/apiSeed')
+const { NavBar } = require('../../pages/navBar')
+const { captureUiAuditScreenshot } = require('../../fixtures/uiAudit')
+
+const designSystemReferences = [
+  'front-end/design-system/SKILL.md',
+  'front-end/design-system/colors_and_type.css',
+  'front-end/design-system/ui_kits/reef-pi-app'
+]
+
+const desktopViewport = { name: 'desktop', size: { width: 1440, height: 1000 } }
+const mobileViewport = { name: 'mobile', size: { width: 390, height: 844 } }
+
+async function expectNoFatalError (page) {
+  await expect(page.getByText('Something went wrong')).toHaveCount(0)
+}
+
+async function expectPageText (page, values) {
+  for (const value of values) {
+    await expect(page.locator('body')).toContainText(value)
+  }
+  await expectNoFatalError(page)
+}
+
+async function seedForCapture (baseURL) {
+  const api = await createSmokeApi(baseURL)
+  try {
+    await seedFullSmokeConfiguration(api)
+  } finally {
+    await api.dispose()
+  }
+}
+
+async function expectShellForViewport (page, viewport) {
+  await expect(page.getByTestId('smoke-shell-root')).toBeVisible()
+  const brand = page.getByTestId('smoke-brand')
+  if (await brand.count()) {
+    await expect(brand.first()).toBeVisible()
+  }
+
+  if (viewport.name === 'mobile') {
+    await expect(page.getByTestId('smoke-current-tab')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Toggle navigation' })).toBeVisible()
+  } else {
+    await expect(page.getByTestId('smoke-tab-dashboard')).toBeVisible()
+  }
+}
+
+async function openRoute (page, navBar, viewport, moduleId) {
+  const tab = navBar.tab(moduleId).first()
+  if (!await tab.isVisible()) {
+    await page.getByRole('button', { name: 'Toggle navigation' }).click()
+    await expect(tab).toBeVisible()
+  }
+  await tab.click()
+}
+
+async function captureCurrentScreen ({ page, moduleId, screenName, viewport, route, tab = null }) {
+  await captureUiAuditScreenshot({
+    page,
+    moduleId,
+    screenName,
+    viewportName: viewport.name,
+    viewport: viewport.size,
+    seedProfile: 'full-smoke',
+    route,
+    tab,
+    designSystemReferences
+  })
+}
+
+async function openDashboard (page, navBar, viewport) {
+  await page.goto('/')
+  await expectShellForViewport(page, viewport)
+  await expectPageText(page, ['Temperature', 'pH', 'ATO'])
+  await captureCurrentScreen({
+    page,
+    moduleId: 'dashboard',
+    screenName: 'landing',
+    viewport,
+    route: '/'
+  })
+}
+
+async function openConfigurationTab (page, navBar, viewport, tabId, moduleId, expectedText) {
+  await openRoute(page, navBar, viewport, 'configuration')
+  await page.locator(tabId).click()
+  await expectPageText(page, expectedText)
+  await captureCurrentScreen({
+    page,
+    moduleId,
+    screenName: 'landing',
+    viewport,
+    route: '/configuration',
+    tab: tabId.replace(/^#config-/, '')
+  })
+}
+
+async function openModule (page, navBar, viewport, moduleId, expectedText) {
+  await openRoute(page, navBar, viewport, moduleId)
+  await expectPageText(page, expectedText)
+  await captureCurrentScreen({
+    page,
+    moduleId,
+    screenName: 'landing',
+    viewport,
+    route: `/${moduleId}`
+  })
+}
+
+test.describe('seeded UI audit screenshot corpus', () => {
+  test.setTimeout(120000)
+
+  test('captures desktop screenshots for the seeded module corpus', async ({ page, baseURL }) => {
+    await page.setViewportSize(desktopViewport.size)
+    await seedForCapture(baseURL)
+
+    const navBar = new NavBar(page)
+    await openDashboard(page, navBar, desktopViewport)
+    await openConfigurationTab(page, navBar, desktopViewport, '#config-drivers', 'configuration-drivers', ['pca9685', 'ph', 'hs103'])
+    await openConfigurationTab(page, navBar, desktopViewport, '#config-connectors', 'configuration-connectors', ['O1', 'O8', 'I1', 'I3', 'J0', 'J1', 'AI1', 'AI2'])
+    await openModule(page, navBar, desktopViewport, 'equipment', ['Return', 'Light', 'Heater', 'Skimmer', 'Fan', 'ATO Pump'])
+    await openModule(page, navBar, desktopViewport, 'timers', ['Nightly Skimmer Run'])
+    await openModule(page, navBar, desktopViewport, 'lighting', ['Kessil A360'])
+    await openModule(page, navBar, desktopViewport, 'temperature', ['Biocube29 Temperature'])
+    await openModule(page, navBar, desktopViewport, 'ato', ['Biocube29 ATO'])
+    await openModule(page, navBar, desktopViewport, 'ph', ['Biocube29 pH'])
+    await openModule(page, navBar, desktopViewport, 'doser', ['Two Part - CaCO3'])
+    await openModule(page, navBar, desktopViewport, 'macro', ['Feed Start', 'Water Change'])
+  })
+
+  test('captures mobile shell and major module landing states', async ({ page, baseURL }) => {
+    await page.setViewportSize(mobileViewport.size)
+    await seedForCapture(baseURL)
+
+    const navBar = new NavBar(page)
+    await openDashboard(page, navBar, mobileViewport)
+    await openModule(page, navBar, mobileViewport, 'equipment', ['Return', 'Light', 'Heater'])
+    await openModule(page, navBar, mobileViewport, 'lighting', ['Kessil A360'])
+    await openModule(page, navBar, mobileViewport, 'temperature', ['Biocube29 Temperature'])
+    await openModule(page, navBar, mobileViewport, 'ato', ['Biocube29 ATO'])
+    await openModule(page, navBar, mobileViewport, 'ph', ['Biocube29 pH'])
+  })
+})

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "smoke": "playwright test --project=smoke-chromium",
     "pw-smoke": "playwright test --project=smoke-chromium",
     "pw-smoke:headed": "playwright test --project=smoke-chromium --headed",
+    "ui-audit": "node -e \"require('./front-end/e2e/fixtures/uiAudit').resetUiAuditArtifacts()\" && playwright test --project=ui-audit-chromium",
     "integration": "playwright test --project=integration-chromium",
     "integration:headed": "playwright test --project=integration-chromium --headed"
   },

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -39,6 +39,17 @@ module.exports = defineConfig({
       }
     },
     {
+      name: 'ui-audit-chromium',
+      dependencies: ['setup'],
+      testMatch: /specs\/ui-audit\/.*\.spec\.js/,
+      outputDir: 'test-results/ui-audit/playwright',
+      use: {
+        browserName: 'chromium',
+        storageState: 'front-end/e2e/.auth/user.json',
+        viewport: { width: 1440, height: 1000 }
+      }
+    },
+    {
       name: 'integration-chromium',
       dependencies: ['setup'],
       testMatch: /specs\/integration\/.*\.spec\.js/,


### PR DESCRIPTION
## Summary
- add seeded UI audit coverage for desktop and mobile viewports
- reuse createSmokeApi and seedFullSmokeConfiguration for deterministic state
- capture dashboard, configuration drivers/connectors, equipment, timers, lighting, temperature, ATO, pH, doser, and macro on desktop
- capture mobile shell/landing states for dashboard and major modules

Fixes #3055

## Validation
- yarn ui-audit
- ./node_modules/.bin/standard front-end/e2e/specs/ui-audit/seeded-corpus.spec.js front-end/e2e/fixtures/uiAudit.js front-end/e2e/specs/ui-audit/artifact-foundation.spec.js
- inspected test-results/ui-audit/manifest.json: 18 entries across desktop/mobile