### PR TITLE
[codex] Add new shell connectors overhaul

### DIFF
--- a/front-end/assets/sass/style.scss
+++ b/front-end/assets/sass/style.scss
@@ -320,3 +320,212 @@ textarea:focus,
     margin-bottom: 70px;
   }
 }
+
+.connectors-shell {
+  display: flex;
+  flex-direction: column;
+  gap: var(--reefpi-space-md);
+}
+
+.connectors-filter-row {
+  position: sticky;
+  top: 0;
+  z-index: 1010;
+  min-height: 3.5rem;
+  display: grid;
+  grid-template-columns: minmax(12rem, 1fr) auto auto minmax(10rem, 12rem) auto auto;
+  gap: var(--reefpi-space-sm);
+  align-items: center;
+  padding: var(--reefpi-space-sm);
+  background: var(--reefpi-color-surface);
+  border: 1px solid var(--reefpi-color-border);
+  border-radius: var(--reefpi-radius-md);
+}
+
+.connectors-toggle {
+  min-height: var(--reefpi-tap-target-min);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--reefpi-space-xs);
+  margin: 0;
+  white-space: nowrap;
+}
+
+.connector-groups {
+  display: grid;
+  gap: var(--reefpi-space-md);
+}
+
+.connector-group {
+  border: 1px solid var(--reefpi-color-border);
+  border-radius: var(--reefpi-radius-md);
+  background: var(--reefpi-color-surface-elevated);
+  overflow: hidden;
+}
+
+.connector-group-header {
+  width: 100%;
+  min-height: var(--reefpi-tap-target-min);
+  display: grid;
+  grid-template-columns: minmax(8rem, 1fr) auto auto auto auto;
+  gap: var(--reefpi-space-sm);
+  align-items: center;
+  padding: var(--reefpi-space-sm) var(--reefpi-space-md);
+  border: 0;
+  background: transparent;
+  color: var(--reefpi-color-text);
+  text-align: left;
+}
+
+.connector-group-title {
+  font-weight: var(--reefpi-weight-bold);
+  font-size: 1.125rem;
+  overflow-wrap: anywhere;
+}
+
+.connector-count-pill,
+.connector-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.75rem;
+  padding: 0 var(--reefpi-space-sm);
+  border-radius: var(--reefpi-radius-sm);
+  background: var(--reefpi-color-surface);
+  border: 1px solid var(--reefpi-color-border);
+  color: var(--reefpi-color-text-muted);
+  font-size: var(--reefpi-small);
+  white-space: nowrap;
+}
+
+.connector-badge.available {
+  color: var(--reefpi-color-success-strong);
+}
+
+.connector-badge.warning {
+  color: var(--reefpi-color-warn);
+  background: var(--reefpi-color-warn-bg);
+}
+
+.connector-group-add,
+.connector-group-caret {
+  color: var(--reefpi-color-brand);
+  font-weight: var(--reefpi-weight-bold);
+  white-space: nowrap;
+}
+
+.connector-channel-list {
+  display: grid;
+  gap: 1px;
+  background: var(--reefpi-color-border);
+}
+
+.connector-list-row {
+  min-height: var(--reefpi-tap-target-min);
+  display: grid;
+  grid-template-columns: auto minmax(8rem, 1fr) auto auto;
+  gap: var(--reefpi-space-sm);
+  align-items: center;
+  padding: var(--reefpi-space-sm) var(--reefpi-space-md);
+  border: 0;
+  background: var(--reefpi-color-surface-elevated);
+  color: var(--reefpi-color-text);
+  text-align: left;
+}
+
+.connector-list-main {
+  min-width: 0;
+  display: grid;
+}
+
+.connector-list-main small {
+  color: var(--reefpi-color-text-muted);
+}
+
+.connector-channel-grid {
+  display: grid;
+  grid-template-columns: repeat(16, minmax(2.75rem, 1fr));
+  gap: var(--reefpi-space-xs);
+  padding: var(--reefpi-space-sm);
+}
+
+.connector-channel-cell {
+  min-height: var(--reefpi-tap-target-min);
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  gap: 0.125rem;
+  padding: var(--reefpi-space-xs);
+  border: 1px solid var(--reefpi-color-border);
+  border-radius: var(--reefpi-radius-sm);
+  background: var(--reefpi-color-surface);
+  color: var(--reefpi-color-text);
+}
+
+.connector-channel-cell.selected,
+.connector-list-row.selected {
+  border-color: var(--reefpi-color-brand);
+  box-shadow: inset 0 0 0 1px var(--reefpi-color-brand);
+}
+
+.connector-conflict {
+  border-color: var(--reefpi-color-warn);
+}
+
+.connector-status-dot {
+  width: 0.625rem;
+  height: 0.625rem;
+  border-radius: 50%;
+  background: var(--reefpi-color-success-strong);
+}
+
+.connector-conflict .connector-status-dot {
+  background: var(--reefpi-color-warn);
+}
+
+.connector-cell-pin {
+  font-weight: var(--reefpi-weight-bold);
+}
+
+.connector-cell-kind {
+  max-width: 100%;
+  color: var(--reefpi-color-text-muted);
+  font-size: 0.68rem;
+  text-align: center;
+  overflow-wrap: anywhere;
+}
+
+.connector-empty-state {
+  min-height: var(--reefpi-tap-target-min);
+  display: flex;
+  align-items: center;
+  padding: var(--reefpi-space-md);
+  border: 1px solid var(--reefpi-color-border);
+  border-radius: var(--reefpi-radius-md);
+  color: var(--reefpi-color-text-muted);
+}
+
+@media screen and (max-width: 1023.98px) {
+  .connector-channel-grid {
+    grid-template-columns: repeat(8, minmax(2.75rem, 1fr));
+  }
+}
+
+@media screen and (max-width: 767.98px) {
+  .connectors-filter-row {
+    grid-template-columns: 1fr;
+  }
+
+  .connector-group-header,
+  .connector-list-row {
+    grid-template-columns: 1fr auto;
+  }
+
+  .connector-channel-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .connector-channel-cell {
+    grid-template-columns: auto auto 1fr;
+    justify-items: start;
+  }
+}

--- a/front-end/src/connectors/connectors.test.js
+++ b/front-end/src/connectors/connectors.test.js
@@ -70,10 +70,121 @@ describe('Connectors', () => {
   })
 
   it('<Main /> maps state and fetch dispatch props', () => {
-    expect(mapStateToProps({ drivers: stockDrivers })).toEqual({ drivers: stockDrivers })
+    expect(mapStateToProps({
+      drivers: stockDrivers,
+      outlets: [],
+      inlets: [],
+      jacks: [],
+      analog_inputs: []
+    })).toEqual({
+      drivers: stockDrivers,
+      outlets: [],
+      inlets: [],
+      jacks: [],
+      analog_inputs: []
+    })
     const dispatch = jest.fn(action => action)
     mapDispatchToProps(dispatch).fetchDrivers()
     expect(dispatch).toHaveBeenCalledTimes(1)
+  })
+
+  it('<Main /> renders new shell connector groups behind the feature flag', () => {
+    window.FEATURE_FLAGS = { new_shell: true }
+    const component = new RawConnectors({
+      drivers: stockDrivers,
+      outlets: [
+        { id: 'out-1', name: 'Return Pump', pin: 0, driver: '1', equipment: 'eq-1' },
+        { id: 'out-2', name: 'Skimmer', pin: 1, driver: '1' }
+      ],
+      jacks: [{ id: 'jack-1', name: 'Moon', pins: [2], driver: '1' }],
+      inlets: [{ id: 'in-1', name: 'Float', pin: 1, driver: 'rpi' }],
+      analog_inputs: [
+        { id: 'ai-1', name: 'pH', pin: 0, driver: 'rpi' },
+        { id: 'ai-2', name: 'ORP', pin: 0, driver: 'rpi' }
+      ],
+      fetchDrivers: jest.fn(),
+      fetchOutlets: jest.fn(),
+      fetchInlets: jest.fn(),
+      fetchJacks: jest.fn(),
+      fetchAnalogInputs: jest.fn(),
+      deleteOutlet: jest.fn(),
+      deleteInlet: jest.fn(),
+      deleteJack: jest.fn(),
+      deleteAnalogInput: jest.fn(),
+      updateOutlet: jest.fn(),
+      updateInlet: jest.fn(),
+      updateJack: jest.fn(),
+      updateAnalogInput: jest.fn()
+    })
+    patchSetState(component)
+    const html = renderToStaticMarkup(component.render())
+
+    expect(html).toContain('connectors-shell')
+    expect(html).toContain('Rasoverry Pi')
+    expect(html).toContain('PCA9685')
+    expect(html).toContain('3 / 9 used')
+    expect(html).toContain('connector-channel-grid')
+    expect((html.match(/connector-channel-cell/g) || []).length).toBe(9)
+    expect(html).toContain('connector-conflict')
+    window.FEATURE_FLAGS = {}
+  })
+
+  it('<Main /> filters, persists group state, and batch deletes selected channels', async () => {
+    window.FEATURE_FLAGS = { new_shell: true }
+    const setItem = jest.fn()
+    const getItem = jest.fn(() => 'false')
+    Object.defineProperty(window, 'localStorage', {
+      value: { getItem, setItem },
+      configurable: true
+    })
+    const deleteOutlet = jest.fn()
+    const deleteJack = jest.fn()
+    const updateOutlet = jest.fn()
+    const updateJack = jest.fn()
+    const component = new RawConnectors({
+      drivers: stockDrivers,
+      outlets: [{ id: 'out-1', name: 'Return Pump', pin: 0, driver: '1', equipment: 'eq-1' }],
+      jacks: [{ id: 'jack-1', name: 'Moon', pins: [2], driver: '1' }],
+      inlets: [],
+      analog_inputs: [],
+      fetchDrivers: jest.fn(),
+      fetchOutlets: jest.fn(),
+      fetchInlets: jest.fn(),
+      fetchJacks: jest.fn(),
+      fetchAnalogInputs: jest.fn(),
+      deleteOutlet,
+      deleteInlet: jest.fn(),
+      deleteJack,
+      deleteAnalogInput: jest.fn(),
+      updateOutlet,
+      updateInlet: jest.fn(),
+      updateJack,
+      updateAnalogInput: jest.fn()
+    })
+    patchSetState(component)
+
+    expect(component.state.openGroups.PCA9685).toBe(false)
+    component.toggleGroup('PCA9685')
+    expect(setItem).toHaveBeenCalledWith('reefpi.connectors.PCA9685.open', 'true')
+
+    component.handleFilterChange({ target: { value: 'moon' } })
+    expect(renderToStaticMarkup(component.render())).toContain('Moon')
+    expect(renderToStaticMarkup(component.render())).not.toContain('Return Pump')
+
+    component.toggleSelection({ id: 'out-1', kind: 'outlet', name: 'Return Pump', pin: 0, driver: '1', equipment: 'eq-1' })
+    component.toggleSelection({ id: 'jack-1', kind: 'jack', name: 'Moon', pins: [2], driver: '1' })
+    component.handleBatchDriverChange({ target: { value: 'rpi' } })
+    component.handleBatchMove()
+    expect(updateOutlet).toHaveBeenCalledWith('out-1', { name: 'Return Pump', driver: 'rpi', pin: 0, equipment: 'eq-1' })
+    expect(updateJack).toHaveBeenCalledWith('jack-1', { name: 'Moon', driver: 'rpi', pins: [2] })
+
+    component.toggleSelection({ id: 'out-1', kind: 'outlet', name: 'Return Pump' })
+    component.toggleSelection({ id: 'jack-1', kind: 'jack', name: 'Moon' })
+    component.handleBatchDelete()
+    await Promise.resolve()
+    expect(deleteOutlet).toHaveBeenCalledWith('out-1')
+    expect(deleteJack).toHaveBeenCalledWith('jack-1')
+    window.FEATURE_FLAGS = {}
   })
 
   it('<InletSelector />', () => {

--- a/front-end/src/connectors/connectors.test.js
+++ b/front-end/src/connectors/connectors.test.js
@@ -96,7 +96,12 @@ describe('Connectors', () => {
         { id: 'out-1', name: 'Return Pump', pin: 0, driver: '1', equipment: 'eq-1' },
         { id: 'out-2', name: 'Skimmer', pin: 1, driver: '1' }
       ],
-      jacks: [{ id: 'jack-1', name: 'Moon', pins: [2], driver: '1' }],
+      jacks: [
+        { id: 'jack-auto-0', name: 'PCA9685-0', pins: [0], driver: '1' },
+        { id: 'jack-0', name: 'J0', pins: [0], driver: '1' },
+        { id: 'jack-1', name: 'J1', pins: [0, 1], driver: '1' },
+        { id: 'jack-2', name: 'Moon', pins: [2], driver: '1' }
+      ],
       inlets: [{ id: 'in-1', name: 'Float', pin: 1, driver: 'rpi' }],
       analog_inputs: [
         { id: 'ai-1', name: 'pH', pin: 0, driver: 'rpi' },
@@ -122,8 +127,11 @@ describe('Connectors', () => {
     expect(html).toContain('connectors-shell')
     expect(html).toContain('Rasoverry Pi')
     expect(html).toContain('PCA9685')
-    expect(html).toContain('3 / 9 used')
+    expect(html).toContain('6 / 9 used')
     expect(html).toContain('connector-channel-grid')
+    expect(html).toContain('Moon')
+    expect(html).toContain('J0')
+    expect(html).toContain('J1')
     expect((html.match(/connector-channel-cell/g) || []).length).toBe(9)
     expect(html).toContain('connector-conflict')
     window.FEATURE_FLAGS = {}

--- a/front-end/src/connectors/main.jsx
+++ b/front-end/src/connectors/main.jsx
@@ -4,20 +4,382 @@ import Jacks from './jacks'
 import AnalogInputs from './analog_inputs'
 import Inlets from './inlets'
 import i18n from 'utils/i18n'
+import { confirm } from 'utils/confirm'
 import { connect } from 'react-redux'
 import { fetchDrivers } from 'redux/actions/drivers'
+import { fetchOutlets, deleteOutlet, updateOutlet } from 'redux/actions/outlets'
+import { fetchInlets, deleteInlet, updateInlet } from 'redux/actions/inlets'
+import { fetchJacks, deleteJack, updateJack } from 'redux/actions/jacks'
+import { fetchAnalogInputs, deleteAnalogInput, updateAnalogInput } from 'redux/actions/analog_inputs'
+
+const CONNECTOR_KINDS = {
+  inlet: { label: 'Inlet', deleteProp: 'deleteInlet', updateProp: 'updateInlet' },
+  outlet: { label: 'Outlet', deleteProp: 'deleteOutlet', updateProp: 'updateOutlet' },
+  analog: { label: 'Analog input', deleteProp: 'deleteAnalogInput', updateProp: 'updateAnalogInput' },
+  jack: { label: 'Jack', deleteProp: 'deleteJack', updateProp: 'updateJack' }
+}
+
+const getLocalStorage = () => {
+  if (typeof window === 'undefined' || !window.localStorage) return undefined
+  return window.localStorage
+}
+
+const readGroupOpenState = driverName => {
+  const storage = getLocalStorage()
+  if (!storage) return true
+  const value = storage.getItem('reefpi.connectors.' + driverName + '.open')
+  return value === null ? true : value === 'true'
+}
+
+const driverDisplayName = (driverMap, driverId) => {
+  return (driverMap[driverId] || {}).name || driverId || 'Unassigned'
+}
+
+const pinCountForDriver = driver => {
+  if (!driver || !driver.pinmap) return 0
+  return Object.keys(driver.pinmap).reduce((total, kind) => total + (driver.pinmap[kind] || []).length, 0)
+}
+
+const pinmapKindToConnectorKind = kind => {
+  if (kind === 'digital-output') return 'outlet'
+  if (kind === 'digital-input') return 'inlet'
+  if (kind === 'analog-input') return 'analog'
+  if (kind === 'pwm') return 'jack'
+  return kind
+}
+
+const gridChannelsForGroup = group => {
+  if (!group.driver || !group.driver.pinmap) return group.channels
+  const byKindAndPin = {}
+  group.channels.forEach(channel => {
+    channel.pins.forEach(pin => {
+      byKindAndPin[channel.kind + ':' + pin] = channel
+    })
+  })
+  const displayChannels = []
+  Object.keys(group.driver.pinmap).sort().forEach(pinmapKind => {
+    const kind = pinmapKindToConnectorKind(pinmapKind)
+    ;(group.driver.pinmap[pinmapKind] || []).forEach(pin => {
+      displayChannels.push(byKindAndPin[kind + ':' + pin] || {
+        id: group.driver.id + ':' + kind + ':' + pin,
+        name: 'Available',
+        kind,
+        driver: group.driver.id,
+        pins: [pin],
+        placeholder: true
+      })
+    })
+  })
+  return displayChannels
+}
+
+const buildChannels = props => {
+  const channels = []
+  ;(props.inlets || []).forEach(conn => channels.push({ ...conn, kind: 'inlet', pins: [conn.pin] }))
+  ;(props.outlets || []).forEach(conn => channels.push({ ...conn, kind: 'outlet', pins: [conn.pin] }))
+  ;(props.analog_inputs || []).forEach(conn => channels.push({ ...conn, kind: 'analog', pins: [conn.pin] }))
+  ;(props.jacks || []).forEach(conn => channels.push({ ...conn, kind: 'jack', pins: conn.pins || [] }))
+  return channels
+}
+
+const markConflicts = channels => {
+  const pinMap = {}
+  channels.forEach(channel => {
+    channel.pins.forEach(pin => {
+      const key = channel.driver + ':' + pin
+      if (!pinMap[key]) pinMap[key] = []
+      pinMap[key].push(channel.id)
+    })
+  })
+  return channels.map(channel => {
+    const conflict = channel.pins.some(pin => (pinMap[channel.driver + ':' + pin] || []).length > 1)
+    return { ...channel, conflict }
+  })
+}
+
+const selectedKey = channel => channel.kind + ':' + channel.id
+
+const batchMovePayload = (channel, driver) => {
+  const payload = {
+    name: channel.name,
+    driver
+  }
+  if (channel.reverse !== undefined) payload.reverse = channel.reverse
+  if (channel.kind === 'jack') payload.pins = channel.pins || []
+  else payload.pin = channel.pin
+  if (channel.equipment) payload.equipment = channel.equipment
+  return payload
+}
 
 class connectors extends React.Component {
-  render () {
-    if (this.props.drivers === undefined ||
-          this.props.drivers.length === 0) {
-      return (
-        <div className='container'>
-          {i18n.t('loading')}
-        </div>
-      )
+  constructor (props) {
+    super(props)
+    const openGroups = {}
+    ;(props.drivers || []).forEach(driver => {
+      openGroups[driver.name || driver.id] = readGroupOpenState(driver.name || driver.id)
+    })
+    this.state = {
+      filter: '',
+      inUseOnly: false,
+      conflictsOnly: false,
+      selected: {},
+      batchDriver: '',
+      openGroups
     }
+    this.handleFilterChange = this.handleFilterChange.bind(this)
+    this.handleInUseOnlyToggle = this.handleInUseOnlyToggle.bind(this)
+    this.handleConflictsOnlyToggle = this.handleConflictsOnlyToggle.bind(this)
+    this.toggleGroup = this.toggleGroup.bind(this)
+    this.toggleSelection = this.toggleSelection.bind(this)
+    this.handleBatchDelete = this.handleBatchDelete.bind(this)
+    this.handleBatchDriverChange = this.handleBatchDriverChange.bind(this)
+    this.handleBatchMove = this.handleBatchMove.bind(this)
+  }
 
+  componentDidMount () {
+    if (this.props.fetchDrivers) this.props.fetchDrivers()
+    if (this.props.fetchOutlets) this.props.fetchOutlets()
+    if (this.props.fetchInlets) this.props.fetchInlets()
+    if (this.props.fetchJacks) this.props.fetchJacks()
+    if (this.props.fetchAnalogInputs) this.props.fetchAnalogInputs()
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.drivers === this.props.drivers) return
+    const nextOpenGroups = { ...this.state.openGroups }
+    ;(this.props.drivers || []).forEach(driver => {
+      const driverName = driver.name || driver.id
+      if (nextOpenGroups[driverName] === undefined) nextOpenGroups[driverName] = readGroupOpenState(driverName)
+    })
+    this.setState({ openGroups: nextOpenGroups })
+  }
+
+  handleFilterChange (e) {
+    this.setState({ filter: e.target.value })
+  }
+
+  handleInUseOnlyToggle () {
+    this.setState({ inUseOnly: !this.state.inUseOnly })
+  }
+
+  handleConflictsOnlyToggle () {
+    this.setState({ conflictsOnly: !this.state.conflictsOnly })
+  }
+
+  handleBatchDriverChange (e) {
+    this.setState({ batchDriver: e.target.value })
+  }
+
+  toggleGroup (driverName) {
+    const open = !this.state.openGroups[driverName]
+    const storage = getLocalStorage()
+    if (storage) storage.setItem('reefpi.connectors.' + driverName + '.open', String(open))
+    this.setState({
+      openGroups: {
+        ...this.state.openGroups,
+        [driverName]: open
+      }
+    })
+  }
+
+  toggleSelection (channel) {
+    const key = selectedKey(channel)
+    const selected = { ...this.state.selected }
+    if (selected[key]) delete selected[key]
+    else selected[key] = channel
+    this.setState({ selected })
+  }
+
+  selectedChannels () {
+    return Object.keys(this.state.selected).map(key => this.state.selected[key])
+  }
+
+  handleBatchDelete () {
+    const selected = this.selectedChannels()
+    if (selected.length === 0) return
+    const names = selected.map(channel => channel.name).join(', ')
+    const message = <div><p>Delete {selected.length} connectors: {names}</p></div>
+    confirm('Delete selected connectors?', { description: message }).then(() => {
+      selected.forEach(channel => {
+        const deleteProp = CONNECTOR_KINDS[channel.kind].deleteProp
+        this.props[deleteProp](channel.id)
+      })
+      this.setState({ selected: {} })
+    })
+  }
+
+  handleBatchMove () {
+    const selected = this.selectedChannels()
+    if (selected.length === 0 || !this.state.batchDriver) return
+    selected.forEach(channel => {
+      const updateProp = CONNECTOR_KINDS[channel.kind].updateProp
+      this.props[updateProp](channel.id, batchMovePayload(channel, this.state.batchDriver))
+    })
+    this.setState({ selected: {} })
+  }
+
+  groups () {
+    const driverMap = {}
+    ;(this.props.drivers || []).forEach(driver => { driverMap[driver.id] = driver })
+    const filter = this.state.filter.trim().toLowerCase()
+    const channels = markConflicts(buildChannels(this.props))
+      .filter(channel => {
+        const haystack = [
+          channel.name,
+          channel.driver,
+          driverDisplayName(driverMap, channel.driver),
+          String(channel.pin),
+          (channel.pins || []).join(',')
+        ].join(' ').toLowerCase()
+        if (filter && !haystack.includes(filter)) return false
+        if (this.state.inUseOnly && !channel.equipment) return false
+        if (this.state.conflictsOnly && !channel.conflict) return false
+        return true
+      })
+
+    const grouped = {}
+    channels.forEach(channel => {
+      const driverName = driverDisplayName(driverMap, channel.driver)
+      if (!grouped[driverName]) {
+        grouped[driverName] = {
+          driverName,
+          driver: driverMap[channel.driver] || { id: channel.driver, name: driverName },
+          channels: []
+        }
+      }
+      grouped[driverName].channels.push(channel)
+    })
+
+    return Object.keys(grouped).sort().map(driverName => grouped[driverName])
+  }
+
+  renderFilterRow () {
+    const selected = this.selectedChannels()
+    const selectedCount = selected.length
+    const batchDrivers = this.props.drivers || []
+    return (
+      <div className='connectors-filter-row'>
+        <input
+          type='search'
+          className='form-control connectors-search'
+          placeholder='Search name, pin, or driver'
+          value={this.state.filter}
+          onChange={this.handleFilterChange}
+          aria-label='Search connectors'
+        />
+        <label className='connectors-toggle'>
+          <input type='checkbox' checked={this.state.inUseOnly} onChange={this.handleInUseOnlyToggle} />
+          <span>In use</span>
+        </label>
+        <label className='connectors-toggle'>
+          <input type='checkbox' checked={this.state.conflictsOnly} onChange={this.handleConflictsOnlyToggle} />
+          <span>Conflicts</span>
+        </label>
+        <select
+          className='custom-select connectors-batch-driver'
+          disabled={selectedCount === 0}
+          value={this.state.batchDriver}
+          onChange={this.handleBatchDriverChange}
+          aria-label='Move selected to driver'
+        >
+          <option value=''>Move to driver</option>
+          {batchDrivers.map(driver => <option key={driver.id} value={driver.id}>{driver.name}</option>)}
+        </select>
+        <button type='button' className='btn btn-outline-primary' disabled={selectedCount === 0 || !this.state.batchDriver} onClick={this.handleBatchMove}>Move</button>
+        <button type='button' className='btn btn-outline-danger' disabled={selectedCount === 0} onClick={this.handleBatchDelete}>Delete {selectedCount || ''}</button>
+      </div>
+    )
+  }
+
+  renderChannelList (channels) {
+    return (
+      <div className='connector-channel-list'>
+        {channels.map(channel => {
+          const selected = !!this.state.selected[selectedKey(channel)]
+          return (
+            <button
+              type='button'
+              key={selectedKey(channel)}
+              className={'connector-list-row' + (selected ? ' selected' : '') + (channel.conflict ? ' connector-conflict' : '')}
+              onClick={() => this.toggleSelection(channel)}
+            >
+              <span className='connector-status-dot' />
+              <span className='connector-list-main'>
+                <strong>{channel.name}</strong>
+                <small>{CONNECTOR_KINDS[channel.kind].label} - pin {(channel.pins || []).join(', ')}</small>
+              </span>
+              {channel.equipment ? <span className='connector-badge'>in use</span> : <span className='connector-badge available'>available</span>}
+              {channel.conflict ? <span className='connector-badge warning'>conflict</span> : null}
+            </button>
+          )
+        })}
+      </div>
+    )
+  }
+
+  renderChannelGrid (channels) {
+    return (
+      <div className='connector-channel-grid'>
+        {channels.map(channel => {
+          const selected = !!this.state.selected[selectedKey(channel)]
+          return (
+            <button
+              type='button'
+              key={selectedKey(channel)}
+              className={'connector-channel-cell' + (selected ? ' selected' : '') + (channel.conflict ? ' connector-conflict' : '') + (channel.placeholder ? ' available' : '')}
+              onClick={channel.placeholder ? undefined : () => this.toggleSelection(channel)}
+              title={channel.name}
+            >
+              <span className='connector-cell-pin'>{(channel.pins || []).join(', ')}</span>
+              <span className='connector-status-dot' />
+              <span className='connector-cell-kind'>{CONNECTOR_KINDS[channel.kind].label}</span>
+            </button>
+          )
+        })}
+      </div>
+    )
+  }
+
+  renderGroup (group) {
+    const open = this.state.openGroups[group.driverName] !== false
+    const used = group.channels.length
+    const total = Math.max(pinCountForDriver(group.driver), group.channels.length)
+    const driverName = String(group.driverName || group.driver.id || '').toLowerCase()
+    const highCount = total > 8 && driverName.includes('pca9685')
+    const hasConflict = group.channels.some(channel => channel.conflict)
+    return (
+      <section className='connector-group' key={group.driverName}>
+        <button type='button' className='connector-group-header' onClick={() => this.toggleGroup(group.driverName)}>
+          <span className='connector-group-title'>{group.driverName}</span>
+          <span className='connector-count-pill'>{used} / {total} used</span>
+          {hasConflict ? <span className='connector-badge warning'>conflicts</span> : null}
+          <span className='connector-group-add'>+ Add</span>
+          <span className='connector-group-caret'>{open ? '-' : '+'}</span>
+        </button>
+        {open
+          ? highCount
+            ? this.renderChannelGrid(gridChannelsForGroup(group))
+            : this.renderChannelList(group.channels)
+          : null}
+      </section>
+    )
+  }
+
+  renderNewShell () {
+    const groups = this.groups()
+    return (
+      <div className='container connectors-shell'>
+        {this.renderFilterRow()}
+        <div className='connector-groups'>
+          {groups.length > 0
+            ? groups.map(group => this.renderGroup(group))
+            : <div className='connector-empty-state'>No connectors match the current filters.</div>}
+        </div>
+      </div>
+    )
+  }
+
+  renderLegacy () {
     return (
       <div className='container'>
         <div className='row inlets'>
@@ -39,17 +401,50 @@ class connectors extends React.Component {
       </div>
     )
   }
+
+  render () {
+    if (this.props.drivers === undefined ||
+          this.props.drivers.length === 0) {
+      return (
+        <div className='container'>
+          {i18n.t('loading')}
+        </div>
+      )
+    }
+
+    if (typeof window !== 'undefined' && window.FEATURE_FLAGS && window.FEATURE_FLAGS.new_shell) {
+      return this.renderNewShell()
+    }
+
+    return this.renderLegacy()
+  }
 }
 
 export const mapStateToProps = state => {
   return {
-    drivers: state.drivers
+    drivers: state.drivers,
+    outlets: state.outlets,
+    inlets: state.inlets,
+    jacks: state.jacks,
+    analog_inputs: state.analog_inputs
   }
 }
 
 export const mapDispatchToProps = dispatch => {
   return {
-    fetchDrivers: () => dispatch(fetchDrivers())
+    fetchDrivers: () => dispatch(fetchDrivers()),
+    fetchOutlets: () => dispatch(fetchOutlets()),
+    fetchInlets: () => dispatch(fetchInlets()),
+    fetchJacks: () => dispatch(fetchJacks()),
+    fetchAnalogInputs: () => dispatch(fetchAnalogInputs()),
+    deleteOutlet: id => dispatch(deleteOutlet(id)),
+    deleteInlet: id => dispatch(deleteInlet(id)),
+    deleteJack: id => dispatch(deleteJack(id)),
+    deleteAnalogInput: id => dispatch(deleteAnalogInput(id)),
+    updateOutlet: (id, outlet) => dispatch(updateOutlet(id, outlet)),
+    updateInlet: (id, inlet) => dispatch(updateInlet(id, inlet)),
+    updateJack: (id, jack) => dispatch(updateJack(id, jack)),
+    updateAnalogInput: (id, analogInput) => dispatch(updateAnalogInput(id, analogInput))
   }
 }
 

--- a/front-end/src/connectors/main.jsx
+++ b/front-end/src/connectors/main.jsx
@@ -51,9 +51,19 @@ const pinmapKindToConnectorKind = kind => {
 const gridChannelsForGroup = group => {
   if (!group.driver || !group.driver.pinmap) return group.channels
   const byKindAndPin = {}
+  const driverName = group.driver.name || group.driver.id
+  const autoProvisionedName = pin => driverName + '-' + pin
+  const channelScore = (channel, pin) => {
+    const explicitName = channel.name !== autoProvisionedName(pin)
+    const singlePin = (channel.pins || []).length === 1
+    return (explicitName ? 4 : 0) + (singlePin ? 2 : 0)
+  }
   group.channels.forEach(channel => {
     channel.pins.forEach(pin => {
-      byKindAndPin[channel.kind + ':' + pin] = channel
+      const key = channel.kind + ':' + pin
+      if (!byKindAndPin[key] || channelScore(channel, pin) > channelScore(byKindAndPin[key], pin)) {
+        byKindAndPin[key] = channel
+      }
     })
   })
   const displayChannels = []
@@ -98,6 +108,13 @@ const markConflicts = channels => {
 }
 
 const selectedKey = channel => channel.kind + ':' + channel.id
+
+const channelDisplayName = channel => {
+  if (!channel.placeholder) return channel.name
+  const pin = (channel.pins || [])[0]
+  if (channel.kind === 'jack') return 'J' + pin
+  return String(pin)
+}
 
 const batchMovePayload = (channel, driver) => {
   const payload = {
@@ -330,7 +347,7 @@ class connectors extends React.Component {
               onClick={channel.placeholder ? undefined : () => this.toggleSelection(channel)}
               title={channel.name}
             >
-              <span className='connector-cell-pin'>{(channel.pins || []).join(', ')}</span>
+              <span className='connector-cell-pin'>{channelDisplayName(channel)}</span>
               <span className='connector-status-dot' />
               <span className='connector-cell-kind'>{CONNECTOR_KINDS[channel.kind].label}</span>
             </button>


### PR DESCRIPTION
## Summary
- Add the new_shell-gated Configuration -> Connectors grouped view by driver.
- Add sticky search/filter controls, conflict surfacing, multi-select, batch delete, and batch move.
- Add PCA9685 compact channel grid styling and connector regression coverage.

Fixes #3065

## Validation
- rtk yarn jest front-end/src/connectors/connectors.test.js --runInBand
- rtk ./node_modules/.bin/standard front-end/src/connectors/main.jsx
- rtk yarn build
- rtk yarn sass-lint (exits 0 with existing warnings)