### PR TITLE
[codex] add objective UI audit checks

### DIFF
--- a/front-end/e2e/fixtures/uiAudit.js
+++ b/front-end/e2e/fixtures/uiAudit.js
@@ -35,6 +35,124 @@ function normalizeObjectiveFindings (findings = {}) {
   return normalized
 }
 
+const captureState = new WeakMap()
+
+function startUiAuditMonitor (page, options = {}) {
+  const state = {
+    consoleErrors: [],
+    failedRequests: [],
+    allowlist: {
+      consoleErrors: ['Failed to load resource: the server responded with a status of 404'],
+      failedRequests: ['/usage', '/readings'],
+      ...(options.allowlist || {})
+    }
+  }
+
+  function onConsole (message) {
+    if (message.type() !== 'error') {
+      return
+    }
+    const text = message.text()
+    if (isAllowed(state.allowlist.consoleErrors, text)) {
+      return
+    }
+    state.consoleErrors.push({ text })
+  }
+
+  function onResponse (response) {
+    const status = response.status()
+    if (status < 400) {
+      return
+    }
+    const url = response.url()
+    if (!isAppUrl(url) || isAllowed(state.allowlist.failedRequests, url)) {
+      return
+    }
+    state.failedRequests.push({ url, status })
+  }
+
+  page.on('console', onConsole)
+  page.on('response', onResponse)
+  captureState.set(page, state)
+
+  return {
+    stop: () => {
+      page.off('console', onConsole)
+      page.off('response', onResponse)
+      captureState.delete(page)
+    }
+  }
+}
+
+function isAllowed (patterns = [], value) {
+  return patterns.some(pattern => String(value).includes(pattern))
+}
+
+function isAppUrl (url) {
+  try {
+    const parsed = new URL(url)
+    return parsed.pathname.startsWith('/api/') || parsed.origin === 'http://127.0.0.1:8080'
+  } catch (error) {
+    return false
+  }
+}
+
+async function collectDomObjectiveFindings (page) {
+  return page.evaluate(() => {
+    function visibleRect (element) {
+      const style = window.getComputedStyle(element)
+      if (style.visibility === 'hidden' || style.display === 'none' || element.disabled || element.getAttribute('aria-hidden') === 'true') {
+        return null
+      }
+      const rect = element.getBoundingClientRect()
+      if (rect.width <= 0 || rect.height <= 0 || rect.bottom < 0 || rect.right < 0 || rect.top > window.innerHeight || rect.left > window.innerWidth) {
+        return null
+      }
+      return rect
+    }
+
+    function labelFor (element) {
+      return element.getAttribute('data-testid') || element.getAttribute('aria-label') || element.id || element.textContent.trim().slice(0, 80) || element.tagName.toLowerCase()
+    }
+
+    const fatalText = document.body && document.body.innerText.includes('Something went wrong')
+      ? [{ text: 'Something went wrong' }]
+      : []
+
+    const tapTargets = Array.from(document.querySelectorAll('a, button, input, select, textarea, [role="button"], [tabindex]'))
+      .filter(element => element.tagName.toLowerCase() !== 'a' || element.getAttribute('role') === 'button' || element.classList.contains('btn'))
+      .map(element => ({ element, rect: visibleRect(element) }))
+      .filter(item => item.rect !== null)
+      .filter(item => item.rect.width < 44 && item.rect.height < 44)
+      .map(item => ({
+        target: labelFor(item.element),
+        width: Math.round(item.rect.width),
+        height: Math.round(item.rect.height)
+      }))
+
+    const overflow = Array.from(document.querySelectorAll('body *'))
+      .map(element => ({ element, rect: visibleRect(element) }))
+      .filter(item => item.rect !== null)
+      .filter(item => item.rect.right > document.documentElement.clientWidth + 8 || item.rect.left < -8)
+      .slice(0, 20)
+      .map(item => ({
+        target: labelFor(item.element),
+        left: Math.round(item.rect.left),
+        right: Math.round(item.rect.right),
+        viewportWidth: document.documentElement.clientWidth
+      }))
+
+    const missingAnchors = []
+    if (!document.querySelector('[data-testid="smoke-shell-root"]')) {
+      missingAnchors.push({ anchor: 'smoke-shell-root' })
+    }
+    if (!document.querySelector('[data-testid="smoke-nav"]') && !document.querySelector('[data-testid="smoke-current-tab"]')) {
+      missingAnchors.push({ anchor: 'smoke-nav-or-smoke-current-tab' })
+    }
+
+    return { fatalText, tapTargets, overflow, missingAnchors }
+  })
+}
 async function resetUiAuditArtifacts () {
   await fs.rm(artifactRoot, { recursive: true, force: true })
   await fs.mkdir(screenshotRoot, { recursive: true })
@@ -103,6 +221,17 @@ async function captureUiAuditScreenshot ({
     fullPage: true
   })
 
+  const domFindings = await collectDomObjectiveFindings(page)
+  const state = captureState.get(page) || { consoleErrors: [], failedRequests: [] }
+  const mergedObjectiveFindings = normalizeObjectiveFindings({
+    ...objectiveFindings,
+    fatalText: domFindings.fatalText,
+    consoleErrors: state.consoleErrors,
+    failedRequests: state.failedRequests,
+    tapTargets: domFindings.tapTargets,
+    overflow: domFindings.overflow,
+    missingAnchors: domFindings.missingAnchors
+  })
   const entry = {
     id: `${viewportSlug}-${moduleSlug}-${screenSlug}`,
     screenshotPath: relativeScreenshotPath,
@@ -117,7 +246,7 @@ async function captureUiAuditScreenshot ({
     route: route || page.url(),
     tab,
     designSystemReferences: designSystemReferences || [],
-    objectiveFindings: normalizeObjectiveFindings(objectiveFindings)
+    objectiveFindings: mergedObjectiveFindings
   }
 
   await appendManifestEntry(entry)
@@ -131,6 +260,7 @@ module.exports = {
   captureUiAuditScreenshot,
   emptyObjectiveFindings,
   normalizeObjectiveFindings,
+  startUiAuditMonitor,
   resetUiAuditArtifacts,
   stableId
 }

--- a/front-end/e2e/specs/ui-audit/artifact-foundation.spec.js
+++ b/front-end/e2e/specs/ui-audit/artifact-foundation.spec.js
@@ -1,8 +1,6 @@
 const { test, expect } = require('@playwright/test')
 const { NavBar } = require('../../pages/navBar')
-const {
-  captureUiAuditScreenshot
-} = require('../../fixtures/uiAudit')
+const { captureUiAuditScreenshot, startUiAuditMonitor } = require('../../fixtures/uiAudit')
 
 const designSystemReferences = [
   'front-end/design-system/SKILL.md',
@@ -11,19 +9,24 @@ const designSystemReferences = [
 ]
 
 test('captures the authenticated shell audit baseline', async ({ page }) => {
-  const navBar = new NavBar(page)
+  const monitor = startUiAuditMonitor(page)
+  try {
+    const navBar = new NavBar(page)
 
-  await page.goto('/')
-  await navBar.expectShell()
-  await expect(page.getByTestId('smoke-shell-root')).toBeVisible()
+    await page.goto('/')
+    await navBar.expectShell()
+    await expect(page.getByTestId('smoke-shell-root')).toBeVisible()
 
-  await captureUiAuditScreenshot({
-    page,
-    moduleId: 'shell',
-    screenName: 'authenticated-shell',
-    viewportName: 'desktop',
-    seedProfile: 'auth-only',
-    route: '/',
-    designSystemReferences
-  })
+    await captureUiAuditScreenshot({
+      page,
+      moduleId: 'shell',
+      screenName: 'authenticated-shell',
+      viewportName: 'desktop',
+      seedProfile: 'auth-only',
+      route: '/',
+      designSystemReferences
+    })
+  } finally {
+    monitor.stop()
+  }
 })

--- a/front-end/e2e/specs/ui-audit/seeded-corpus.spec.js
+++ b/front-end/e2e/specs/ui-audit/seeded-corpus.spec.js
@@ -1,7 +1,7 @@
 const { test, expect } = require('@playwright/test')
 const { createSmokeApi, seedFullSmokeConfiguration } = require('../../fixtures/apiSeed')
 const { NavBar } = require('../../pages/navBar')
-const { captureUiAuditScreenshot } = require('../../fixtures/uiAudit')
+const { captureUiAuditScreenshot, startUiAuditMonitor } = require('../../fixtures/uiAudit')
 
 const designSystemReferences = [
   'front-end/design-system/SKILL.md',
@@ -113,33 +113,43 @@ test.describe('seeded UI audit screenshot corpus', () => {
   test.setTimeout(120000)
 
   test('captures desktop screenshots for the seeded module corpus', async ({ page, baseURL }) => {
-    await page.setViewportSize(desktopViewport.size)
-    await seedForCapture(baseURL)
+    const monitor = startUiAuditMonitor(page)
+    try {
+      await page.setViewportSize(desktopViewport.size)
+      await seedForCapture(baseURL)
 
-    const navBar = new NavBar(page)
-    await openDashboard(page, navBar, desktopViewport)
-    await openConfigurationTab(page, navBar, desktopViewport, '#config-drivers', 'configuration-drivers', ['pca9685', 'ph', 'hs103'])
-    await openConfigurationTab(page, navBar, desktopViewport, '#config-connectors', 'configuration-connectors', ['O1', 'O8', 'I1', 'I3', 'J0', 'J1', 'AI1', 'AI2'])
-    await openModule(page, navBar, desktopViewport, 'equipment', ['Return', 'Light', 'Heater', 'Skimmer', 'Fan', 'ATO Pump'])
-    await openModule(page, navBar, desktopViewport, 'timers', ['Nightly Skimmer Run'])
-    await openModule(page, navBar, desktopViewport, 'lighting', ['Kessil A360'])
-    await openModule(page, navBar, desktopViewport, 'temperature', ['Biocube29 Temperature'])
-    await openModule(page, navBar, desktopViewport, 'ato', ['Biocube29 ATO'])
-    await openModule(page, navBar, desktopViewport, 'ph', ['Biocube29 pH'])
-    await openModule(page, navBar, desktopViewport, 'doser', ['Two Part - CaCO3'])
-    await openModule(page, navBar, desktopViewport, 'macro', ['Feed Start', 'Water Change'])
+      const navBar = new NavBar(page)
+      await openDashboard(page, navBar, desktopViewport)
+      await openConfigurationTab(page, navBar, desktopViewport, '#config-drivers', 'configuration-drivers', ['pca9685', 'ph', 'hs103'])
+      await openConfigurationTab(page, navBar, desktopViewport, '#config-connectors', 'configuration-connectors', ['O1', 'O8', 'I1', 'I3', 'J0', 'J1', 'AI1', 'AI2'])
+      await openModule(page, navBar, desktopViewport, 'equipment', ['Return', 'Light', 'Heater', 'Skimmer', 'Fan', 'ATO Pump'])
+      await openModule(page, navBar, desktopViewport, 'timers', ['Nightly Skimmer Run'])
+      await openModule(page, navBar, desktopViewport, 'lighting', ['Kessil A360'])
+      await openModule(page, navBar, desktopViewport, 'temperature', ['Biocube29 Temperature'])
+      await openModule(page, navBar, desktopViewport, 'ato', ['Biocube29 ATO'])
+      await openModule(page, navBar, desktopViewport, 'ph', ['Biocube29 pH'])
+      await openModule(page, navBar, desktopViewport, 'doser', ['Two Part - CaCO3'])
+      await openModule(page, navBar, desktopViewport, 'macro', ['Feed Start', 'Water Change'])
+    } finally {
+      monitor.stop()
+    }
   })
 
   test('captures mobile shell and major module landing states', async ({ page, baseURL }) => {
-    await page.setViewportSize(mobileViewport.size)
-    await seedForCapture(baseURL)
+    const monitor = startUiAuditMonitor(page)
+    try {
+      await page.setViewportSize(mobileViewport.size)
+      await seedForCapture(baseURL)
 
-    const navBar = new NavBar(page)
-    await openDashboard(page, navBar, mobileViewport)
-    await openModule(page, navBar, mobileViewport, 'equipment', ['Return', 'Light', 'Heater'])
-    await openModule(page, navBar, mobileViewport, 'lighting', ['Kessil A360'])
-    await openModule(page, navBar, mobileViewport, 'temperature', ['Biocube29 Temperature'])
-    await openModule(page, navBar, mobileViewport, 'ato', ['Biocube29 ATO'])
-    await openModule(page, navBar, mobileViewport, 'ph', ['Biocube29 pH'])
+      const navBar = new NavBar(page)
+      await openDashboard(page, navBar, mobileViewport)
+      await openModule(page, navBar, mobileViewport, 'equipment', ['Return', 'Light', 'Heater'])
+      await openModule(page, navBar, mobileViewport, 'lighting', ['Kessil A360'])
+      await openModule(page, navBar, mobileViewport, 'temperature', ['Biocube29 Temperature'])
+      await openModule(page, navBar, mobileViewport, 'ato', ['Biocube29 ATO'])
+      await openModule(page, navBar, mobileViewport, 'ph', ['Biocube29 pH'])
+    } finally {
+      monitor.stop()
+    }
   })
 })

--- a/front-end/scripts/ui-audit-report.mjs
+++ b/front-end/scripts/ui-audit-report.mjs
@@ -1,0 +1,85 @@
+import fs from 'fs/promises'
+import path from 'path'
+
+const artifactRoot = path.join(process.cwd(), 'test-results', 'ui-audit')
+const manifestPath = path.join(artifactRoot, 'manifest.json')
+const fatalFindingKeys = [
+  'requiredScreenshots',
+  'fatalText',
+  'consoleErrors',
+  'failedRequests',
+  'tapTargets',
+  'overflow',
+  'missingAnchors'
+]
+
+async function readManifest () {
+  const raw = await fs.readFile(manifestPath, 'utf8')
+  return JSON.parse(raw)
+}
+
+async function fileExists (file) {
+  try {
+    const stat = await fs.stat(file)
+    return stat.isFile() && stat.size > 0
+  } catch (error) {
+    return false
+  }
+}
+
+function findingCount (entry, key) {
+  const findings = entry.objectiveFindings || {}
+  return Array.isArray(findings[key]) ? findings[key].length : 0
+}
+
+async function collectViolations (manifest) {
+  const violations = []
+  const entries = Array.isArray(manifest.entries) ? manifest.entries : []
+  if (entries.length === 0) {
+    violations.push({ severity: 'error', type: 'manifest-empty', message: 'manifest has no screenshot entries' })
+  }
+
+  for (const entry of entries) {
+    const screenshotPath = path.join(process.cwd(), entry.screenshotPath || '')
+    if (!entry.screenshotPath || !await fileExists(screenshotPath)) {
+      violations.push({ severity: 'error', type: 'requiredScreenshots', id: entry.id, message: 'required screenshot is missing or unreadable' })
+    }
+
+    for (const key of fatalFindingKeys) {
+      const count = findingCount(entry, key)
+      if (count > 0) {
+        violations.push({ severity: 'error', type: key, id: entry.id, count })
+      }
+    }
+  }
+  return violations
+}
+
+async function main () {
+  const manifest = await readManifest()
+  const violations = await collectViolations(manifest)
+  const report = {
+    generatedAt: new Date().toISOString(),
+    entries: Array.isArray(manifest.entries) ? manifest.entries.length : 0,
+    violations
+  }
+
+  await fs.mkdir(artifactRoot, { recursive: true })
+  await fs.writeFile(path.join(artifactRoot, 'objective-report.json'), JSON.stringify(report, null, 2) + '\n')
+
+  if (violations.length > 0) {
+    console.error('UI audit found ' + violations.length + ' objective violation(s).')
+    for (const violation of violations) {
+      console.error('- ' + violation.type + (violation.id ? ' in ' + violation.id : ''))
+    }
+    process.exitCode = 1
+    return
+  }
+
+  console.log('UI audit objective report passed (' + report.entries + ' entries).')
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/package.json
+++ b/package.json
@@ -86,9 +86,10 @@
     "smoke": "playwright test --project=smoke-chromium",
     "pw-smoke": "playwright test --project=smoke-chromium",
     "pw-smoke:headed": "playwright test --project=smoke-chromium --headed",
-    "ui-audit": "node -e \"require('./front-end/e2e/fixtures/uiAudit').resetUiAuditArtifacts()\" && playwright test --project=ui-audit-chromium",
+    "ui-audit": "node -e \"require('./front-end/e2e/fixtures/uiAudit').resetUiAuditArtifacts()\" && playwright test --project=ui-audit-chromium && node front-end/scripts/ui-audit-report.mjs",
     "integration": "playwright test --project=integration-chromium",
-    "integration:headed": "playwright test --project=integration-chromium --headed"
+    "integration:headed": "playwright test --project=integration-chromium --headed",
+    "ui-audit-report": "node front-end/scripts/ui-audit-report.mjs"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- add UI audit runtime monitors for console errors and failed app requests
- collect high-confidence DOM objective findings for fatal text, touch targets, overflow, and smoke anchors
- add a ui-audit report gate that validates screenshots and writes objective-report.json

Fixes #3056

## Validation
- yarn ui-audit
- yarn ui-audit-report
- yarn pw-smoke --list
- standard front-end/e2e/fixtures/uiAudit.js front-end/e2e/specs/ui-audit/artifact-foundation.spec.js front-end/e2e/specs/ui-audit/seeded-corpus.spec.js front-end/scripts/ui-audit-report.mjs