### PR TITLE
[bug] dashboard: suppress 404 toasts from stale chart subscriptions

### DIFF
--- a/front-end/e2e/fixtures/apiSeed.js
+++ b/front-end/e2e/fixtures/apiSeed.js
@@ -455,5 +455,6 @@ module.exports = {
   resetSmokeState,
   seedConfiguration,
   seedFullSmokeConfiguration,
-  seedDashboard
+  seedDashboard,
+  updateDashboard
 }

--- a/front-end/e2e/specs/dashboard-and-responsive.spec.js
+++ b/front-end/e2e/specs/dashboard-and-responsive.spec.js
@@ -1,5 +1,5 @@
 const { test, expect } = require('@playwright/test')
-const { createSmokeApi, seedDashboard } = require('../fixtures/apiSeed')
+const { createSmokeApi, seedDashboard, updateDashboard } = require('../fixtures/apiSeed')
 const { NavBar } = require('../pages/navBar')
 
 async function expectDashboardReady (page) {
@@ -28,6 +28,28 @@ test('seeded dashboard survives reload', async ({ page, baseURL }) => {
   await page.reload()
   await expect(page.locator('body')).toContainText('Return')
   await expectDashboardReady(page)
+})
+
+test('stale dashboard config shows no error toasts', async ({ page, baseURL }) => {
+  const api = await createSmokeApi(baseURL)
+
+  try {
+    await updateDashboard(api, {
+      row: 1,
+      column: 1,
+      width: 400,
+      height: 200,
+      grid_details: [[{ type: 'temp_current', id: '99999' }]]
+    })
+  } finally {
+    await api.dispose()
+  }
+
+  await page.goto('/')
+  await expect(page.getByTestId('smoke-dashboard-configure')).toBeVisible({ timeout: 10000 })
+
+  await page.waitForTimeout(2000)
+  await expect(page.locator('.alert-danger')).toHaveCount(0)
 })
 
 test.describe('mobile shell', () => {

--- a/front-end/e2e/specs/dashboard-and-responsive.spec.js
+++ b/front-end/e2e/specs/dashboard-and-responsive.spec.js
@@ -45,8 +45,9 @@ test('stale dashboard config shows no error toasts', async ({ page, baseURL }) =
     await api.dispose()
   }
 
+  const navBar = new NavBar(page)
   await page.goto('/')
-  await expect(page.getByTestId('smoke-dashboard-configure')).toBeVisible({ timeout: 10000 })
+  await navBar.expectShell()
 
   await page.waitForTimeout(2000)
   await expect(page.locator('.alert-danger')).toHaveCount(0)

--- a/front-end/src/ato/chart.jsx
+++ b/front-end/src/ato/chart.jsx
@@ -16,9 +16,19 @@ export class RawATOChart extends React.Component {
   }
 
   componentDidMount () {
-    this.updateUsage()
-    const timer = window.setInterval(this.updateUsage, 10 * 1000)
-    this.setState({ timer })
+    if (this.props.config !== undefined) {
+      this.updateUsage()
+      const timer = window.setInterval(this.updateUsage, 10 * 1000)
+      this.setState({ timer })
+    }
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.config === undefined && this.props.config !== undefined) {
+      this.updateUsage()
+      const timer = window.setInterval(this.updateUsage, 10 * 1000)
+      this.setState({ timer })
+    }
   }
 
   componentWillUnmount () {

--- a/front-end/src/ato/chart.test.js
+++ b/front-end/src/ato/chart.test.js
@@ -65,6 +65,41 @@ describe('ATO Chart', () => {
     expect(chart.render().type).toBe('div')
   })
 
+  it('skips fetch on mount when entity is not in store (deleted)', () => {
+    const fetchATOUsage = jest.fn()
+    const chart = new RawATOChart({
+      ato_id: '1',
+      height: 200,
+      config: undefined,
+      usage: undefined,
+      fetchATOUsage
+    })
+    chart.setState = jest.fn()
+    chart.componentDidMount()
+    expect(fetchATOUsage).not.toHaveBeenCalled()
+    expect(chart.setState).not.toHaveBeenCalled()
+  })
+
+  it('starts polling via componentDidUpdate when entity loads after mount', () => {
+    const fetchATOUsage = jest.fn()
+    const chart = new RawATOChart({
+      ato_id: '1',
+      height: 200,
+      config: undefined,
+      usage: undefined,
+      fetchATOUsage
+    })
+    chart.setState = jest.fn(update => {
+      chart.state = { ...chart.state, ...update }
+    })
+    chart.componentDidMount()
+    expect(fetchATOUsage).not.toHaveBeenCalled()
+
+    chart.props = { ...chart.props, config: atoConfig }
+    chart.componentDidUpdate({ config: undefined })
+    expect(fetchATOUsage).toHaveBeenCalledWith('1')
+  })
+
   it('fetches usage on mount', () => {
     const fetchATOUsage = jest.fn()
     const chart = new RawATOChart({

--- a/front-end/src/doser/chart.jsx
+++ b/front-end/src/doser/chart.jsx
@@ -16,9 +16,19 @@ export class RawDoserChart extends React.Component {
   }
 
   componentDidMount () {
-    this.updateUsage()
-    const timer = window.setInterval(this.updateUsage, 10 * 1000)
-    this.setState({ timer })
+    if (this.props.config !== undefined) {
+      this.updateUsage()
+      const timer = window.setInterval(this.updateUsage, 10 * 1000)
+      this.setState({ timer })
+    }
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.config === undefined && this.props.config !== undefined) {
+      this.updateUsage()
+      const timer = window.setInterval(this.updateUsage, 10 * 1000)
+      this.setState({ timer })
+    }
   }
 
   componentWillUnmount () {

--- a/front-end/src/doser/chart.test.js
+++ b/front-end/src/doser/chart.test.js
@@ -72,6 +72,41 @@ describe('Doser Chart', () => {
     expect(chart.render().type).toBe('div')
   })
 
+  it('skips fetch on mount when entity is not in store (deleted)', () => {
+    const fetchDoserUsage = jest.fn()
+    const chart = new RawDoserChart({
+      doser_id: '1',
+      height: 200,
+      config: undefined,
+      usage: undefined,
+      fetchDoserUsage
+    })
+    chart.setState = jest.fn()
+    chart.componentDidMount()
+    expect(fetchDoserUsage).not.toHaveBeenCalled()
+    expect(chart.setState).not.toHaveBeenCalled()
+  })
+
+  it('starts polling via componentDidUpdate when entity loads after mount', () => {
+    const fetchDoserUsage = jest.fn()
+    const chart = new RawDoserChart({
+      doser_id: '1',
+      height: 200,
+      config: undefined,
+      usage: undefined,
+      fetchDoserUsage
+    })
+    chart.setState = jest.fn(update => {
+      chart.state = { ...chart.state, ...update }
+    })
+    chart.componentDidMount()
+    expect(fetchDoserUsage).not.toHaveBeenCalled()
+
+    chart.props = { ...chart.props, config: doserConfig }
+    chart.componentDidUpdate({ config: undefined })
+    expect(fetchDoserUsage).toHaveBeenCalledWith('1')
+  })
+
   it('fetches usage on mount', () => {
     const fetchDoserUsage = jest.fn()
     const chart = new RawDoserChart({

--- a/front-end/src/journal/chart.jsx
+++ b/front-end/src/journal/chart.jsx
@@ -6,11 +6,23 @@ import { connect } from 'react-redux'
 
 export class RawJournalChart extends React.Component {
   componentDidMount () {
-    this.props.fetch(this.props.journal_id)
-    const timer = window.setInterval(() => {
+    if (this.props.config !== undefined) {
       this.props.fetch(this.props.journal_id)
-    }, 10 * 1000)
-    this.setState({ timer })
+      const timer = window.setInterval(() => {
+        this.props.fetch(this.props.journal_id)
+      }, 10 * 1000)
+      this.setState({ timer })
+    }
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.config === undefined && this.props.config !== undefined) {
+      this.props.fetch(this.props.journal_id)
+      const timer = window.setInterval(() => {
+        this.props.fetch(this.props.journal_id)
+      }, 10 * 1000)
+      this.setState({ timer })
+    }
   }
 
   componentWillUnmount () {

--- a/front-end/src/journal/chart.test.js
+++ b/front-end/src/journal/chart.test.js
@@ -90,6 +90,39 @@ describe('<Chart />', () => {
     expect(yAxis.props.dataKey).toBe('value')
   })
 
+  it('skips fetch on mount when entity is not in store (deleted)', () => {
+    const fetch = jest.fn()
+    const chart = new RawJournalChart({
+      journal_id: '1',
+      config: undefined,
+      readings: undefined,
+      fetch
+    })
+    chart.setState = jest.fn()
+    chart.componentDidMount()
+    expect(fetch).not.toHaveBeenCalled()
+    expect(chart.setState).not.toHaveBeenCalled()
+  })
+
+  it('starts polling via componentDidUpdate when entity loads after mount', () => {
+    const fetch = jest.fn()
+    const chart = new RawJournalChart({
+      journal_id: '1',
+      config: undefined,
+      readings: undefined,
+      fetch
+    })
+    chart.setState = jest.fn(update => {
+      chart.state = { ...chart.state, ...update }
+    })
+    chart.componentDidMount()
+    expect(fetch).not.toHaveBeenCalled()
+
+    chart.props = { ...chart.props, config: journal }
+    chart.componentDidUpdate({ config: undefined })
+    expect(fetch).toHaveBeenCalledWith('1')
+  })
+
   it('polls on mount and clears timer on unmount', () => {
     jest.useFakeTimers()
     const fetch = jest.fn()

--- a/front-end/src/lighting/charts/charts.test.js
+++ b/front-end/src/lighting/charts/charts.test.js
@@ -257,6 +257,41 @@ describe('GenericLightChart', () => {
     expect(usage.current).toEqual(originalCurrent)
   })
 
+  it('skips fetch on mount when light is not in store (deleted)', () => {
+    const fetch = jest.fn()
+    const component = new RawGenericLightChart({
+      light_id: '1',
+      light: undefined,
+      usage: undefined,
+      fetch,
+      height: 200
+    })
+    component.setState = jest.fn()
+    component.componentDidMount()
+    expect(fetch).not.toHaveBeenCalled()
+    expect(component.setState).not.toHaveBeenCalled()
+  })
+
+  it('starts polling via componentDidUpdate when light loads after mount', () => {
+    const fetch = jest.fn()
+    const component = new RawGenericLightChart({
+      light_id: '1',
+      light: undefined,
+      usage: undefined,
+      fetch,
+      height: 200
+    })
+    component.setState = jest.fn(update => {
+      component.state = { ...component.state, ...update }
+    })
+    component.componentDidMount()
+    expect(fetch).not.toHaveBeenCalled()
+
+    component.props = { ...component.props, light: lightConfig }
+    component.componentDidUpdate({ light: undefined })
+    expect(fetch).toHaveBeenCalledWith('1')
+  })
+
   it('clears interval on unmount', () => {
     jest.useFakeTimers()
     const fetch = jest.fn()

--- a/front-end/src/lighting/charts/generic.jsx
+++ b/front-end/src/lighting/charts/generic.jsx
@@ -8,9 +8,19 @@ import { ParseTimestamp } from 'utils/timestamp'
 
 export class RawGenericLightChart extends React.Component {
   componentDidMount () {
-    this.props.fetch(this.props.light_id)
-    const timer = window.setInterval(() => { this.props.fetch(this.props.light.id) }, 10 * 1000)
-    this.setState({ timer })
+    if (this.props.light !== undefined) {
+      this.props.fetch(this.props.light_id)
+      const timer = window.setInterval(() => { this.props.fetch(this.props.light_id) }, 10 * 1000)
+      this.setState({ timer })
+    }
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.light === undefined && this.props.light !== undefined) {
+      this.props.fetch(this.props.light_id)
+      const timer = window.setInterval(() => { this.props.fetch(this.props.light_id) }, 10 * 1000)
+      this.setState({ timer })
+    }
   }
 
   componentWillUnmount () {

--- a/front-end/src/ph/chart.jsx
+++ b/front-end/src/ph/chart.jsx
@@ -7,11 +7,23 @@ import { TwoDecimalParse } from 'utils/two_decimal_parse'
 
 class chart extends React.Component {
   componentDidMount () {
-    this.props.fetchProbeReadings(this.props.probe_id)
-    const timer = window.setInterval(() => {
+    if (this.props.config !== undefined) {
       this.props.fetchProbeReadings(this.props.probe_id)
-    }, 10 * 1000)
-    this.setState({ timer })
+      const timer = window.setInterval(() => {
+        this.props.fetchProbeReadings(this.props.probe_id)
+      }, 10 * 1000)
+      this.setState({ timer })
+    }
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.config === undefined && this.props.config !== undefined) {
+      this.props.fetchProbeReadings(this.props.probe_id)
+      const timer = window.setInterval(() => {
+        this.props.fetchProbeReadings(this.props.probe_id)
+      }, 10 * 1000)
+      this.setState({ timer })
+    }
   }
 
   componentWillUnmount () {

--- a/front-end/src/ph/chart.test.js
+++ b/front-end/src/ph/chart.test.js
@@ -76,6 +76,41 @@ describe('pH Chart', () => {
     expect(maxLine.props).toMatchObject({ y: 8.5, stroke: 'orange', strokeDasharray: '4 2' })
   })
 
+  it('skips fetch on mount when entity is not in store (deleted)', () => {
+    const fetchProbeReadings = jest.fn()
+    const chart = new RawPhChart({
+      probe_id: '1',
+      config: undefined,
+      readings: undefined,
+      type: 'historical',
+      fetchProbeReadings
+    })
+    chart.setState = jest.fn()
+    chart.componentDidMount()
+    expect(fetchProbeReadings).not.toHaveBeenCalled()
+    expect(chart.setState).not.toHaveBeenCalled()
+  })
+
+  it('starts polling via componentDidUpdate when entity loads after mount', () => {
+    const fetchProbeReadings = jest.fn()
+    const chart = new RawPhChart({
+      probe_id: '1',
+      config: undefined,
+      readings: undefined,
+      type: 'historical',
+      fetchProbeReadings
+    })
+    chart.setState = jest.fn(update => {
+      chart.state = { ...chart.state, ...update }
+    })
+    chart.componentDidMount()
+    expect(fetchProbeReadings).not.toHaveBeenCalled()
+
+    chart.props = { ...chart.props, config: probeConfig }
+    chart.componentDidUpdate({ config: undefined })
+    expect(fetchProbeReadings).toHaveBeenCalledWith('1')
+  })
+
   it('polls readings on mount and clears the timer on unmount', () => {
     jest.useFakeTimers()
     const fetchProbeReadings = jest.fn()

--- a/front-end/src/ph/control_chart.jsx
+++ b/front-end/src/ph/control_chart.jsx
@@ -8,11 +8,23 @@ import humanizeDuration from 'humanize-duration'
 
 export class RawControlChart extends React.Component {
   componentDidMount () {
-    this.props.fetchProbeReadings(this.props.probe_id)
-    const timer = window.setInterval(() => {
+    if (this.props.config !== undefined) {
       this.props.fetchProbeReadings(this.props.probe_id)
-    }, 10 * 1000)
-    this.setState({ timer })
+      const timer = window.setInterval(() => {
+        this.props.fetchProbeReadings(this.props.probe_id)
+      }, 10 * 1000)
+      this.setState({ timer })
+    }
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.config === undefined && this.props.config !== undefined) {
+      this.props.fetchProbeReadings(this.props.probe_id)
+      const timer = window.setInterval(() => {
+        this.props.fetchProbeReadings(this.props.probe_id)
+      }, 10 * 1000)
+      this.setState({ timer })
+    }
   }
 
   componentWillUnmount () {

--- a/front-end/src/ph/control_chart.test.js
+++ b/front-end/src/ph/control_chart.test.js
@@ -75,6 +75,39 @@ describe('Ph ControlChart', () => {
     expect(tooltip.props.formatter(1, 'unknown')).toBeUndefined()
   })
 
+  it('skips fetch on mount when entity is not in store (deleted)', () => {
+    const fetchProbeReadings = jest.fn()
+    const chart = new RawControlChart({
+      probe_id: '1',
+      config: undefined,
+      readings: undefined,
+      fetchProbeReadings
+    })
+    chart.setState = jest.fn()
+    chart.componentDidMount()
+    expect(fetchProbeReadings).not.toHaveBeenCalled()
+    expect(chart.setState).not.toHaveBeenCalled()
+  })
+
+  it('starts polling via componentDidUpdate when entity loads after mount', () => {
+    const fetchProbeReadings = jest.fn()
+    const chart = new RawControlChart({
+      probe_id: '1',
+      config: undefined,
+      readings: undefined,
+      fetchProbeReadings
+    })
+    chart.setState = jest.fn(update => {
+      chart.state = { ...chart.state, ...update }
+    })
+    chart.componentDidMount()
+    expect(fetchProbeReadings).not.toHaveBeenCalled()
+
+    chart.props = { ...chart.props, config: probeConfig }
+    chart.componentDidUpdate({ config: undefined })
+    expect(fetchProbeReadings).toHaveBeenCalledWith('1')
+  })
+
   it('fetches probe readings on mount via interval', () => {
     jest.useFakeTimers()
     const readings = { historical: [] }

--- a/front-end/src/redux/actions/ato.js
+++ b/front-end/src/redux/actions/ato.js
@@ -38,7 +38,7 @@ export const atoUsageLoaded = (id) => {
 }
 
 export const fetchATOUsage = (id) => {
-  return getAction(['atos', id, 'usage'], atoUsageLoaded(id))
+  return getAction(['atos', id, 'usage'], atoUsageLoaded(id), { silent404: true })
 }
 
 export const createATO = (a) => {

--- a/front-end/src/redux/actions/doser.js
+++ b/front-end/src/redux/actions/doser.js
@@ -48,7 +48,7 @@ export const saveDosingPumpCalibration = (id, s) => {
 }
 
 export const fetchDoserUsage = (id) => {
-  return getAction(['doser', 'pumps', id, 'usage'], doserUsageLoaded(id))
+  return getAction(['doser', 'pumps', id, 'usage'], doserUsageLoaded(id), { silent404: true })
 }
 
 export const doserUsageLoaded = (id) => {

--- a/front-end/src/redux/actions/journal.js
+++ b/front-end/src/redux/actions/journal.js
@@ -38,7 +38,7 @@ export const journalUsageLoaded = (id) => {
 }
 
 export const fetchJournalUsage = (id) => {
-  return getAction(['journal', id, 'usage'], journalUsageLoaded(id))
+  return getAction(['journal', id, 'usage'], journalUsageLoaded(id), { silent404: true })
 }
 
 export const createJournal = (a) => {

--- a/front-end/src/redux/actions/lights.js
+++ b/front-end/src/redux/actions/lights.js
@@ -54,5 +54,5 @@ export const deleteLight = (s) => {
 }
 
 export const fetchLightUsage = (id) => {
-  return getAction(['lights', id, 'usage'], lightUsageLoaded(id))
+  return getAction(['lights', id, 'usage'], lightUsageLoaded(id), { silent404: true })
 }

--- a/front-end/src/redux/actions/phprobes.js
+++ b/front-end/src/redux/actions/phprobes.js
@@ -45,7 +45,7 @@ export const probeReadComplete = (id) => {
 }
 
 export const fetchProbeReadings = (id) => {
-  return getAction(['phprobes', id, 'readings'], probeReadingsLoaded(id))
+  return getAction(['phprobes', id, 'readings'], probeReadingsLoaded(id), { silent404: true })
 }
 
 export const updateProbe = (id, a) => {

--- a/front-end/src/redux/actions/tcs.js
+++ b/front-end/src/redux/actions/tcs.js
@@ -44,7 +44,7 @@ export const fetchSensors = () => {
 }
 
 export const fetchTCUsage = (id) => {
-  return getAction(['tcs', id, 'usage'], tcUsageLoaded(id))
+  return getAction(['tcs', id, 'usage'], tcUsageLoaded(id), { silent404: true })
 }
 
 export const readTC = (id) => {

--- a/front-end/src/temperature/control_chart.jsx
+++ b/front-end/src/temperature/control_chart.jsx
@@ -9,11 +9,23 @@ import i18next from 'i18next'
 
 export class RawControlChart extends React.Component {
   componentDidMount () {
-    this.props.fetchTCUsage(this.props.sensor_id)
-    const timer = window.setInterval(() => {
+    if (this.props.config !== undefined) {
       this.props.fetchTCUsage(this.props.sensor_id)
-    }, 10 * 1000)
-    this.setState({ timer })
+      const timer = window.setInterval(() => {
+        this.props.fetchTCUsage(this.props.sensor_id)
+      }, 10 * 1000)
+      this.setState({ timer })
+    }
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.config === undefined && this.props.config !== undefined) {
+      this.props.fetchTCUsage(this.props.sensor_id)
+      const timer = window.setInterval(() => {
+        this.props.fetchTCUsage(this.props.sensor_id)
+      }, 10 * 1000)
+      this.setState({ timer })
+    }
   }
 
   componentWillUnmount () {

--- a/front-end/src/temperature/control_chart.test.js
+++ b/front-end/src/temperature/control_chart.test.js
@@ -92,6 +92,40 @@ describe('Temperature ControlChart', () => {
     })
   })
 
+  it('skips fetch on mount when entity is not in store (deleted)', () => {
+    const fetchTCUsage = jest.fn()
+    const chart = new RawControlChart({
+      sensor_id: '1',
+      config: undefined,
+      usage: undefined,
+      fetchTCUsage
+    })
+    chart.setState = jest.fn()
+    chart.componentDidMount()
+    expect(fetchTCUsage).not.toHaveBeenCalled()
+    expect(chart.setState).not.toHaveBeenCalled()
+  })
+
+  it('starts polling via componentDidUpdate when entity loads after mount', () => {
+    jest.useFakeTimers()
+    const fetchTCUsage = jest.fn()
+    const chart = new RawControlChart({
+      sensor_id: '1',
+      config: undefined,
+      usage: undefined,
+      fetchTCUsage
+    })
+    chart.setState = jest.fn(update => {
+      chart.state = { ...chart.state, ...update }
+    })
+    chart.componentDidMount()
+    expect(fetchTCUsage).not.toHaveBeenCalled()
+
+    chart.props = { ...chart.props, config }
+    chart.componentDidUpdate({ config: undefined })
+    expect(fetchTCUsage).toHaveBeenCalledWith('1')
+  })
+
   it('polls control usage on mount and clears the timer on unmount', () => {
     jest.useFakeTimers()
     const fetchTCUsage = jest.fn()

--- a/front-end/src/temperature/readings_chart.jsx
+++ b/front-end/src/temperature/readings_chart.jsx
@@ -7,9 +7,19 @@ import { filterToday, timestampToEpoch } from 'utils/timestamp'
 
 export class RawReadingsChart extends React.Component {
   componentDidMount () {
-    this.props.fetch(this.props.sensor_id)
-    const timer = window.setInterval(() => { this.props.fetch(this.props.sensor_id) }, 10 * 1000)
-    this.setState({ timer })
+    if (this.props.config !== undefined) {
+      this.props.fetch(this.props.sensor_id)
+      const timer = window.setInterval(() => { this.props.fetch(this.props.sensor_id) }, 10 * 1000)
+      this.setState({ timer })
+    }
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.config === undefined && this.props.config !== undefined) {
+      this.props.fetch(this.props.sensor_id)
+      const timer = window.setInterval(() => { this.props.fetch(this.props.sensor_id) }, 10 * 1000)
+      this.setState({ timer })
+    }
   }
 
   componentWillUnmount () {

--- a/front-end/src/temperature/readings_chart.test.js
+++ b/front-end/src/temperature/readings_chart.test.js
@@ -77,6 +77,40 @@ describe('Temperature ReadingsChart', () => {
     })
   })
 
+  it('skips fetch on mount when entity is not in store (deleted)', () => {
+    const fetch = jest.fn()
+    const chart = new RawReadingsChart({
+      sensor_id: '1',
+      config: undefined,
+      usage: undefined,
+      fetch
+    })
+    chart.setState = jest.fn()
+    chart.componentDidMount()
+    expect(fetch).not.toHaveBeenCalled()
+    expect(chart.setState).not.toHaveBeenCalled()
+  })
+
+  it('starts polling via componentDidUpdate when entity loads after mount', () => {
+    jest.useFakeTimers()
+    const fetch = jest.fn()
+    const chart = new RawReadingsChart({
+      sensor_id: '1',
+      config: undefined,
+      usage: undefined,
+      fetch
+    })
+    chart.setState = jest.fn(update => {
+      chart.state = { ...chart.state, ...update }
+    })
+    chart.componentDidMount()
+    expect(fetch).not.toHaveBeenCalled()
+
+    chart.props = { ...chart.props, config }
+    chart.componentDidUpdate({ config: undefined })
+    expect(fetch).toHaveBeenCalledWith('1')
+  })
+
   it('polls readings on mount and clears the timer on unmount', () => {
     jest.useFakeTimers()
     const fetch = jest.fn()

--- a/front-end/src/utils/ajax.js
+++ b/front-end/src/utils/ajax.js
@@ -43,6 +43,10 @@ function handleErrorResponse (response, params) {
       params.failure(response)
       return handledError
     }
+    if (response.status === 404 && params.silent404) {
+      console.warn(err)
+      return handledError
+    }
     showError(err + ' | HTTP ' + response.status)
     return handledError
   })

--- a/front-end/src/utils/ajax.test.js
+++ b/front-end/src/utils/ajax.test.js
@@ -141,6 +141,27 @@ describe('Ajax', () => {
     })
   })
 
+  it('console.warns instead of toasting for 404 when silent404 is set', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    global.fetch.mockResolvedValue(response({ ok: false, status: 404, text: 'not found' }))
+
+    return reduxGet({ url: '/foo', success, silent404: true })(dispatch).then(() => {
+      expect(showError).not.toHaveBeenCalled()
+      expect(warnSpy).toHaveBeenCalledWith('not found')
+      expect(dispatch).not.toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
+  })
+
+  it('still toasts for non-404 errors when silent404 is set', () => {
+    global.fetch.mockResolvedValue(response({ ok: false, status: 500, text: 'server error' }))
+
+    return reduxGet({ url: '/foo', success, silent404: true })(dispatch).then(() => {
+      expect(showError).toHaveBeenCalledWith('server error | HTTP 500')
+      expect(dispatch).not.toHaveBeenCalled()
+    })
+  })
+
   it('dispatches API_FAILURE when fetch rejects', () => {
     global.fetch.mockRejectedValue(new Error('offline'))
 


### PR DESCRIPTION
Fixes #3066

## Summary

- Dashboard shows 3 identical `HTTP 404` toasts on every page load when chart subscriptions reference deleted entities
- Two-pronged fix: entity existence guard prevents fetching for orphaned subscriptions; `silent404` option on all usage actions silences any 404s that slip through

**Entity existence guard** — `componentDidMount` skips polling when `this.props.config` is `undefined` (entity deleted); `componentDidUpdate` starts polling the first time the entity appears in the store (handles async load order). Applied to 8 chart components: temperature readings, temperature control, ATO, doser, journal, pH chart, pH control chart, and lighting.

**`silent404: true`** — added to `fetchTCUsage`, `fetchATOUsage`, `fetchDoserUsage`, `fetchProbeReadings`, `fetchLightUsage`, `fetchJournalUsage`. 404 responses go to `console.warn`; all other errors still show a toast.

## Test plan

- [ ] New unit tests on all 8 chart components: "skips fetch when entity is not in store" + "starts polling via componentDidUpdate when entity loads after mount"
- [ ] New ajax unit tests: `silent404` suppresses toast for 404, still toasts for non-404
- [ ] New Playwright test: stale dashboard config with non-existent entity id shows zero `.alert-danger` toasts
- [ ] All 1129 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)