### PR TITLE
[codex] dashboard: prune orphaned chart subscriptions

### DIFF
--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import PropTypes from 'prop-types'
 import SystemStrip from './SystemStrip'
 import TemperatureTile from './TemperatureTile'
@@ -44,8 +44,168 @@ function toTileAlert (a) {
   return { severity: a.severity, message: a.detail || a.title, at: a.ts }
 }
 
+const DASHBOARD_CONFIG_KEY = 'dashboard_config'
+
+const RESOURCE_META = {
+  temperature: {
+    aliases: ['temperature', 'temperatures', 'tcs', 'temp', 'temp_current', 'temp_historical'],
+    title: 'Temperature',
+    copy: 'No temperature probe is selected for this chart.',
+    action: 'Configure temperature probe',
+    href: '/temperature'
+  },
+  ph: {
+    aliases: ['ph', 'phprobes', 'ph_current', 'ph_historical', 'ph_usage'],
+    title: 'pH',
+    copy: 'No pH probe is selected for this chart.',
+    action: 'Configure pH probe',
+    href: '/ph'
+  },
+  ato: {
+    aliases: ['ato', 'atos'],
+    title: 'ATO',
+    copy: 'No ATO controller is selected for this chart.',
+    action: 'Configure ATO',
+    href: '/ato'
+  }
+}
+
+function readDashboardConfig () {
+  try {
+    const raw = window.localStorage?.getItem(DASHBOARD_CONFIG_KEY)
+    return raw ? JSON.parse(raw) : null
+  } catch (_) {
+    return null
+  }
+}
+
+function writeDashboardConfig (config) {
+  try {
+    window.localStorage?.setItem(DASHBOARD_CONFIG_KEY, JSON.stringify(config))
+  } catch (_) {}
+}
+
+function removeDashboardConfig () {
+  try { window.localStorage?.removeItem(DASHBOARD_CONFIG_KEY) } catch (_) {}
+}
+
+function normalizeResource (value) {
+  const v = String(value || '').toLowerCase()
+  return Object.keys(RESOURCE_META).find(resource => RESOURCE_META[resource].aliases.includes(v)) || v
+}
+
+function subscriptionFor (config, resource) {
+  if (!config || typeof config !== 'object') return null
+  const subscriptions = Array.isArray(config.subscriptions) ? config.subscriptions : []
+  const match = subscriptions.find(item => normalizeResource(item.resource || item.type || item.kind || item.metric) === resource)
+  if (match) return match
+  const direct = config[resource] || config.charts?.[resource]
+  return direct && typeof direct === 'object' ? direct : null
+}
+
+function idExists (items, id) {
+  return (items || []).some(item => String(item.id) === String(id))
+}
+
+function tileStateFor (config, resource, items) {
+  const subscription = subscriptionFor(config, resource)
+  if (!subscription || subscription.id == null || subscription.id === '') {
+    return { configured: (items || []).length > 0, orphan: null }
+  }
+  if (idExists(items, subscription.id)) {
+    return { configured: true, orphan: null }
+  }
+  return { configured: false, orphan: { resource, id: String(subscription.id) } }
+}
+
+function pruneDashboardConfig (config, orphans) {
+  if (!config || !orphans.length) return { config, changed: false }
+  const orphaned = new Set(orphans.map(item => `${item.resource}:${item.id}`))
+  let changed = false
+  const next = { ...config }
+
+  if (Array.isArray(config.subscriptions)) {
+    next.subscriptions = config.subscriptions.filter(item => {
+      const key = `${normalizeResource(item.resource || item.type || item.kind || item.metric)}:${String(item.id)}`
+      const keep = !orphaned.has(key)
+      if (!keep) changed = true
+      return keep
+    })
+  }
+
+  Object.keys(RESOURCE_META).forEach(resource => {
+    const direct = next[resource]
+    if (direct && direct.id != null && orphaned.has(`${resource}:${String(direct.id)}`)) {
+      delete next[resource]
+      changed = true
+    }
+    const chart = next.charts?.[resource]
+    if (chart && chart.id != null && orphaned.has(`${resource}:${String(chart.id)}`)) {
+      next.charts = { ...next.charts }
+      delete next.charts[resource]
+      changed = true
+    }
+  })
+
+  return { config: next, changed }
+}
+
+function NotConfiguredTile ({ resource }) {
+  const meta = RESOURCE_META[resource]
+  return (
+    <div
+      data-testid={`dashboard-tile-${resource}`}
+      style={{
+        background: 'var(--reefpi-color-surface-elevated)',
+        border: '1px solid var(--reefpi-color-border)',
+        borderRadius: 'var(--reefpi-radius-md)',
+        minHeight: resource === 'temperature' ? '320px' : '220px',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '0.75rem',
+        padding: '1rem',
+        textAlign: 'center',
+        fontFamily: 'var(--reefpi-font-app)'
+      }}
+    >
+      <div style={{ fontSize: '0.75rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--reefpi-color-text-muted)' }}>
+        {meta.title}
+      </div>
+      <div style={{ fontSize: '1rem', fontWeight: 500, color: 'var(--reefpi-color-text)' }}>Not configured</div>
+      <div style={{ fontSize: '0.8rem', color: 'var(--reefpi-color-text-muted)', maxWidth: '18rem' }}>{meta.copy}</div>
+      <a
+        href={meta.href}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minHeight: '44px',
+          padding: '0 1rem',
+          borderRadius: 'var(--reefpi-radius-sm)',
+          background: 'var(--reefpi-color-brand)',
+          color: 'var(--reefpi-color-on-brand, #fff)',
+          textDecoration: 'none',
+          fontSize: '0.85rem',
+          fontWeight: 600
+        }}
+      >
+        {meta.action}
+      </a>
+    </div>
+  )
+}
+
+NotConfiguredTile.propTypes = {
+  resource: PropTypes.oneOf(Object.keys(RESOURCE_META)).isRequired
+}
+
 export default function DashboardV2 ({
   equipment,
+  temperatureControllers,
+  phProbes,
+  atos,
   onToggle,
   onConfigure,
   sseEndpoint,
@@ -54,9 +214,29 @@ export default function DashboardV2 ({
   children
 }) {
   const { alerts } = useAlertsStore({ sseEndpoint })
+  const [configRevision, setConfigRevision] = useState(0)
 
   if (!window.FEATURE_FLAGS?.dashboard_v2) {
     return children ?? null
+  }
+
+  const dashboardConfig = useMemo(() => readDashboardConfig(), [configRevision])
+  const tempState = tileStateFor(dashboardConfig, 'temperature', temperatureControllers)
+  const phState = tileStateFor(dashboardConfig, 'ph', phProbes)
+  const atoState = tileStateFor(dashboardConfig, 'ato', atos)
+  const orphans = [tempState.orphan, phState.orphan, atoState.orphan].filter(Boolean)
+
+  useEffect(() => {
+    const result = pruneDashboardConfig(dashboardConfig, orphans)
+    if (result.changed) {
+      writeDashboardConfig(result.config)
+      setConfigRevision(v => v + 1)
+    }
+  }, [dashboardConfig, orphans])
+
+  const handleResetDashboardConfig = () => {
+    removeDashboardConfig()
+    setConfigRevision(v => v + 1)
   }
 
   const tempAlert = toTileAlert(firstAlertFor(alerts, 'temperature.display'))
@@ -78,22 +258,29 @@ export default function DashboardV2 ({
       <SystemStrip
         sseEndpoint={sseEndpoint}
         onConfigure={onConfigure}
+        onResetDashboardConfig={handleResetDashboardConfig}
       />
 
       {/* Primary metric row */}
       <div className='row' style={{ margin: 0, gap: '1rem', display: 'flex', flexWrap: 'wrap' }}>
         <div style={{ flex: '2 1 300px', minWidth: 0 }}>
-          <TemperatureTile globalRange={globalRange} alert={tempAlert} />
+          {tempState.configured
+            ? <div data-testid='dashboard-tile-temperature'><TemperatureTile globalRange={globalRange} alert={tempAlert} /></div>
+            : <NotConfiguredTile resource='temperature' />}
         </div>
         <div style={{ flex: '1 1 200px', minWidth: 0 }}>
-          <PhTile globalRange={globalRange} alert={phAlert} />
+          {phState.configured
+            ? <div data-testid='dashboard-tile-ph'><PhTile globalRange={globalRange} alert={phAlert} /></div>
+            : <NotConfiguredTile resource='ph' />}
         </div>
       </div>
 
       {/* Secondary metric row */}
       <div className='row' style={{ margin: 0 }}>
         <div style={{ flex: '1 1 200px', minWidth: 0 }}>
-          <AtoTile globalRange={globalRange} targetLevel={targetAtoLevel} alert={atoAlert} />
+          {atoState.configured
+            ? <div data-testid='dashboard-tile-ato'><AtoTile globalRange={globalRange} targetLevel={targetAtoLevel} alert={atoAlert} /></div>
+            : <NotConfiguredTile resource='ato' />}
         </div>
       </div>
 
@@ -105,6 +292,9 @@ export default function DashboardV2 ({
 
 DashboardV2.propTypes = {
   equipment: PropTypes.array,
+  temperatureControllers: PropTypes.array,
+  phProbes: PropTypes.array,
+  atos: PropTypes.array,
   onToggle: PropTypes.func,
   onConfigure: PropTypes.func,
   sseEndpoint: PropTypes.string,

--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { act } from 'react'
+import { createRoot } from 'react-dom/client'
 import { renderToStaticMarkup } from 'react-dom/server'
 
 let mockAlerts = []
@@ -6,16 +7,53 @@ jest.mock('../hooks/useAlertsStore', () => ({
   useAlertsStore: () => ({ alerts: mockAlerts })
 }))
 
+jest.mock('./SystemStrip', () => function MockSystemStrip (props) {
+  return <section data-testid='system-strip' data-sse-endpoint={props.sseEndpoint} />
+})
+jest.mock('./TemperatureTile', () => function MockTemperatureTile (props) {
+  return <section data-testid='temperature-tile' data-global-range={props.globalRange} data-alert={JSON.stringify(props.alert || null)} />
+})
+jest.mock('./PhTile', () => function MockPhTile (props) {
+  return <section data-testid='ph-tile' data-global-range={props.globalRange} data-alert={JSON.stringify(props.alert || null)} />
+})
+jest.mock('./AtoTile', () => function MockAtoTile (props) {
+  return <section data-testid='ato-tile' data-global-range={props.globalRange} data-target-level={props.targetLevel} data-alert={JSON.stringify(props.alert || null)} />
+})
+jest.mock('./EquipmentStrip', () => function MockEquipmentStrip (props) {
+  return <section data-testid='equipment-strip' data-items={props.items?.length || 0} data-toggle={props.onToggle ? 'yes' : 'no'} />
+})
+
 import DashboardV2 from './DashboardV2'
-import AtoTile from './AtoTile'
-import EquipmentStrip from './EquipmentStrip'
-import PhTile from './PhTile'
-import SystemStrip from './SystemStrip'
-import TemperatureTile from './TemperatureTile'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+function renderDashboard (props = {}) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  act(() => {
+    root.render(<DashboardV2 {...props} />)
+  })
+
+  return {
+    container,
+    root,
+    cleanup: () => {
+      act(() => root.unmount())
+      container.remove()
+    }
+  }
+}
+
+function dataAlert (container, testId) {
+  return JSON.parse(container.querySelector(`[data-testid="${testId}"]`).getAttribute('data-alert'))
+}
 
 describe('design-system DashboardV2', () => {
   beforeEach(() => {
     mockAlerts = []
+    window.localStorage.clear()
   })
 
   afterEach(() => {
@@ -34,8 +72,11 @@ describe('design-system DashboardV2', () => {
     window.FEATURE_FLAGS = { dashboard_v2: true }
     const onToggle = jest.fn()
     const equipment = [{ id: 'pump', name: 'Pump', state: 'on' }]
-    const tree = DashboardV2({
+    const { container, cleanup } = renderDashboard({
       equipment,
+      temperatureControllers: [{ id: '1' }],
+      phProbes: [{ id: '1' }],
+      atos: [{ id: '1' }],
       onToggle,
       sseEndpoint: '/api/alerts',
       globalRange: '7d',
@@ -43,18 +84,15 @@ describe('design-system DashboardV2', () => {
       children: <span>Legacy dashboard</span>
     })
 
-    const rows = tree.props.children
-    expect(tree.props['data-testid']).toBe('smoke-dashboard-v2')
-    expect(rows[0].type).toBe(SystemStrip)
-    expect(rows[0].props.sseEndpoint).toBe('/api/alerts')
-    expect(rows[1].props.children[0].props.children.type).toBe(TemperatureTile)
-    expect(rows[1].props.children[0].props.children.props.globalRange).toBe('7d')
-    expect(rows[1].props.children[1].props.children.type).toBe(PhTile)
-    expect(rows[2].props.children.props.children.type).toBe(AtoTile)
-    expect(rows[2].props.children.props.children.props.targetLevel).toBe(50)
-    expect(rows[3].type).toBe(EquipmentStrip)
-    expect(rows[3].props.items).toBe(equipment)
-    expect(rows[3].props.onToggle).toBe(onToggle)
+    expect(container.querySelector('[data-testid="smoke-dashboard-v2"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="system-strip"]').getAttribute('data-sse-endpoint')).toBe('/api/alerts')
+    expect(container.querySelector('[data-testid="temperature-tile"]').getAttribute('data-global-range')).toBe('7d')
+    expect(container.querySelector('[data-testid="ph-tile"]').getAttribute('data-global-range')).toBe('7d')
+    expect(container.querySelector('[data-testid="ato-tile"]').getAttribute('data-target-level')).toBe('50')
+    expect(container.querySelector('[data-testid="equipment-strip"]').getAttribute('data-items')).toBe('1')
+    expect(container.querySelector('[data-testid="equipment-strip"]').getAttribute('data-toggle')).toBe('yes')
+
+    cleanup()
   })
 
   it('maps unacknowledged alert-center messages to matching tiles', () => {
@@ -66,24 +104,31 @@ describe('design-system DashboardV2', () => {
       { title: 'Temperature old', detail: 'acknowledged alert', severity: 'critical', ts: 104, acknowledged: true }
     ]
 
-    const tree = DashboardV2({ equipment: [], sseEndpoint: '/api/alerts' })
-    const rows = tree.props.children
+    const { container, cleanup } = renderDashboard({
+      equipment: [],
+      temperatureControllers: [{ id: '1' }],
+      phProbes: [{ id: '1' }],
+      atos: [{ id: '1' }],
+      sseEndpoint: '/api/alerts'
+    })
 
-    expect(rows[1].props.children[0].props.children.props.alert).toEqual({
+    expect(dataAlert(container, 'temperature-tile')).toEqual({
       severity: 'critical',
       message: 'Water temperature exceeded limit',
       at: 101
     })
-    expect(rows[1].props.children[1].props.children.props.alert).toEqual({
+    expect(dataAlert(container, 'ph-tile')).toEqual({
       severity: 'warn',
       message: 'pH warning',
       at: 102
     })
-    expect(rows[2].props.children.props.children.props.alert).toEqual({
+    expect(dataAlert(container, 'ato-tile')).toEqual({
       severity: 'warn',
       message: 'Water level low',
       at: 103
     })
+
+    cleanup()
   })
 
   it('leaves tile alerts unset when no alert keywords match', () => {
@@ -92,10 +137,17 @@ describe('design-system DashboardV2', () => {
       { title: 'Camera offline', detail: 'No recent images', severity: 'critical', ts: 105 }
     ]
 
-    const rows = DashboardV2({ equipment: [] }).props.children
+    const { container, cleanup } = renderDashboard({
+      equipment: [],
+      temperatureControllers: [{ id: '1' }],
+      phProbes: [{ id: '1' }],
+      atos: [{ id: '1' }]
+    })
 
-    expect(rows[1].props.children[0].props.children.props.alert).toBeUndefined()
-    expect(rows[1].props.children[1].props.children.props.alert).toBeUndefined()
-    expect(rows[2].props.children.props.children.props.alert).toBeUndefined()
+    expect(dataAlert(container, 'temperature-tile')).toBeNull()
+    expect(dataAlert(container, 'ph-tile')).toBeNull()
+    expect(dataAlert(container, 'ato-tile')).toBeNull()
+
+    cleanup()
   })
 })

--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/SystemStrip.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/SystemStrip.jsx
@@ -15,8 +15,8 @@ function healthFromAlerts (alerts) {
 }
 
 const PILL_COLORS = {
-  ok:       'var(--reefpi-color-brand)',
-  warn:     'var(--reefpi-color-warn)',
+  ok: 'var(--reefpi-color-brand)',
+  warn: 'var(--reefpi-color-warn)',
   critical: 'var(--reefpi-color-error)'
 }
 
@@ -27,6 +27,7 @@ export default function SystemStrip ({
   alerts = [],
   onAlertClick,
   onConfigure,
+  onResetDashboardConfig,
   onSignOut
 }) {
   const [menuOpen, setMenuOpen] = React.useState(false)
@@ -73,28 +74,32 @@ export default function SystemStrip ({
       />
 
       {/* Tank name */}
-      <span style={{
-        fontSize: '0.9rem',
-        fontWeight: 500,
-        color: 'var(--reefpi-color-text)',
-        whiteSpace: 'nowrap',
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        flex: '1 1 auto',
-        minWidth: 0
-      }}>
+      <span
+        style={{
+          fontSize: '0.9rem',
+          fontWeight: 500,
+          color: 'var(--reefpi-color-text)',
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          flex: '1 1 auto',
+          minWidth: 0
+        }}
+      >
         {displayName}
       </span>
 
       {/* Uptime + version (hidden on very narrow viewports via flex shrink) */}
       {(uptimeLabel || version) && (
-        <span style={{
-          fontSize: '0.72rem',
-          color: 'var(--reefpi-color-text-muted)',
-          whiteSpace: 'nowrap',
-          flexShrink: 1,
-          overflow: 'hidden'
-        }}>
+        <span
+          style={{
+            fontSize: '0.72rem',
+            color: 'var(--reefpi-color-text-muted)',
+            whiteSpace: 'nowrap',
+            flexShrink: 1,
+            overflow: 'hidden'
+          }}
+        >
           {[uptimeLabel, version].filter(Boolean).join(' · ')}
         </span>
       )}
@@ -127,10 +132,15 @@ export default function SystemStrip ({
             flexShrink: 0
           }}
         >
-          <span style={{
-            width: '6px', height: '6px', borderRadius: '50%',
-            background: 'currentColor', flexShrink: 0
-          }} />
+          <span
+            style={{
+              width: '6px',
+              height: '6px',
+              borderRadius: '50%',
+              background: 'currentColor',
+              flexShrink: 0
+            }}
+          />
           {alertCount} alert{alertCount !== 1 ? 's' : ''}
         </button>
       )}
@@ -157,8 +167,8 @@ export default function SystemStrip ({
           }}
         >
           <svg width='4' height='16' viewBox='0 0 4 16' fill='currentColor' aria-hidden='true'>
-            <circle cx='2' cy='2'  r='1.5' />
-            <circle cx='2' cy='8'  r='1.5' />
+            <circle cx='2' cy='2' r='1.5' />
+            <circle cx='2' cy='8' r='1.5' />
             <circle cx='2' cy='14' r='1.5' />
           </svg>
         </button>
@@ -185,6 +195,13 @@ export default function SystemStrip ({
               style={menuItemStyle}
             >
               Configure
+            </button>
+            <button
+              role='menuitem'
+              onClick={() => { setMenuOpen(false); onResetDashboardConfig?.() }}
+              style={{ ...menuItemStyle, borderTop: '1px solid var(--reefpi-color-border)' }}
+            >
+              Reset dashboard config
             </button>
             <button
               role='menuitem'
@@ -223,5 +240,6 @@ SystemStrip.propTypes = {
   })),
   onAlertClick: PropTypes.func,
   onConfigure: PropTypes.func,
+  onResetDashboardConfig: PropTypes.func,
   onSignOut: PropTypes.func
 }

--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/SystemStrip.test.js
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/SystemStrip.test.js
@@ -30,6 +30,7 @@ describe('design-system SystemStrip', () => {
   it('opens menu, invokes actions, and closes on outside pointer down', () => {
     const onAlertClick = jest.fn()
     const onConfigure = jest.fn()
+    const onResetDashboardConfig = jest.fn()
     const onSignOut = jest.fn()
     const container = document.createElement('div')
     document.body.appendChild(container)
@@ -41,6 +42,7 @@ describe('design-system SystemStrip', () => {
           alerts={[{ severity: 'warn' }]}
           onAlertClick={onAlertClick}
           onConfigure={onConfigure}
+          onResetDashboardConfig={onResetDashboardConfig}
           onSignOut={onSignOut}
         />
       )
@@ -54,12 +56,19 @@ describe('design-system SystemStrip', () => {
     act(() => menuButton.click())
     expect(container.querySelector('[role="menu"]')).not.toBeNull()
 
-    act(() => container.querySelectorAll('[role="menuitem"]')[0].click())
+    const menuItemNamed = name => Array.from(container.querySelectorAll('[role="menuitem"]'))
+      .find(item => item.textContent === name)
+
+    act(() => menuItemNamed('Configure').click())
     expect(onConfigure).toHaveBeenCalled()
     expect(container.querySelector('[role="menu"]')).toBeNull()
 
     act(() => menuButton.click())
-    act(() => container.querySelectorAll('[role="menuitem"]')[1].click())
+    act(() => menuItemNamed('Reset dashboard config').click())
+    expect(onResetDashboardConfig).toHaveBeenCalled()
+
+    act(() => menuButton.click())
+    act(() => menuItemNamed('Sign out').click())
     expect(onSignOut).toHaveBeenCalled()
 
     act(() => menuButton.click())

--- a/front-end/e2e/specs/dashboard-and-responsive.spec.js
+++ b/front-end/e2e/specs/dashboard-and-responsive.spec.js
@@ -53,6 +53,38 @@ test('stale dashboard config shows no error toasts', async ({ page, baseURL }) =
   await expect(page.locator('.alert-danger')).toHaveCount(0)
 })
 
+test('prunes orphaned dashboard chart subscriptions from local storage', async ({ page, baseURL }) => {
+  const api = await createSmokeApi(baseURL)
+
+  try {
+    await seedDashboard(api)
+  } finally {
+    await api.dispose()
+  }
+
+  await page.addInitScript(() => {
+    window.localStorage.setItem('dashboard_config', JSON.stringify({
+      subscriptions: [
+        { resource: 'temperature', id: '999', metric: 'temperature.display' }
+      ]
+    }))
+  })
+
+  const navBar = new NavBar(page)
+  await page.goto('/')
+  await navBar.expectShell()
+
+  const dashboard = page.getByTestId('smoke-dashboard-v2')
+  await expect(dashboard).toBeVisible()
+  const temperatureTile = page.getByTestId('dashboard-tile-temperature')
+  await expect(temperatureTile).toContainText('Not configured')
+  await expect(temperatureTile).toContainText('Configure temperature probe')
+  await expect(temperatureTile).not.toContainText('HTTP 404')
+  await expect(temperatureTile).not.toContainText('Retry')
+
+  await expect.poll(async () => page.evaluate(() => window.localStorage.getItem('dashboard_config'))).not.toContain('999')
+})
+
 test.describe('mobile shell', () => {
   test.use({ viewport: { width: 390, height: 844 } })
 

--- a/front-end/src/dashboard/main.jsx
+++ b/front-end/src/dashboard/main.jsx
@@ -232,6 +232,9 @@ export class RawDashboardMain extends React.Component {
     return (
       <DashboardV2
         equipment={this.props.equipment}
+        temperatureControllers={this.props.temperatureControllers}
+        phProbes={this.props.phProbes}
+        atos={this.props.atos}
         onToggle={this.handleEquipmentToggle}
         onConfigure={this.handleToggle}
         sseEndpoint='/api/alerts'
@@ -245,7 +248,10 @@ export class RawDashboardMain extends React.Component {
 const mapStateToProps = state => {
   return {
     config: state.dashboard,
-    equipment: state.equipment
+    equipment: state.equipment,
+    temperatureControllers: state.tcs,
+    phProbes: state.phprobes,
+    atos: state.atos
   }
 }
 


### PR DESCRIPTION
## Summary
- Validate dashboard chart subscriptions against the current Temperature, pH, and ATO entities before rendering charts.
- Render a gentle Not configured state and prune orphaned dashboard_config subscriptions from localStorage.
- Add a Reset dashboard config action to the dashboard system menu.
- Add Playwright coverage for pruning a stale temperature subscription.

## Root Cause
Dashboard chart config can persist references to deleted entities. The dashboard rendered chart tiles without checking whether the referenced entity still exists, so tiles attempted stale stats requests and fell into the inline HTTP 404 retry state.

## Validation
- yarn build
- playwright test front-end/e2e/specs/dashboard-and-responsive.spec.js --project=smoke-chromium
- standard front-end/e2e/specs/dashboard-and-responsive.spec.js front-end/src/dashboard/main.jsx front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.jsx front-end/design-system/ui_kits/reef-pi-app/dashboard/SystemStrip.jsx