### PR TITLE
[bug] fix ui-audit CI: handle both old and new shell in mobile

### DIFF
--- a/front-end/e2e/specs/ui-audit/seeded-corpus.spec.js
+++ b/front-end/e2e/specs/ui-audit/seeded-corpus.spec.js
@@ -40,8 +40,14 @@ async function expectShellForViewport (page, viewport) {
   }
 
   if (viewport.name === 'mobile') {
-    await expect(page.getByTestId('smoke-current-tab')).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Toggle navigation' })).toBeVisible()
+    const currentTab = page.getByTestId('smoke-current-tab')
+    if (await currentTab.count()) {
+      await expect(currentTab).toBeVisible()
+      await expect(page.getByRole('button', { name: 'Toggle navigation' })).toBeVisible()
+    } else {
+      await expect(page.getByTestId('smoke-nav')).toBeVisible()
+      await expect(page.getByRole('button', { name: 'More routes' })).toBeVisible()
+    }
   } else {
     await expect(page.getByTestId('smoke-tab-dashboard')).toBeVisible()
   }
@@ -50,7 +56,12 @@ async function expectShellForViewport (page, viewport) {
 async function openRoute (page, navBar, viewport, moduleId) {
   const tab = navBar.tab(moduleId).first()
   if (!await tab.isVisible()) {
-    await page.getByRole('button', { name: 'Toggle navigation' }).click()
+    const toggleBtn = page.getByRole('button', { name: 'Toggle navigation' })
+    if (await toggleBtn.count()) {
+      await toggleBtn.click()
+    } else {
+      await page.getByRole('button', { name: 'More routes' }).click()
+    }
     await expect(tab).toBeVisible()
   }
   await tab.click()


### PR DESCRIPTION
## Summary

- `seeded-corpus.spec.js` hardcoded `smoke-current-tab` and `Toggle navigation` checks in the mobile viewport block — elements that only exist in the legacy navbar shell
- When the new shell (`BottomNav`) is active those elements are absent and the UI Audit CI job fails
- `expectShellForViewport` now detects which shell is rendered (via `smoke-current-tab` presence) and branches accordingly — matching the pattern already established in `dashboard-and-responsive.spec.js`
- `openRoute` similarly falls back to `More routes` (new shell) when `Toggle navigation` (old shell) is not present

## Test plan

- [ ] UI Audit CI job passes on this branch
- [ ] Old shell: mobile viewport still checks `smoke-current-tab` + `Toggle navigation`
- [ ] New shell: mobile viewport checks `smoke-nav` + `More routes`
- [ ] Desktop path unchanged (`smoke-tab-dashboard`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)