### PR TITLE
[bug] shell: prevent footer overlapping page content

### DIFF
--- a/front-end/assets/sass/style.scss
+++ b/front-end/assets/sass/style.scss
@@ -124,7 +124,12 @@
 }
 
 .bottom-bar {
+  min-height: var(--reefpi-summary-height, 64px);
   border-top: solid 1px var(--reefpi-color-border-subtle);
+}
+
+.bottom-bar .list-inline {
+  margin-bottom: 0;
 }
 
 html {
@@ -137,6 +142,7 @@ body {
 }
 
 #main-panel {
+  --reefpi-summary-height: 64px;
   min-height: 100vh;
 }
 
@@ -316,6 +322,10 @@ textarea:focus,
 }
 
 @media screen and (min-width: 992px) {
+  #main-panel {
+    padding-bottom: var(--reefpi-summary-height, 64px);
+  }
+
   .body-panel {
     margin-bottom: 70px;
   }
@@ -527,5 +537,11 @@ textarea:focus,
   .connector-channel-cell {
     grid-template-columns: auto auto 1fr;
     justify-items: start;
+  }
+}
+
+@media screen and (max-width: 991.98px) {
+  #main-panel {
+    padding-bottom: 0;
   }
 }

--- a/front-end/assets/sass/style.scss
+++ b/front-end/assets/sass/style.scss
@@ -30,6 +30,7 @@
   --reefpi-color-nav-text-strong: #{$nav-text-strong-color};
   --reefpi-shell-gutter: #{$space-sm};
   --reefpi-panel-gap: #{$space-md};
+  --reefpi-summary-height: 64px;
   --reefpi-space-xxs: #{$space-xxs};
   --reefpi-space-xs: #{$space-xs};
   --reefpi-space-sm: #{$space-sm};
@@ -142,7 +143,6 @@ body {
 }
 
 #main-panel {
-  --reefpi-summary-height: 64px;
   min-height: 100vh;
 }
 

--- a/front-end/design-system/colors_and_type.css
+++ b/front-end/design-system/colors_and_type.css
@@ -86,6 +86,7 @@
   /* ---------- Layout ---------- */
   --reefpi-shell-gutter:  0.75rem; /* 1rem on ≥768px */
   --reefpi-panel-gap:     1rem;
+  --reefpi-summary-height: 64px;
   --reefpi-tap-target-min: 2.75rem; /* 44px — min touch target */
 
   /* ---------- Type ---------- */

--- a/front-end/e2e/specs/seeded-configuration.spec.js
+++ b/front-end/e2e/specs/seeded-configuration.spec.js
@@ -1,5 +1,5 @@
 const { test, expect } = require('@playwright/test')
-const { createSmokeApi, seedConfiguration } = require('../fixtures/apiSeed')
+const { createSmokeApi, seedConfiguration, seedFullSmokeConfiguration } = require('../fixtures/apiSeed')
 const { NavBar } = require('../pages/navBar')
 
 test('seeded configuration entities render in the UI', async ({ page, baseURL }) => {
@@ -28,4 +28,48 @@ test('seeded configuration entities render in the UI', async ({ page, baseURL })
   await navBar.open('equipment')
   await expect(page.locator('body')).toContainText('Return')
   await expect(page.locator('body')).toContainText('Light')
+})
+
+test('configuration connectors bottom content is not hidden behind the summary footer', async ({ page, baseURL }) => {
+  const api = await createSmokeApi(baseURL)
+
+  try {
+    await seedFullSmokeConfiguration(api)
+  } finally {
+    await api.dispose()
+  }
+
+  const navBar = new NavBar(page)
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await page.goto('/')
+  await navBar.expectShell()
+  await navBar.open('configuration')
+  await page.locator('#config-connectors').click()
+  await expect(page.getByTestId('smoke-jack-add-toggle')).toBeVisible()
+
+  const desktopShellSpacing = await page.evaluate(() => {
+    const panel = document.querySelector('#main-panel')
+    const footer = document.querySelector('.bottom-bar')
+    return {
+      panelPadding: parseFloat(window.getComputedStyle(panel).paddingBottom),
+      footerHeight: footer.getBoundingClientRect().height
+    }
+  })
+  expect(desktopShellSpacing.panelPadding).toBeGreaterThanOrEqual(desktopShellSpacing.footerHeight)
+
+  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight))
+
+  const spacing = await page.evaluate(() => {
+    const footer = document.querySelector('.bottom-bar')
+    const target = document.querySelector('[data-testid="smoke-jack-add-toggle"]')
+    const footerRect = footer.getBoundingClientRect()
+    const targetRect = target.getBoundingClientRect()
+    return Math.floor(footerRect.top - targetRect.bottom)
+  })
+
+  expect(spacing).toBeGreaterThanOrEqual(0)
+
+  await page.setViewportSize({ width: 390, height: 844 })
+  const mobilePanelPadding = await page.evaluate(() => parseFloat(window.getComputedStyle(document.querySelector('#main-panel')).paddingBottom))
+  expect(mobilePanelPadding).toBe(0)
 })

--- a/front-end/e2e/specs/seeded-configuration.spec.js
+++ b/front-end/e2e/specs/seeded-configuration.spec.js
@@ -45,7 +45,8 @@ test('configuration connectors bottom content is not hidden behind the summary f
   await navBar.expectShell()
   await navBar.open('configuration')
   await page.locator('#config-connectors').click()
-  await expect(page.getByTestId('smoke-jack-add-toggle')).toBeVisible()
+  const bottomConnector = page.locator('[data-testid="smoke-jack-add-toggle"], .connector-groups .connector-group').last()
+  await expect(bottomConnector).toBeVisible()
 
   const desktopShellSpacing = await page.evaluate(() => {
     const panel = document.querySelector('#main-panel')
@@ -61,7 +62,7 @@ test('configuration connectors bottom content is not hidden behind the summary f
 
   const spacing = await page.evaluate(() => {
     const footer = document.querySelector('.bottom-bar')
-    const target = document.querySelector('[data-testid="smoke-jack-add-toggle"]')
+    const target = document.querySelector('[data-testid="smoke-jack-add-toggle"]') || Array.from(document.querySelectorAll('.connector-groups .connector-group')).pop()
     const footerRect = footer.getBoundingClientRect()
     const targetRect = target.getBoundingClientRect()
     return Math.floor(footerRect.top - targetRect.bottom)


### PR DESCRIPTION
Fixes #3067

## Summary
- Reserve the summary footer height in the desktop shell via --reefpi-summary-height
- Keep the shell unpadded on mobile where the summary footer is hidden
- Add a Playwright regression for Configuration > Connectors bottom content

## Tests
- rtk ./node_modules/.bin/standard front-end/e2e/specs/seeded-configuration.spec.js
- rtk ./node_modules/.bin/playwright test --project=smoke-chromium front-end/e2e/specs/seeded-configuration.spec.js
- rtk yarn build