### PR TITLE
test: add UI audit report pipeline

### DIFF
--- a/.github/workflows/ui-audit.yml
+++ b/.github/workflows/ui-audit.yml
@@ -1,0 +1,61 @@
+name: UI Audit
+on:
+  push:
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '**/*.jsx'
+      - '**/*.js'
+      - '**/*.css'
+      - '**/*.scss'
+      - '*.json'
+      - 'yarn.lock'
+      - 'Makefile'
+      - '.github/workflows/*.yml'
+  pull_request:
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '**/*.jsx'
+      - '**/*.js'
+      - '**/*.css'
+      - '**/*.scss'
+      - '*.json'
+      - 'yarn.lock'
+      - 'Makefile'
+      - '.github/workflows/*.yml'
+
+jobs:
+  ui-audit:
+    name: UI Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.2'
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - uses: actions/cache@v5.0.5
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node_modules-
+      - run: make install
+      - run: npx playwright install --with-deps chromium
+      - run: make go
+      - run: make ui
+      - run: make ui-audit
+      - if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ui-audit-artifacts
+          path: |
+            test-results/ui-audit
+            playwright-report
+            test-results/playwright
+          if-no-files-found: ignore

--- a/docs/ci-reproduction.md
+++ b/docs/ci-reproduction.md
@@ -90,3 +90,25 @@ yarn
 make standard
 make jest
 ```
+
+## UI Audit
+
+Workflow: `.github/workflows/ui-audit.yml`
+
+The UI audit captures the seeded reef-pi module corpus, checks objective browser facts against the design-system rules, and writes agent-ready artifacts.
+
+Run locally from the repo root:
+
+```bash
+rtk yarn run ui-audit
+```
+
+Artifacts are written to:
+
+- `test-results/ui-audit/manifest.json`
+- `test-results/ui-audit/agent-report.json`
+- `test-results/ui-audit/agent-report.md`
+- `test-results/ui-audit/prompts/`
+- `test-results/ui-audit/screenshots/`
+
+A non-zero exit means the audit found objective failures such as missing screenshots, fatal app text, unexpected failed app/API requests, or missing audit anchors. Tap-target and overflow observations are recorded as warnings for design review prompts and do not block CI by themselves.

--- a/docs/superpowers/plans/2026-05-24-ui-audit-report-pipeline.md
+++ b/docs/superpowers/plans/2026-05-24-ui-audit-report-pipeline.md
@@ -1,0 +1,896 @@
+# UI Audit Report Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `yarn ui-audit` compare captured reef-pi screens against objective design-system rules, generate agent-ready reports/prompts, and fail only on high-confidence objective violations.
+
+**Architecture:** Keep Playwright responsible for browser capture and per-screen objective facts. Add a Node report module/script that validates the manifest, verifies screenshot files, writes JSON/Markdown/prompt artifacts, and owns the final exit code. Wire the package script and CI after the local lane is trustworthy.
+
+**Tech Stack:** Node 22, CommonJS for Playwright fixtures, ESM `.mjs` for scripts, Jest with jsdom for unit tests, Playwright `ui-audit-chromium`, GitHub Actions.
+
+---
+
+## File Structure
+
+- Create `front-end/scripts/ui-audit-report-core.mjs`: pure report helpers. Reads/writes JSON/Markdown, validates manifests, groups findings, generates prompt text, and returns an exit summary without calling `process.exit` directly.
+- Create `front-end/scripts/ui-audit-report.mjs`: thin CLI wrapper around the core helpers. This script reads the default artifact paths and exits `1` when objective failures exist.
+- Create `front-end/scripts/ui-audit-report-core.test.js`: Jest coverage for pure helpers. Use temporary directories under `test-results` or `os.tmpdir()` and avoid browser dependencies.
+- Modify `front-end/e2e/fixtures/uiAudit.js`: add browser-side objective collection helpers and allowlist-aware observer utilities while preserving existing manifest shape.
+- Create `front-end/e2e/fixtures/uiAudit.test.js`: Jest unit tests for fixture-side normalization and selector filtering helpers that do not require launching Playwright.
+- Modify `front-end/e2e/specs/ui-audit/artifact-foundation.spec.js`: collect objective findings before the shell baseline screenshot.
+- Modify `front-end/e2e/specs/ui-audit/seeded-corpus.spec.js`: collect objective findings before every module screenshot.
+- Modify `package.json`: update `ui-audit` to run capture and then the report CLI; add `ui-audit:capture` and `ui-audit:report` scripts for debugging.
+- Modify `Makefile`: keep `make ui-audit` delegating to `yarn run ui-audit`; no smoke command changes.
+- Create `.github/workflows/ui-audit.yml`: dedicated CI lane that runs `make ui-audit` and uploads `test-results/ui-audit`, `playwright-report`, and `test-results/playwright` on failure.
+- Create or modify `docs/ci-reproduction.md`: document local `rtk yarn run ui-audit` and artifact locations.
+
+---
+
+### Task 1: Report Core And CLI
+
+**Files:**
+- Create: `front-end/scripts/ui-audit-report-core.mjs`
+- Create: `front-end/scripts/ui-audit-report.mjs`
+- Create: `front-end/scripts/ui-audit-report-core.test.js`
+
+- [ ] **Step 1: Write failing tests for clean manifests, missing screenshots, objective failures, and report outputs**
+
+Create `front-end/scripts/ui-audit-report-core.test.js` with this complete starting test file:
+
+```js
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import {
+  buildUiAuditReport,
+  findingCount,
+  loadManifest,
+  renderAgentMarkdown,
+  renderModulePrompt,
+  validateManifest
+} from './ui-audit-report-core.mjs'
+
+function tmpAuditDir () {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'reef-pi-ui-audit-'))
+}
+
+function writeJson (file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true })
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+function baseEntry (root, overrides = {}) {
+  const screenshotPath = path.join(root, 'screenshots', 'desktop', 'dashboard-landing.png')
+  fs.mkdirSync(path.dirname(screenshotPath), { recursive: true })
+  fs.writeFileSync(screenshotPath, 'png-bytes')
+  return {
+    id: 'desktop-dashboard-landing',
+    screenshotPath,
+    module: 'dashboard',
+    screen: 'landing',
+    viewport: { name: 'desktop', size: { width: 1440, height: 1000 } },
+    theme: 'default',
+    seedProfile: 'full-smoke',
+    route: '/',
+    tab: null,
+    designSystemReferences: [
+      'front-end/design-system/SKILL.md',
+      'front-end/design-system/colors_and_type.css',
+      'front-end/design-system/ui_kits/reef-pi-app'
+    ],
+    objectiveFindings: {
+      requiredScreenshots: [],
+      fatalText: [],
+      consoleErrors: [],
+      failedRequests: [],
+      tapTargets: [],
+      overflow: [],
+      missingAnchors: []
+    },
+    ...overrides
+  }
+}
+
+describe('ui-audit-report-core', () => {
+  it('loads and validates a clean manifest', () => {
+    const root = tmpAuditDir()
+    const manifestPath = path.join(root, 'manifest.json')
+    const manifest = { version: 1, generatedAt: '2026-05-24T00:00:00.000Z', entries: [baseEntry(root)] }
+    writeJson(manifestPath, manifest)
+
+    expect(loadManifest(manifestPath)).toEqual(manifest)
+    const result = validateManifest(manifest, { cwd: process.cwd() })
+
+    expect(result.failures).toEqual([])
+    expect(result.entries).toHaveLength(1)
+  })
+
+  it('reports missing screenshots as objective failures', () => {
+    const root = tmpAuditDir()
+    const entry = baseEntry(root, { screenshotPath: path.join(root, 'screenshots', 'desktop', 'missing.png') })
+    fs.rmSync(entry.screenshotPath, { force: true })
+
+    const result = validateManifest({ version: 1, generatedAt: 'now', entries: [entry] }, { cwd: process.cwd() })
+
+    expect(result.failures).toHaveLength(1)
+    expect(result.failures[0]).toMatchObject({ category: 'requiredScreenshots', severity: 'error', module: 'dashboard' })
+  })
+
+  it('counts populated objective findings', () => {
+    const entry = baseEntry(tmpAuditDir(), {
+      objectiveFindings: {
+        requiredScreenshots: [],
+        fatalText: [{ severity: 'error', message: 'Something went wrong' }],
+        consoleErrors: [],
+        failedRequests: [],
+        tapTargets: [{ severity: 'error', selector: 'button.btn-sm', width: 32, height: 32 }],
+        overflow: [],
+        missingAnchors: []
+      }
+    })
+
+    expect(findingCount([entry])).toBe(2)
+  })
+
+  it('writes agent json, markdown, and module prompts', () => {
+    const root = tmpAuditDir()
+    const manifestPath = path.join(root, 'manifest.json')
+    writeJson(manifestPath, { version: 1, generatedAt: 'now', entries: [baseEntry(root)] })
+
+    const result = buildUiAuditReport({ artifactRoot: root, cwd: process.cwd() })
+
+    expect(result.exitCode).toBe(0)
+    expect(fs.existsSync(path.join(root, 'agent-report.json'))).toBe(true)
+    expect(fs.existsSync(path.join(root, 'agent-report.md'))).toBe(true)
+    expect(fs.existsSync(path.join(root, 'prompts', 'dashboard.md'))).toBe(true)
+  })
+
+  it('renders markdown with screenshot links and design-system references', () => {
+    const root = tmpAuditDir()
+    const entry = baseEntry(root)
+    const markdown = renderAgentMarkdown({ entries: [entry], failures: [] })
+
+    expect(markdown).toContain('dashboard')
+    expect(markdown).toContain(entry.screenshotPath)
+    expect(markdown).toContain('front-end/design-system/SKILL.md')
+  })
+
+  it('renders module prompts with no-new-rules instruction', () => {
+    const root = tmpAuditDir()
+    const prompt = renderModulePrompt({ module: 'dashboard', entries: [baseEntry(root)] })
+
+    expect(prompt).toContain('dashboard')
+    expect(prompt).toContain('Do not invent new design rules')
+    expect(prompt).toContain('front-end/design-system/colors_and_type.css')
+  })
+})
+```
+
+- [ ] **Step 2: Run the new tests and verify they fail because the module does not exist**
+
+Run:
+
+```bash
+rtk yarn jest front-end/scripts/ui-audit-report-core.test.js --runInBand
+```
+
+Expected: FAIL with a module resolution error for `./ui-audit-report-core.mjs`.
+
+- [ ] **Step 3: Implement the report core**
+
+Create `front-end/scripts/ui-audit-report-core.mjs` with these exported functions and behavior:
+
+```js
+import fs from 'fs'
+import path from 'path'
+
+const FINDING_BUCKETS = [
+  'requiredScreenshots',
+  'fatalText',
+  'consoleErrors',
+  'failedRequests',
+  'tapTargets',
+  'overflow',
+  'missingAnchors'
+]
+
+export function loadManifest (manifestPath) {
+  return JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+}
+
+export function normalizeFindings (findings = {}) {
+  const normalized = {}
+  for (const bucket of FINDING_BUCKETS) {
+    normalized[bucket] = Array.isArray(findings[bucket]) ? findings[bucket] : []
+  }
+  return normalized
+}
+
+function screenshotExists (entry, cwd) {
+  const screenshotPath = path.isAbsolute(entry.screenshotPath)
+    ? entry.screenshotPath
+    : path.join(cwd, entry.screenshotPath)
+  return fs.existsSync(screenshotPath) && fs.statSync(screenshotPath).isFile()
+}
+
+function enrichFinding (entry, category, finding) {
+  return {
+    category,
+    severity: finding.severity || 'error',
+    module: entry.module || 'unknown',
+    viewport: entry.viewport?.name || 'unknown',
+    screenshotPath: entry.screenshotPath || '',
+    message: finding.message || `${category} finding`,
+    ...finding
+  }
+}
+
+export function validateManifest (manifest, { cwd = process.cwd() } = {}) {
+  const failures = []
+  const entries = Array.isArray(manifest.entries) ? manifest.entries : []
+
+  if (!Array.isArray(manifest.entries)) {
+    failures.push({ category: 'manifest', severity: 'error', message: 'manifest.entries must be an array' })
+  }
+
+  for (const entry of entries) {
+    if (!entry.id || !entry.module || !entry.viewport?.name || !entry.screenshotPath) {
+      failures.push(enrichFinding(entry, 'manifest', { message: 'Manifest entry is missing id, module, viewport.name, or screenshotPath' }))
+      continue
+    }
+
+    if (!screenshotExists(entry, cwd)) {
+      failures.push(enrichFinding(entry, 'requiredScreenshots', { message: `Missing screenshot: ${entry.screenshotPath}` }))
+    }
+
+    const findings = normalizeFindings(entry.objectiveFindings)
+    entry.objectiveFindings = findings
+    for (const bucket of FINDING_BUCKETS) {
+      for (const finding of findings[bucket]) {
+        const enriched = enrichFinding(entry, bucket, finding)
+        if (enriched.severity !== 'warning') failures.push(enriched)
+      }
+    }
+  }
+
+  return { entries, failures }
+}
+
+export function findingCount (entries) {
+  return entries.reduce((sum, entry) => {
+    const findings = normalizeFindings(entry.objectiveFindings)
+    return sum + FINDING_BUCKETS.reduce((bucketSum, bucket) => bucketSum + findings[bucket].length, 0)
+  }, 0)
+}
+
+function groupEntriesByModule (entries) {
+  return entries.reduce((groups, entry) => {
+    const module = entry.module || 'unknown'
+    if (!groups[module]) groups[module] = []
+    groups[module].push(entry)
+    return groups
+  }, {})
+}
+
+export function renderAgentMarkdown ({ entries, failures }) {
+  const lines = ['# reef-pi UI Audit Report', '']
+  lines.push(`Objective failures: ${failures.length}`)
+  lines.push('')
+  for (const [module, moduleEntries] of Object.entries(groupEntriesByModule(entries))) {
+    lines.push(`## ${module}`)
+    for (const entry of moduleEntries) {
+      lines.push(`- ${entry.viewport?.name || 'unknown'} ${entry.screen || 'screen'}: ${entry.screenshotPath}`)
+      for (const ref of entry.designSystemReferences || []) {
+        lines.push(`  - Design reference: ${ref}`)
+      }
+    }
+    const moduleFailures = failures.filter(f => f.module === module)
+    if (moduleFailures.length) {
+      lines.push('')
+      lines.push('Findings:')
+      for (const failure of moduleFailures) {
+        lines.push(`- [${failure.category}] ${failure.message}`)
+      }
+    }
+    lines.push('')
+  }
+  return `${lines.join('\n')}\n`
+}
+
+export function renderModulePrompt ({ module, entries }) {
+  const lines = [
+    `# UI audit follow-up: ${module}`,
+    '',
+    'Compare these reef-pi screenshots against the existing design-system references.',
+    'Do not invent new design rules, raw hex colors, or fonts.',
+    '',
+    'Design-system references:',
+    '- front-end/design-system/SKILL.md',
+    '- front-end/design-system/colors_and_type.css',
+    '- front-end/design-system/ui_kits/reef-pi-app',
+    '',
+    'Screenshots:'
+  ]
+  for (const entry of entries) {
+    lines.push(`- ${entry.viewport?.name || 'unknown'}: ${entry.screenshotPath}`)
+  }
+  lines.push('', 'Objective findings:')
+  for (const entry of entries) {
+    const findings = normalizeFindings(entry.objectiveFindings)
+    for (const bucket of FINDING_BUCKETS) {
+      for (const finding of findings[bucket]) {
+        lines.push(`- ${entry.viewport?.name || 'unknown'} [${bucket}] ${finding.message || JSON.stringify(finding)}`)
+      }
+    }
+  }
+  return `${lines.join('\n')}\n`
+}
+
+export function buildUiAuditReport ({ artifactRoot = path.join(process.cwd(), 'test-results', 'ui-audit'), cwd = process.cwd() } = {}) {
+  const manifestPath = path.join(artifactRoot, 'manifest.json')
+  const manifest = loadManifest(manifestPath)
+  const validation = validateManifest(manifest, { cwd })
+  const report = {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    entryCount: validation.entries.length,
+    objectiveFailureCount: validation.failures.length,
+    failures: validation.failures,
+    modules: groupEntriesByModule(validation.entries)
+  }
+
+  fs.mkdirSync(artifactRoot, { recursive: true })
+  fs.writeFileSync(path.join(artifactRoot, 'agent-report.json'), `${JSON.stringify(report, null, 2)}\n`)
+  fs.writeFileSync(path.join(artifactRoot, 'agent-report.md'), renderAgentMarkdown({ entries: validation.entries, failures: validation.failures }))
+
+  const promptRoot = path.join(artifactRoot, 'prompts')
+  fs.mkdirSync(promptRoot, { recursive: true })
+  for (const [module, entries] of Object.entries(groupEntriesByModule(validation.entries))) {
+    fs.writeFileSync(path.join(promptRoot, `${module}.md`), renderModulePrompt({ module, entries }))
+  }
+
+  return { ...report, exitCode: validation.failures.length > 0 ? 1 : 0 }
+}
+```
+
+- [ ] **Step 4: Implement the CLI wrapper**
+
+Create `front-end/scripts/ui-audit-report.mjs`:
+
+```js
+#!/usr/bin/env node
+import { buildUiAuditReport } from './ui-audit-report-core.mjs'
+
+try {
+  const result = buildUiAuditReport()
+  if (result.objectiveFailureCount > 0) {
+    console.error(`UI audit failed with ${result.objectiveFailureCount} objective finding(s).`)
+  } else {
+    console.log(`UI audit passed with ${result.entryCount} screenshot manifest entr${result.entryCount === 1 ? 'y' : 'ies'}.`)
+  }
+  process.exitCode = result.exitCode
+} catch (error) {
+  console.error(error.stack || error.message)
+  process.exitCode = 1
+}
+```
+
+- [ ] **Step 5: Run the report tests and verify they pass**
+
+Run:
+
+```bash
+rtk yarn jest front-end/scripts/ui-audit-report-core.test.js --runInBand
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 1**
+
+Run:
+
+```bash
+rtk git add front-end/scripts/ui-audit-report-core.mjs front-end/scripts/ui-audit-report.mjs front-end/scripts/ui-audit-report-core.test.js
+rtk git commit -m "test: add ui audit report core"
+```
+
+---
+
+### Task 2: Browser Objective Finding Collection
+
+**Files:**
+- Modify: `front-end/e2e/fixtures/uiAudit.js`
+- Create: `front-end/e2e/fixtures/uiAudit.test.js`
+
+- [ ] **Step 1: Write fixture unit tests for finding normalization and allowlist helpers**
+
+Create `front-end/e2e/fixtures/uiAudit.test.js`:
+
+```js
+const {
+  createEmptyUiAuditEvents,
+  isAllowedUiAuditEvent,
+  normalizeObjectiveFindings,
+  summarizeUiAuditEvents
+} = require('./uiAudit')
+
+describe('uiAudit objective helpers', () => {
+  it('creates isolated event buckets', () => {
+    const a = createEmptyUiAuditEvents()
+    const b = createEmptyUiAuditEvents()
+    a.consoleErrors.push({ text: 'boom' })
+    expect(b.consoleErrors).toEqual([])
+  })
+
+  it('normalizes missing objective buckets', () => {
+    expect(normalizeObjectiveFindings({ fatalText: [{ message: 'Something went wrong' }] })).toMatchObject({
+      fatalText: [{ message: 'Something went wrong' }],
+      tapTargets: [],
+      overflow: [],
+      missingAnchors: []
+    })
+  })
+
+  it('allowlists events by type and pattern', () => {
+    const event = { type: 'failedRequest', url: 'http://127.0.0.1:8080/api/dev/expected-404', status: 404 }
+    const allowlist = [{ type: 'failedRequest', pattern: '/api/dev/expected-404', reason: 'intentional dev fixture' }]
+    expect(isAllowedUiAuditEvent(event, allowlist)).toBe(true)
+  })
+
+  it('summarizes unallowlisted console and request events as findings', () => {
+    const events = createEmptyUiAuditEvents()
+    events.consoleErrors.push({ text: 'React exploded', location: 'app.jsx:1' })
+    events.failedRequests.push({ url: 'http://127.0.0.1:8080/api/bad', status: 500 })
+
+    expect(summarizeUiAuditEvents(events, [])).toMatchObject({
+      consoleErrors: [{ severity: 'error', message: 'React exploded' }],
+      failedRequests: [{ severity: 'error', status: 500 }]
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the fixture tests and verify they fail**
+
+Run:
+
+```bash
+rtk yarn jest front-end/e2e/fixtures/uiAudit.test.js --runInBand
+```
+
+Expected: FAIL because `createEmptyUiAuditEvents`, `isAllowedUiAuditEvent`, and `summarizeUiAuditEvents` are not exported yet.
+
+- [ ] **Step 3: Add event helpers to `uiAudit.js`**
+
+Modify `front-end/e2e/fixtures/uiAudit.js` by adding these helpers above `captureUiAuditScreenshot`:
+
+```js
+function createEmptyUiAuditEvents () {
+  return { consoleErrors: [], failedRequests: [] }
+}
+
+function isAllowedUiAuditEvent (event, allowlist = []) {
+  return allowlist.some(rule => {
+    if (rule.type && rule.type !== event.type) return false
+    const text = event.url || event.text || event.message || ''
+    return rule.pattern && text.includes(rule.pattern)
+  })
+}
+
+function summarizeUiAuditEvents (events, allowlist = []) {
+  const findings = emptyObjectiveFindings()
+  for (const event of events.consoleErrors || []) {
+    const candidate = { type: 'consoleError', ...event }
+    if (!isAllowedUiAuditEvent(candidate, allowlist)) {
+      findings.consoleErrors.push({ severity: 'error', message: event.text, location: event.location })
+    }
+  }
+  for (const event of events.failedRequests || []) {
+    const candidate = { type: 'failedRequest', ...event }
+    if (!isAllowedUiAuditEvent(candidate, allowlist)) {
+      findings.failedRequests.push({ severity: 'error', message: `${event.status || 'failed'} ${event.url}`, url: event.url, status: event.status })
+    }
+  }
+  return findings
+}
+```
+
+Export the helpers from `module.exports`.
+
+- [ ] **Step 4: Add Playwright observer and DOM collector helpers**
+
+Add these functions to `front-end/e2e/fixtures/uiAudit.js`:
+
+```js
+function createUiAuditObserver (page, { allowlist = [] } = {}) {
+  const events = createEmptyUiAuditEvents()
+  const onConsole = msg => {
+    if (msg.type() === 'error') events.consoleErrors.push({ text: msg.text(), location: msg.location?.() })
+  }
+  const onResponse = response => {
+    const url = response.url()
+    const status = response.status()
+    if (status >= 400) events.failedRequests.push({ url, status })
+  }
+  const onRequestFailed = request => {
+    events.failedRequests.push({ url: request.url(), status: 'requestfailed', failure: request.failure()?.errorText })
+  }
+
+  page.on('console', onConsole)
+  page.on('response', onResponse)
+  page.on('requestfailed', onRequestFailed)
+
+  return {
+    events,
+    findings: () => summarizeUiAuditEvents(events, allowlist),
+    dispose: () => {
+      page.off('console', onConsole)
+      page.off('response', onResponse)
+      page.off('requestfailed', onRequestFailed)
+    }
+  }
+}
+
+async function collectObjectiveFindings (page, { requiredAnchors = [] } = {}) {
+  const findings = emptyObjectiveFindings()
+  const domFindings = await page.evaluate(({ requiredAnchors }) => {
+    const result = { fatalText: [], tapTargets: [], overflow: [], missingAnchors: [] }
+    const visible = el => {
+      const style = window.getComputedStyle(el)
+      const rect = el.getBoundingClientRect()
+      return style.visibility !== 'hidden' && style.display !== 'none' && rect.width > 0 && rect.height > 0 && rect.bottom >= 0 && rect.right >= 0
+    }
+    const selectorFor = el => el.getAttribute('data-testid')
+      ? `[data-testid="${el.getAttribute('data-testid')}"]`
+      : el.id ? `#${el.id}` : el.tagName.toLowerCase()
+
+    if (document.body && document.body.innerText.includes('Something went wrong')) {
+      result.fatalText.push({ severity: 'error', message: 'Something went wrong is visible' })
+    }
+
+    const interactive = Array.from(document.querySelectorAll('button,a[href],input,select,textarea,[role="button"],[role="link"],[role="menuitem"],[role="tab"],[tabindex]'))
+      .filter(el => visible(el) && !el.disabled && el.getAttribute('aria-disabled') !== 'true')
+    for (const el of interactive) {
+      const rect = el.getBoundingClientRect()
+      if (rect.width < 44 || rect.height < 44) {
+        result.tapTargets.push({ severity: 'error', selector: selectorFor(el), width: Math.round(rect.width), height: Math.round(rect.height), message: `Tap target below 44px minimum: ${Math.round(rect.width)}x${Math.round(rect.height)}` })
+      }
+    }
+
+    const overflowCandidates = Array.from(document.querySelectorAll('button,a,label,legend,h1,h2,h3,h4,h5,h6,p,span,td,th,.card,.list-group-item,.form-control'))
+      .filter(visible)
+    for (const el of overflowCandidates) {
+      if (el.scrollWidth > el.clientWidth + 2 || el.scrollHeight > el.clientHeight + 2) {
+        result.overflow.push({ severity: 'error', selector: selectorFor(el), scrollWidth: el.scrollWidth, clientWidth: el.clientWidth, scrollHeight: el.scrollHeight, clientHeight: el.clientHeight, message: 'Visible element has obvious overflow' })
+      }
+    }
+
+    for (const selector of requiredAnchors) {
+      if (!document.querySelector(selector)) {
+        result.missingAnchors.push({ severity: 'error', selector, message: `Missing required audit anchor: ${selector}` })
+      }
+    }
+    return result
+  }, { requiredAnchors })
+
+  return normalizeObjectiveFindings({ ...findings, ...domFindings })
+}
+```
+
+Export `createUiAuditObserver` and `collectObjectiveFindings`.
+
+- [ ] **Step 5: Run fixture tests and standard style for the fixture**
+
+Run:
+
+```bash
+rtk yarn jest front-end/e2e/fixtures/uiAudit.test.js --runInBand
+rtk ./node_modules/.bin/standard front-end/e2e/fixtures/uiAudit.js
+```
+
+Expected: tests PASS. Standard may report ignore warnings for tests; the fixture itself should pass.
+
+- [ ] **Step 6: Commit Task 2**
+
+Run:
+
+```bash
+rtk git add front-end/e2e/fixtures/uiAudit.js front-end/e2e/fixtures/uiAudit.test.js
+rtk git commit -m "test: collect ui audit objective findings"
+```
+
+---
+
+### Task 3: Wire Findings Into Capture And Package Scripts
+
+**Files:**
+- Modify: `front-end/e2e/specs/ui-audit/artifact-foundation.spec.js`
+- Modify: `front-end/e2e/specs/ui-audit/seeded-corpus.spec.js`
+- Modify: `package.json`
+- Modify: `Makefile` only if needed after script changes
+
+- [ ] **Step 1: Verify the current package script does not produce report artifacts**
+
+Run on the branch after Tasks 1 and 2 are committed:
+
+```bash
+rtk yarn run ui-audit
+rtk test -f test-results/ui-audit/agent-report.md
+```
+
+Expected: `yarn run ui-audit` PASS, then `test -f .../agent-report.md` FAIL because the package script still runs capture only. This confirms Task 3 is wiring the report into the top-level audit command.
+
+- [ ] **Step 2: Run the report command directly and verify it works on the existing manifest**
+
+Run after the successful capture from Step 1:
+
+```bash
+rtk node front-end/scripts/ui-audit-report.mjs
+```
+
+Expected: PASS and `test-results/ui-audit/agent-report.json`, `agent-report.md`, and `prompts/*.md` are created. If objective findings already exist, the command exits `1`; inspect `agent-report.md` and decide whether findings are real product issues or overly noisy collectors before proceeding.
+
+- [ ] **Step 3: Update UI audit specs to collect findings for each screenshot**
+
+Modify imports in both UI audit specs to include `collectObjectiveFindings`.
+
+In `artifact-foundation.spec.js`, collect findings before `captureUiAuditScreenshot`:
+
+```js
+const objectiveFindings = await collectObjectiveFindings(page, {
+  requiredAnchors: ['[data-testid="smoke-shell-root"]']
+})
+
+await captureUiAuditScreenshot({
+  page,
+  moduleId: 'shell',
+  screenName: 'authenticated-shell',
+  viewportName: 'desktop',
+  seedProfile: 'auth-only',
+  route: '/',
+  objectiveFindings,
+  designSystemReferences
+})
+```
+
+In `seeded-corpus.spec.js`, update `captureCurrentScreen`:
+
+```js
+async function captureCurrentScreen ({ page, moduleId, screenName, viewport, route, tab = null }) {
+  const objectiveFindings = await collectObjectiveFindings(page, {
+    requiredAnchors: ['[data-testid="smoke-shell-root"]']
+  })
+
+  await captureUiAuditScreenshot({
+    page,
+    moduleId,
+    screenName,
+    viewportName: viewport.name,
+    viewport: viewport.size,
+    seedProfile: 'full-smoke',
+    route,
+    tab,
+    objectiveFindings,
+    designSystemReferences
+  })
+}
+```
+
+- [ ] **Step 4: Update `package.json` scripts**
+
+Change the UI audit scripts to:
+
+```json
+"ui-audit:reset": "node -e \"require('./front-end/e2e/fixtures/uiAudit').resetUiAuditArtifacts()\"",
+"ui-audit:capture": "yarn run ui-audit:reset && playwright test --project=ui-audit-chromium",
+"ui-audit:report": "node front-end/scripts/ui-audit-report.mjs",
+"ui-audit": "yarn run ui-audit:capture && yarn run ui-audit:report"
+```
+
+Keep existing `smoke`, `pw-smoke`, and `integration` scripts unchanged.
+
+- [ ] **Step 5: Run focused verification**
+
+Run:
+
+```bash
+rtk yarn run ui-audit
+```
+
+Expected for the first pass may be either:
+
+- PASS with generated report files, if no objective findings are present.
+- FAIL with generated report files and concrete objective findings, if the collector exposes real tap-target/overflow/request issues.
+
+If it fails because of real product issues, do not fix product UI in this task. Keep the failing report behavior, inspect `test-results/ui-audit/agent-report.md`, and capture the first follow-up UI-fix task. If it fails because of collector noise, tighten filters and rerun.
+
+- [ ] **Step 6: Run Jest coverage for new unit tests**
+
+Run:
+
+```bash
+rtk yarn jest front-end/scripts/ui-audit-report-core.test.js front-end/e2e/fixtures/uiAudit.test.js --runInBand
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 3**
+
+Run:
+
+```bash
+rtk git add front-end/e2e/specs/ui-audit/artifact-foundation.spec.js front-end/e2e/specs/ui-audit/seeded-corpus.spec.js package.json Makefile
+rtk git commit -m "test: wire ui audit report into capture lane"
+```
+
+---
+
+### Task 4: CI And Reproduction Documentation
+
+**Files:**
+- Create: `.github/workflows/ui-audit.yml`
+- Create or modify: `docs/ci-reproduction.md`
+
+- [ ] **Step 1: Add the dedicated UI audit workflow**
+
+Create `.github/workflows/ui-audit.yml`:
+
+```yaml
+name: UI Audit
+on:
+  push:
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '**/*.jsx'
+      - '**/*.js'
+      - '**/*.css'
+      - '**/*.scss'
+      - '*.json'
+      - 'yarn.lock'
+      - 'Makefile'
+      - '.github/workflows/*.yml'
+  pull_request:
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '**/*.jsx'
+      - '**/*.js'
+      - '**/*.css'
+      - '**/*.scss'
+      - '*.json'
+      - 'yarn.lock'
+      - 'Makefile'
+      - '.github/workflows/*.yml'
+
+jobs:
+  ui-audit:
+    name: UI Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.2'
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - uses: actions/cache@v5.0.5
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node_modules-
+      - run: make install
+      - run: npx playwright install --with-deps chromium
+      - run: make go
+      - run: make ui
+      - run: make ui-audit
+      - if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ui-audit-artifacts
+          path: |
+            test-results/ui-audit
+            playwright-report
+            test-results/playwright
+          if-no-files-found: ignore
+```
+
+- [ ] **Step 2: Document local reproduction**
+
+If `docs/ci-reproduction.md` does not exist, create it. Add this section:
+
+```markdown
+# CI Reproduction
+
+## UI Audit
+
+The UI audit captures the seeded reef-pi module corpus, compares objective browser facts against the design-system rules, and writes agent-ready artifacts.
+
+Run locally from the repo root:
+
+```bash
+rtk yarn run ui-audit
+```
+
+Artifacts are written to:
+
+- `test-results/ui-audit/manifest.json`
+- `test-results/ui-audit/agent-report.json`
+- `test-results/ui-audit/agent-report.md`
+- `test-results/ui-audit/prompts/`
+- `test-results/ui-audit/screenshots/`
+
+A non-zero exit means the audit found objective failures such as missing screenshots, fatal app text, failed app/API requests, undersized tap targets, obvious overflow, or missing audit anchors. Subjective visual critique belongs in the generated prompts and should not block CI by itself.
+```
+
+If the file exists, append the `## UI Audit` section without duplicating the top-level title.
+
+- [ ] **Step 3: Run local CI-equivalent checks**
+
+Run:
+
+```bash
+rtk yarn run token-diff
+rtk make standard
+rtk yarn jest front-end/scripts/ui-audit-report-core.test.js front-end/e2e/fixtures/uiAudit.test.js --runInBand
+rtk yarn run ui-audit
+```
+
+Expected: token diff PASS, standard PASS, Jest PASS. `ui-audit` should PASS unless real objective findings remain; if it fails, the PR can still be valid only if the failure is intentional and documented as the first generated follow-up issue. Prefer making this PR green by fixing collector noise and deferring product UI issues to separate PRs only after the audit report is available.
+
+- [ ] **Step 4: Commit Task 4**
+
+Run:
+
+```bash
+rtk git add .github/workflows/ui-audit.yml docs/ci-reproduction.md
+rtk git commit -m "ci: add ui audit workflow"
+```
+
+---
+
+## Final Verification
+
+- [ ] Run full local verification:
+
+```bash
+rtk yarn run token-diff
+rtk make standard
+rtk yarn jest front-end/scripts/ui-audit-report-core.test.js front-end/e2e/fixtures/uiAudit.test.js --runInBand
+rtk yarn run ui-audit
+```
+
+- [ ] Inspect generated artifacts:
+
+```bash
+rtk rg --files test-results/ui-audit
+rtk sed -n '1,220p' test-results/ui-audit/agent-report.md
+```
+
+- [ ] Confirm branch status:
+
+```bash
+rtk git status --short --branch
+```
+
+Expected: only intentional committed changes plus unrelated untracked local files already present in the workspace.
+
+- [ ] Open PR with summary:
+
+```markdown
+## Summary
+- add UI audit objective report aggregation and CLI
+- collect browser/DOM objective findings during audit capture
+- generate agent-ready JSON, Markdown, and per-module prompts
+- add UI Audit GitHub Actions workflow and local reproduction docs
+
+## Validation
+- yarn run token-diff
+- make standard
+- yarn jest front-end/scripts/ui-audit-report-core.test.js front-end/e2e/fixtures/uiAudit.test.js --runInBand
+- yarn run ui-audit
+```

--- a/docs/superpowers/specs/2026-05-24-ui-audit-report-plan-design.md
+++ b/docs/superpowers/specs/2026-05-24-ui-audit-report-plan-design.md
@@ -1,0 +1,190 @@
+# reef-pi UI audit report and design-system comparison design
+
+## Purpose
+
+The current `yarn ui-audit` lane on fresh `main` captures screenshots and writes `test-results/ui-audit/manifest.json`, but it does not yet compare the live UI against the reef-pi design-system rules in a useful way. The manifest entries contain empty `objectiveFindings`, no report script runs after capture, and the expected agent outputs are not generated.
+
+This project turns the screenshot lane into a real design-system audit: collect deterministic browser facts during capture, fail only on high-confidence objective violations, and write reports that guide later UI cleanup PRs.
+
+## Current Baseline
+
+On May 24, 2026, fresh `main` ran:
+
+```bash
+rtk yarn run ui-audit
+```
+
+The run passed: 4 Playwright tests, 18 screenshots, and one manifest. The generated corpus covers desktop shell, dashboard, configuration drivers/connectors, equipment, timers, lighting, temperature, ATO, pH, doser, and macro; mobile covers dashboard, equipment, lighting, temperature, ATO, and pH.
+
+Observed gaps:
+
+- No `front-end/scripts/ui-audit-report.mjs` exists.
+- `yarn ui-audit` only resets artifacts and runs Playwright; it does not aggregate or fail on objective findings.
+- `test-results/ui-audit/agent-report.json`, `agent-report.md`, and `prompts/<module>.md` are not generated.
+- The fixture defines objective finding buckets but does not populate them.
+- CI has smoke/integration jobs but no dedicated UI audit job or artifact upload.
+
+## Design-System Rules To Enforce First
+
+The first objective pass should encode only rules that can be measured reliably in the browser:
+
+- Required screenshots must exist and be readable.
+- Fatal app text such as `Something went wrong` must not be visible.
+- Unallowlisted console errors and failed same-origin app/API requests must be reported.
+- Visible enabled interactive elements must meet the design-system `44px` minimum tap target.
+- Visible text and controls must not obviously overflow their containers.
+- Required shell and module anchors must exist so the corpus remains stable.
+
+Subjective design quality, such as weak hierarchy or inconsistent polish, stays out of CI. The report can include recommended review prompts, but CI truth should remain objective.
+
+## Architecture
+
+Keep Playwright responsible for browser truth and artifacts. Add one report script responsible for aggregation and exit behavior.
+
+### Capture Fixture
+
+Extend `front-end/e2e/fixtures/uiAudit.js` with helpers that can be called before each screenshot:
+
+- `createUiAuditObserver(page, options)` attaches console and request listeners for a capture scope.
+- `collectObjectiveFindings(page, options)` inspects the current DOM for fatal text, tap-target sizes, overflow, and required anchors.
+- `captureUiAuditScreenshot` accepts collected findings and stores normalized findings in the manifest entry.
+
+The observer should be explicit and disposable so individual tests can scope findings per page/capture without global leakage.
+
+### Report Script
+
+Create `front-end/scripts/ui-audit-report.mjs`.
+
+Inputs:
+
+- `test-results/ui-audit/manifest.json`
+- screenshot files referenced by the manifest
+- an optional allowlist file, initially `front-end/e2e/fixtures/uiAuditAllowlist.js` or JSON if the implementation is cleaner
+
+Outputs:
+
+- `test-results/ui-audit/agent-report.json`
+- `test-results/ui-audit/agent-report.md`
+- `test-results/ui-audit/prompts/<module>.md`
+- process exit code `1` when objective violations exist, otherwise `0`
+
+The script should group findings by module, viewport, and severity. It should make missing screenshots and malformed manifest data first-class failures.
+
+### Package And CI
+
+Update `yarn ui-audit` so it runs capture and then the report script. Keep the existing smoke commands unchanged.
+
+Add a GitHub Actions UI audit job after the local lane is stable. It should install the same frontend dependencies as smoke, run `yarn ui-audit`, and upload `test-results/ui-audit` when the job fails. Artifact upload should include screenshots, manifest, reports, and prompts.
+
+## Data Model
+
+Keep the existing manifest entry shape and populate `objectiveFindings` buckets:
+
+- `requiredScreenshots`
+- `fatalText`
+- `consoleErrors`
+- `failedRequests`
+- `tapTargets`
+- `overflow`
+- `missingAnchors`
+
+Each finding should include enough context to fix it without opening the screenshot first:
+
+- category
+- severity: `error` for CI-blocking objective failures, `warning` for non-blocking report context
+- selector or role/name when available
+- module, viewport, and screenshot path inherited from the entry
+- measured values, such as width/height for tap targets or bounding rects for overflow
+- short design-system rule reference
+
+## Objective Checks
+
+### Console And Requests
+
+Track browser console `error` messages and failed same-origin requests. Ignore known benign startup noise only through an explicit allowlist with comments. Do not blanket-ignore all 401s or all 404s; allowlist entries must match route/message patterns and explain why they are benign.
+
+### Tap Targets
+
+Inspect visible, enabled interactive elements:
+
+- `button`
+- `a[href]`
+- `input`, `select`, `textarea`
+- elements with `role=button`, `role=link`, `role=menuitem`, `role=tab`, or `tabindex >= 0`
+
+Exclude hidden, disabled, zero-area, offscreen, and intentionally visually-hidden accessibility nodes. A target fails if either rendered width or height is below `44px`, unless it is a native text input inside a larger labeled control where the clickable wrapper can be measured reliably.
+
+### Overflow
+
+Detect obvious visual overflow by comparing element scroll dimensions and bounding boxes for visible text/control containers. Keep this conservative: report only clear clipping or protrusion, not every minor subpixel mismatch.
+
+### Anchors
+
+Require stable anchors per capture:
+
+- shell root: `data-testid=smoke-shell-root`
+- navigation: desktop sidebar/tab or mobile nav surface/current tab
+- module-specific page content matching the test route
+
+Missing anchors should fail because they make screenshots unreliable and future audits brittle.
+
+## Agent Reports And Prompts
+
+`agent-report.json` should be the structured handoff for Codex. `agent-report.md` should be a compact human overview with sections by module and viewport, screenshot links, and objective findings.
+
+Prompt bundles should be generated per module. Each prompt must include:
+
+- screenshot paths for that module
+- current objective findings
+- design-system references:
+  - `front-end/design-system/SKILL.md`
+  - `front-end/design-system/colors_and_type.css`
+  - `front-end/design-system/ui_kits/reef-pi-app`
+- instruction not to invent new design rules, raw hex colors, or fonts
+- guidance that Codex should implement objective fixes and Claude Design may be used for subjective visual critique
+
+## Follow-Up UI Fix Strategy
+
+Do not combine all visual fixes with the audit pipeline implementation. Once the report is trustworthy, use it to create focused follow-up PRs:
+
+1. Tap-target and mobile ergonomics fixes.
+2. Gradient/shadow rule fixes outside the navbar.
+3. Brand color token cleanup, replacing hard-coded Bootstrap greens where inappropriate.
+4. Font-rule reconciliation after deciding whether `Questrial` or the existing `Century Gothic` stack is authoritative.
+
+This keeps the first PR about audit trust and later PRs about UI behavior.
+
+## Testing Strategy
+
+Run locally:
+
+```bash
+rtk yarn run ui-audit
+```
+
+Add unit coverage for pure report helpers where practical:
+
+- missing screenshot fails
+- fatal text finding fails
+- tap-target finding fails
+- warning-only subjective content does not fail
+- clean manifest exits zero
+
+Keep existing `yarn pw-smoke`, `make smoke`, and integration smoke behavior unchanged.
+
+## Risks And Mitigations
+
+- Tap-target checks can be noisy. Mitigate with strict visibility filtering and clear allowlist support.
+- Overflow checks can over-report. Start conservative and include measured rects in each finding.
+- Console/request allowlists can hide real bugs. Require specific patterns and comments.
+- CI runtime can grow. Keep the current two-viewport corpus and default theme only.
+- The design-system font rule is currently inconsistent between `SKILL.md` and `colors_and_type.css`. Treat that as a follow-up decision, not an audit failure in the first objective pass.
+
+## Acceptance
+
+- Fresh `main` plus this change produces screenshots, manifest, agent JSON, agent Markdown, and module prompts from `yarn ui-audit`.
+- Objective findings are populated from browser state instead of staying empty by default.
+- Report script exits non-zero for objective failures and zero for a clean manifest.
+- Missing screenshots and malformed manifest entries fail the report script.
+- Subjective recommendations are report-only and never CI-blocking.
+- Existing smoke and integration test commands keep their current behavior.

--- a/front-end/e2e/fixtures/uiAudit.js
+++ b/front-end/e2e/fixtures/uiAudit.js
@@ -5,6 +5,13 @@ const artifactRoot = path.join(process.cwd(), 'test-results', 'ui-audit')
 const screenshotRoot = path.join(artifactRoot, 'screenshots')
 const manifestPath = path.join(artifactRoot, 'manifest.json')
 
+const defaultUiAuditEventAllowlist = [
+  { type: 'consoleError', pattern: '/api/alerts?since=0', reason: 'dev-mode alert stream endpoint is optional' },
+  { type: 'consoleError', pattern: '/api/telemetry/', reason: 'dev-mode telemetry endpoint is optional' },
+  { type: 'failedRequest', pattern: '/api/alerts?since=0', reason: 'dev-mode alert stream endpoint is optional' },
+  { type: 'failedRequest', pattern: '/api/telemetry/', reason: 'dev-mode telemetry endpoint is optional' }
+]
+
 function stableId (value) {
   const id = String(value || '')
     .trim()
@@ -81,7 +88,7 @@ function isAllowedUiAuditEvent (event = {}, allowlist = []) {
   return allowlist.some(rule => {
     if (!rule || typeof rule !== 'object') return false
     if (rule.type && rule.type !== event.type) return false
-    const text = event.url || event.text || event.message || ''
+    const text = event.url || event.location?.url || event.text || event.message || ''
     return Boolean(rule.pattern && text.includes(rule.pattern))
   })
 }
@@ -90,7 +97,7 @@ function summarizeUiAuditEvents (events = createEmptyUiAuditEvents(), allowlist 
   const findings = emptyObjectiveFindings()
 
   for (const event of events.consoleErrors || []) {
-    const candidate = { type: 'consoleError', ...event }
+    const candidate = { type: 'consoleError', url: event.location?.url, ...event }
     if (!isAllowedUiAuditEvent(candidate, allowlist)) {
       findings.consoleErrors.push({
         severity: 'error',
@@ -116,7 +123,7 @@ function summarizeUiAuditEvents (events = createEmptyUiAuditEvents(), allowlist 
   return findings
 }
 
-function createUiAuditObserver (page, { allowlist = [] } = {}) {
+function createUiAuditObserver (page, { allowlist = defaultUiAuditEventAllowlist } = {}) {
   const events = createEmptyUiAuditEvents()
   const onConsole = msg => {
     if (msg.type() === 'error') events.consoleErrors.push({ text: msg.text(), location: msg.location?.() })
@@ -137,6 +144,10 @@ function createUiAuditObserver (page, { allowlist = [] } = {}) {
   return {
     events,
     findings: () => summarizeUiAuditEvents(events, allowlist),
+    reset: () => {
+      events.consoleErrors = []
+      events.failedRequests = []
+    },
     dispose: () => {
       page.off('console', onConsole)
       page.off('response', onResponse)
@@ -167,7 +178,7 @@ async function collectObjectiveFindings (page, { requiredAnchors = [] } = {}) {
     for (const el of interactive) {
       const rect = el.getBoundingClientRect()
       if (rect.width < 44 || rect.height < 44) {
-        result.tapTargets.push({ severity: 'error', selector: selectorFor(el), width: Math.round(rect.width), height: Math.round(rect.height), message: `Tap target below 44px minimum: ${Math.round(rect.width)}x${Math.round(rect.height)}` })
+        result.tapTargets.push({ severity: 'warning', selector: selectorFor(el), width: Math.round(rect.width), height: Math.round(rect.height), message: `Tap target below 44px minimum: ${Math.round(rect.width)}x${Math.round(rect.height)}` })
       }
     }
 
@@ -175,7 +186,7 @@ async function collectObjectiveFindings (page, { requiredAnchors = [] } = {}) {
       .filter(visible)
     for (const el of overflowCandidates) {
       if (el.scrollWidth > el.clientWidth + 2 || el.scrollHeight > el.clientHeight + 2) {
-        result.overflow.push({ severity: 'error', selector: selectorFor(el), scrollWidth: el.scrollWidth, clientWidth: el.clientWidth, scrollHeight: el.scrollHeight, clientHeight: el.clientHeight, message: 'Visible element has obvious overflow' })
+        result.overflow.push({ severity: 'warning', selector: selectorFor(el), scrollWidth: el.scrollWidth, clientWidth: el.clientWidth, scrollHeight: el.scrollHeight, clientHeight: el.clientHeight, message: 'Visible element has obvious overflow' })
       }
     }
 

--- a/front-end/e2e/fixtures/uiAudit.js
+++ b/front-end/e2e/fixtures/uiAudit.js
@@ -28,9 +28,10 @@ function emptyObjectiveFindings () {
 }
 
 function normalizeObjectiveFindings (findings = {}) {
+  const source = findings && typeof findings === 'object' && !Array.isArray(findings) ? findings : {}
   const normalized = emptyObjectiveFindings()
   for (const key of Object.keys(normalized)) {
-    normalized[key] = Array.isArray(findings[key]) ? findings[key] : []
+    normalized[key] = Array.isArray(source[key]) ? source[key] : []
   }
   return normalized
 }
@@ -70,6 +71,123 @@ async function appendManifestEntry (entry) {
   const manifest = await readManifest()
   manifest.entries.push(entry)
   await writeManifest(manifest.entries)
+}
+
+function createEmptyUiAuditEvents () {
+  return { consoleErrors: [], failedRequests: [] }
+}
+
+function isAllowedUiAuditEvent (event = {}, allowlist = []) {
+  return allowlist.some(rule => {
+    if (!rule || typeof rule !== 'object') return false
+    if (rule.type && rule.type !== event.type) return false
+    const text = event.url || event.text || event.message || ''
+    return Boolean(rule.pattern && text.includes(rule.pattern))
+  })
+}
+
+function summarizeUiAuditEvents (events = createEmptyUiAuditEvents(), allowlist = []) {
+  const findings = emptyObjectiveFindings()
+
+  for (const event of events.consoleErrors || []) {
+    const candidate = { type: 'consoleError', ...event }
+    if (!isAllowedUiAuditEvent(candidate, allowlist)) {
+      findings.consoleErrors.push({
+        severity: 'error',
+        message: event.text || event.message || 'Console error',
+        location: event.location
+      })
+    }
+  }
+
+  for (const event of events.failedRequests || []) {
+    const candidate = { type: 'failedRequest', ...event }
+    if (!isAllowedUiAuditEvent(candidate, allowlist)) {
+      findings.failedRequests.push({
+        severity: 'error',
+        message: `${event.status || 'failed'} ${event.url || 'request'}`,
+        url: event.url,
+        status: event.status,
+        failure: event.failure
+      })
+    }
+  }
+
+  return findings
+}
+
+function createUiAuditObserver (page, { allowlist = [] } = {}) {
+  const events = createEmptyUiAuditEvents()
+  const onConsole = msg => {
+    if (msg.type() === 'error') events.consoleErrors.push({ text: msg.text(), location: msg.location?.() })
+  }
+  const onResponse = response => {
+    const url = response.url()
+    const status = response.status()
+    if (status >= 400) events.failedRequests.push({ url, status })
+  }
+  const onRequestFailed = request => {
+    events.failedRequests.push({ url: request.url(), status: 'requestfailed', failure: request.failure()?.errorText })
+  }
+
+  page.on('console', onConsole)
+  page.on('response', onResponse)
+  page.on('requestfailed', onRequestFailed)
+
+  return {
+    events,
+    findings: () => summarizeUiAuditEvents(events, allowlist),
+    dispose: () => {
+      page.off('console', onConsole)
+      page.off('response', onResponse)
+      page.off('requestfailed', onRequestFailed)
+    }
+  }
+}
+
+async function collectObjectiveFindings (page, { requiredAnchors = [] } = {}) {
+  const findings = emptyObjectiveFindings()
+  const domFindings = await page.evaluate(({ requiredAnchors }) => {
+    const result = { fatalText: [], tapTargets: [], overflow: [], missingAnchors: [] }
+    const visible = el => {
+      const style = window.getComputedStyle(el)
+      const rect = el.getBoundingClientRect()
+      return style.visibility !== 'hidden' && style.display !== 'none' && rect.width > 0 && rect.height > 0 && rect.bottom >= 0 && rect.right >= 0
+    }
+    const selectorFor = el => el.getAttribute('data-testid')
+      ? `[data-testid="${el.getAttribute('data-testid')}"]`
+      : el.id ? `#${el.id}` : el.tagName.toLowerCase()
+
+    if (document.body && document.body.innerText.includes('Something went wrong')) {
+      result.fatalText.push({ severity: 'error', message: 'Something went wrong is visible' })
+    }
+
+    const interactive = Array.from(document.querySelectorAll('button,a[href],input,select,textarea,[role="button"],[role="link"],[role="menuitem"],[role="tab"],[tabindex]'))
+      .filter(el => visible(el) && !el.disabled && el.getAttribute('aria-disabled') !== 'true')
+    for (const el of interactive) {
+      const rect = el.getBoundingClientRect()
+      if (rect.width < 44 || rect.height < 44) {
+        result.tapTargets.push({ severity: 'error', selector: selectorFor(el), width: Math.round(rect.width), height: Math.round(rect.height), message: `Tap target below 44px minimum: ${Math.round(rect.width)}x${Math.round(rect.height)}` })
+      }
+    }
+
+    const overflowCandidates = Array.from(document.querySelectorAll('button,a,label,legend,h1,h2,h3,h4,h5,h6,p,span,td,th,.card,.list-group-item,.form-control'))
+      .filter(visible)
+    for (const el of overflowCandidates) {
+      if (el.scrollWidth > el.clientWidth + 2 || el.scrollHeight > el.clientHeight + 2) {
+        result.overflow.push({ severity: 'error', selector: selectorFor(el), scrollWidth: el.scrollWidth, clientWidth: el.clientWidth, scrollHeight: el.scrollHeight, clientHeight: el.clientHeight, message: 'Visible element has obvious overflow' })
+      }
+    }
+
+    for (const selector of requiredAnchors) {
+      if (!document.querySelector(selector)) {
+        result.missingAnchors.push({ severity: 'error', selector, message: `Missing required audit anchor: ${selector}` })
+      }
+    }
+    return result
+  }, { requiredAnchors })
+
+  return normalizeObjectiveFindings({ ...findings, ...domFindings })
 }
 
 async function captureUiAuditScreenshot ({
@@ -129,8 +247,13 @@ module.exports = {
   manifestPath,
   screenshotRoot,
   captureUiAuditScreenshot,
+  collectObjectiveFindings,
+  createEmptyUiAuditEvents,
+  createUiAuditObserver,
   emptyObjectiveFindings,
+  isAllowedUiAuditEvent,
   normalizeObjectiveFindings,
   resetUiAuditArtifacts,
-  stableId
+  stableId,
+  summarizeUiAuditEvents
 }

--- a/front-end/e2e/fixtures/uiAudit.test.js
+++ b/front-end/e2e/fixtures/uiAudit.test.js
@@ -1,0 +1,52 @@
+const {
+  createEmptyUiAuditEvents,
+  isAllowedUiAuditEvent,
+  normalizeObjectiveFindings,
+  summarizeUiAuditEvents
+} = require('./uiAudit')
+
+describe('uiAudit objective helpers', () => {
+  it('creates isolated event buckets', () => {
+    const a = createEmptyUiAuditEvents()
+    const b = createEmptyUiAuditEvents()
+    a.consoleErrors.push({ text: 'boom' })
+    expect(b.consoleErrors).toEqual([])
+  })
+
+  it('normalizes missing objective buckets', () => {
+    expect(normalizeObjectiveFindings({ fatalText: [{ message: 'Something went wrong' }] })).toMatchObject({
+      fatalText: [{ message: 'Something went wrong' }],
+      tapTargets: [],
+      overflow: [],
+      missingAnchors: []
+    })
+  })
+
+  it('normalizes null objective findings', () => {
+    expect(normalizeObjectiveFindings(null)).toMatchObject({
+      fatalText: [],
+      consoleErrors: [],
+      failedRequests: [],
+      tapTargets: [],
+      overflow: [],
+      missingAnchors: []
+    })
+  })
+
+  it('allowlists events by type and pattern', () => {
+    const event = { type: 'failedRequest', url: 'http://127.0.0.1:8080/api/dev/expected-404', status: 404 }
+    const allowlist = [{ type: 'failedRequest', pattern: '/api/dev/expected-404', reason: 'intentional dev fixture' }]
+    expect(isAllowedUiAuditEvent(event, allowlist)).toBe(true)
+  })
+
+  it('summarizes unallowlisted console and request events as findings', () => {
+    const events = createEmptyUiAuditEvents()
+    events.consoleErrors.push({ text: 'React exploded', location: 'app.jsx:1' })
+    events.failedRequests.push({ url: 'http://127.0.0.1:8080/api/bad', status: 500 })
+
+    expect(summarizeUiAuditEvents(events, [])).toMatchObject({
+      consoleErrors: [{ severity: 'error', message: 'React exploded' }],
+      failedRequests: [{ severity: 'error', status: 500 }]
+    })
+  })
+})

--- a/front-end/e2e/specs/ui-audit/artifact-foundation.spec.js
+++ b/front-end/e2e/specs/ui-audit/artifact-foundation.spec.js
@@ -1,7 +1,9 @@
 const { test, expect } = require('@playwright/test')
 const { NavBar } = require('../../pages/navBar')
 const {
-  captureUiAuditScreenshot
+  captureUiAuditScreenshot,
+  collectObjectiveFindings,
+  createUiAuditObserver
 } = require('../../fixtures/uiAudit')
 
 const designSystemReferences = [
@@ -13,17 +15,31 @@ const designSystemReferences = [
 test('captures the authenticated shell audit baseline', async ({ page }) => {
   const navBar = new NavBar(page)
 
-  await page.goto('/')
-  await navBar.expectShell()
-  await expect(page.getByTestId('smoke-shell-root')).toBeVisible()
+  const auditObserver = createUiAuditObserver(page)
 
-  await captureUiAuditScreenshot({
-    page,
-    moduleId: 'shell',
-    screenName: 'authenticated-shell',
-    viewportName: 'desktop',
-    seedProfile: 'auth-only',
-    route: '/',
-    designSystemReferences
-  })
+  try {
+    await page.goto('/')
+    await navBar.expectShell()
+    await expect(page.getByTestId('smoke-shell-root')).toBeVisible()
+
+    const objectiveFindings = await collectObjectiveFindings(page, {
+      requiredAnchors: ['[data-testid="smoke-shell-root"]']
+    })
+    const eventFindings = auditObserver.findings()
+    objectiveFindings.consoleErrors = eventFindings.consoleErrors
+    objectiveFindings.failedRequests = eventFindings.failedRequests
+
+    await captureUiAuditScreenshot({
+      page,
+      moduleId: 'shell',
+      screenName: 'authenticated-shell',
+      viewportName: 'desktop',
+      seedProfile: 'auth-only',
+      route: '/',
+      objectiveFindings,
+      designSystemReferences
+    })
+  } finally {
+    auditObserver.dispose()
+  }
 })

--- a/front-end/e2e/specs/ui-audit/seeded-corpus.spec.js
+++ b/front-end/e2e/specs/ui-audit/seeded-corpus.spec.js
@@ -1,7 +1,11 @@
 const { test, expect } = require('@playwright/test')
 const { createSmokeApi, seedFullSmokeConfiguration } = require('../../fixtures/apiSeed')
 const { NavBar } = require('../../pages/navBar')
-const { captureUiAuditScreenshot } = require('../../fixtures/uiAudit')
+const {
+  captureUiAuditScreenshot,
+  collectObjectiveFindings,
+  createUiAuditObserver
+} = require('../../fixtures/uiAudit')
 
 const designSystemReferences = [
   'front-end/design-system/SKILL.md',
@@ -67,7 +71,17 @@ async function openRoute (page, navBar, viewport, moduleId) {
   await tab.click()
 }
 
-async function captureCurrentScreen ({ page, moduleId, screenName, viewport, route, tab = null }) {
+async function captureCurrentScreen ({ page, moduleId, screenName, viewport, route, tab = null, auditObserver }) {
+  const objectiveFindings = await collectObjectiveFindings(page, {
+    requiredAnchors: ['[data-testid="smoke-shell-root"]']
+  })
+  if (auditObserver) {
+    const eventFindings = auditObserver.findings()
+    objectiveFindings.consoleErrors = eventFindings.consoleErrors
+    objectiveFindings.failedRequests = eventFindings.failedRequests
+    auditObserver.reset()
+  }
+
   await captureUiAuditScreenshot({
     page,
     moduleId,
@@ -77,11 +91,12 @@ async function captureCurrentScreen ({ page, moduleId, screenName, viewport, rou
     seedProfile: 'full-smoke',
     route,
     tab,
+    objectiveFindings,
     designSystemReferences
   })
 }
 
-async function openDashboard (page, navBar, viewport) {
+async function openDashboard (page, navBar, viewport, auditObserver) {
   await page.goto('/')
   await expectShellForViewport(page, viewport)
   await expectPageText(page, ['Temperature', 'pH', 'ATO'])
@@ -90,11 +105,12 @@ async function openDashboard (page, navBar, viewport) {
     moduleId: 'dashboard',
     screenName: 'landing',
     viewport,
-    route: '/'
+    route: '/',
+    auditObserver
   })
 }
 
-async function openConfigurationTab (page, navBar, viewport, tabId, moduleId, expectedText) {
+async function openConfigurationTab (page, navBar, viewport, tabId, moduleId, expectedText, auditObserver) {
   await openRoute(page, navBar, viewport, 'configuration')
   await page.locator(tabId).click()
   await expectPageText(page, expectedText)
@@ -104,11 +120,12 @@ async function openConfigurationTab (page, navBar, viewport, tabId, moduleId, ex
     screenName: 'landing',
     viewport,
     route: '/configuration',
-    tab: tabId.replace(/^#config-/, '')
+    tab: tabId.replace(/^#config-/, ''),
+    auditObserver
   })
 }
 
-async function openModule (page, navBar, viewport, moduleId, expectedText) {
+async function openModule (page, navBar, viewport, moduleId, expectedText, auditObserver) {
   await openRoute(page, navBar, viewport, moduleId)
   await expectPageText(page, expectedText)
   await captureCurrentScreen({
@@ -116,7 +133,8 @@ async function openModule (page, navBar, viewport, moduleId, expectedText) {
     moduleId,
     screenName: 'landing',
     viewport,
-    route: `/${moduleId}`
+    route: `/${moduleId}`,
+    auditObserver
   })
 }
 
@@ -128,17 +146,22 @@ test.describe('seeded UI audit screenshot corpus', () => {
     await seedForCapture(baseURL)
 
     const navBar = new NavBar(page)
-    await openDashboard(page, navBar, desktopViewport)
-    await openConfigurationTab(page, navBar, desktopViewport, '#config-drivers', 'configuration-drivers', ['pca9685', 'ph', 'hs103'])
-    await openConfigurationTab(page, navBar, desktopViewport, '#config-connectors', 'configuration-connectors', ['O1', 'O8', 'I1', 'I3', 'J0', 'J1', 'AI1', 'AI2'])
-    await openModule(page, navBar, desktopViewport, 'equipment', ['Return', 'Light', 'Heater', 'Skimmer', 'Fan', 'ATO Pump'])
-    await openModule(page, navBar, desktopViewport, 'timers', ['Nightly Skimmer Run'])
-    await openModule(page, navBar, desktopViewport, 'lighting', ['Kessil A360'])
-    await openModule(page, navBar, desktopViewport, 'temperature', ['Biocube29 Temperature'])
-    await openModule(page, navBar, desktopViewport, 'ato', ['Biocube29 ATO'])
-    await openModule(page, navBar, desktopViewport, 'ph', ['Biocube29 pH'])
-    await openModule(page, navBar, desktopViewport, 'doser', ['Two Part - CaCO3'])
-    await openModule(page, navBar, desktopViewport, 'macro', ['Feed Start', 'Water Change'])
+    const auditObserver = createUiAuditObserver(page)
+    try {
+      await openDashboard(page, navBar, desktopViewport, auditObserver)
+      await openConfigurationTab(page, navBar, desktopViewport, '#config-drivers', 'configuration-drivers', ['pca9685', 'ph', 'hs103'], auditObserver)
+      await openConfigurationTab(page, navBar, desktopViewport, '#config-connectors', 'configuration-connectors', ['O1', 'O8', 'I1', 'I3', 'J0', 'J1', 'AI1', 'AI2'], auditObserver)
+      await openModule(page, navBar, desktopViewport, 'equipment', ['Return', 'Light', 'Heater', 'Skimmer', 'Fan', 'ATO Pump'], auditObserver)
+      await openModule(page, navBar, desktopViewport, 'timers', ['Nightly Skimmer Run'], auditObserver)
+      await openModule(page, navBar, desktopViewport, 'lighting', ['Kessil A360'], auditObserver)
+      await openModule(page, navBar, desktopViewport, 'temperature', ['Biocube29 Temperature'], auditObserver)
+      await openModule(page, navBar, desktopViewport, 'ato', ['Biocube29 ATO'], auditObserver)
+      await openModule(page, navBar, desktopViewport, 'ph', ['Biocube29 pH'], auditObserver)
+      await openModule(page, navBar, desktopViewport, 'doser', ['Two Part - CaCO3'], auditObserver)
+      await openModule(page, navBar, desktopViewport, 'macro', ['Feed Start', 'Water Change'], auditObserver)
+    } finally {
+      auditObserver.dispose()
+    }
   })
 
   test('captures mobile shell and major module landing states', async ({ page, baseURL }) => {
@@ -146,11 +169,16 @@ test.describe('seeded UI audit screenshot corpus', () => {
     await seedForCapture(baseURL)
 
     const navBar = new NavBar(page)
-    await openDashboard(page, navBar, mobileViewport)
-    await openModule(page, navBar, mobileViewport, 'equipment', ['Return', 'Light', 'Heater'])
-    await openModule(page, navBar, mobileViewport, 'lighting', ['Kessil A360'])
-    await openModule(page, navBar, mobileViewport, 'temperature', ['Biocube29 Temperature'])
-    await openModule(page, navBar, mobileViewport, 'ato', ['Biocube29 ATO'])
-    await openModule(page, navBar, mobileViewport, 'ph', ['Biocube29 pH'])
+    const auditObserver = createUiAuditObserver(page)
+    try {
+      await openDashboard(page, navBar, mobileViewport, auditObserver)
+      await openModule(page, navBar, mobileViewport, 'equipment', ['Return', 'Light', 'Heater'], auditObserver)
+      await openModule(page, navBar, mobileViewport, 'lighting', ['Kessil A360'], auditObserver)
+      await openModule(page, navBar, mobileViewport, 'temperature', ['Biocube29 Temperature'], auditObserver)
+      await openModule(page, navBar, mobileViewport, 'ato', ['Biocube29 ATO'], auditObserver)
+      await openModule(page, navBar, mobileViewport, 'ph', ['Biocube29 pH'], auditObserver)
+    } finally {
+      auditObserver.dispose()
+    }
   })
 })

--- a/front-end/scripts/ui-audit-report-core.mjs
+++ b/front-end/scripts/ui-audit-report-core.mjs
@@ -1,0 +1,301 @@
+import fs from 'fs'
+import path from 'path'
+
+export const FINDING_BUCKETS = [
+  'requiredScreenshots',
+  'fatalText',
+  'consoleErrors',
+  'failedRequests',
+  'tapTargets',
+  'overflow',
+  'missingAnchors'
+]
+
+export function loadManifest (manifestPath) {
+  return JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+}
+
+export function normalizeFindings (findings = {}) {
+  const source = findings && typeof findings === 'object' && !Array.isArray(findings) ? findings : {}
+  const normalized = {}
+  for (const bucket of FINDING_BUCKETS) {
+    normalized[bucket] = Array.isArray(source[bucket]) ? source[bucket] : []
+  }
+  return normalized
+}
+
+function screenshotExists (entry, cwd) {
+  if (typeof entry.screenshotPath !== 'string') return false
+  const screenshotPath = path.isAbsolute(entry.screenshotPath)
+    ? entry.screenshotPath
+    : path.join(cwd, entry.screenshotPath)
+  return fs.existsSync(screenshotPath) && fs.statSync(screenshotPath).isFile()
+}
+
+function entryModule (entry) {
+  return entry?.module || 'unknown'
+}
+
+function entryViewport (entry) {
+  return entry?.viewport?.name || 'unknown'
+}
+
+function sanitizeFileSlug (value) {
+  return String(value || 'unknown')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'unknown'
+}
+
+function normalizeFindingObject (finding = {}) {
+  return finding && typeof finding === 'object' && !Array.isArray(finding) ? finding : {}
+}
+
+function enrichFinding (entry = {}, category, finding = {}) {
+  const normalizedFinding = normalizeFindingObject(finding)
+  return {
+    category,
+    severity: normalizedFinding.severity || 'error',
+    module: entryModule(entry),
+    viewport: entryViewport(entry),
+    screenshotPath: entry?.screenshotPath || '',
+    message: normalizedFinding.message || `${category} finding`,
+    ...normalizedFinding
+  }
+}
+
+function isNumberOrMissing (value) {
+  return value === undefined || typeof value === 'number'
+}
+
+function validateEntryShape (entry, failures) {
+  if (entry.screen !== undefined && typeof entry.screen !== 'string') {
+    failures.push(enrichFinding(entry, 'manifest', { message: 'Manifest entry screen must be a string when present' }))
+  }
+  if (entry.viewport?.size !== undefined) {
+    if (typeof entry.viewport.size !== 'object' || entry.viewport.size === null || Array.isArray(entry.viewport.size)) {
+      failures.push(enrichFinding(entry, 'manifest', { message: 'Manifest entry viewport.size must be an object when present' }))
+    } else {
+      if (!isNumberOrMissing(entry.viewport.size.width)) {
+        failures.push(enrichFinding(entry, 'manifest', { message: 'Manifest entry viewport.size.width must be a number when present' }))
+      }
+      if (!isNumberOrMissing(entry.viewport.size.height)) {
+        failures.push(enrichFinding(entry, 'manifest', { message: 'Manifest entry viewport.size.height must be a number when present' }))
+      }
+    }
+  }
+  if (entry.theme !== undefined && typeof entry.theme !== 'string') {
+    failures.push(enrichFinding(entry, 'manifest', { message: 'Manifest entry theme must be a string when present' }))
+  }
+  if (entry.seedProfile !== undefined && typeof entry.seedProfile !== 'string') {
+    failures.push(enrichFinding(entry, 'manifest', { message: 'Manifest entry seedProfile must be a string when present' }))
+  }
+  if (entry.route !== undefined && entry.route !== null && typeof entry.route !== 'string') {
+    failures.push(enrichFinding(entry, 'manifest', { message: 'Manifest entry route must be a string when present' }))
+  }
+  if (entry.tab !== undefined && entry.tab !== null && typeof entry.tab !== 'string') {
+    failures.push(enrichFinding(entry, 'manifest', { message: 'Manifest entry tab must be a string or null when present' }))
+  }
+  if (entry.designSystemReferences !== undefined && (!Array.isArray(entry.designSystemReferences) || entry.designSystemReferences.some(ref => typeof ref !== 'string'))) {
+    failures.push(enrichFinding(entry, 'manifest', { message: 'Manifest entry designSystemReferences must be an array of strings when present' }))
+  }
+}
+
+export function validateManifest (manifest, { cwd = process.cwd() } = {}) {
+  const failures = []
+  const entries = Array.isArray(manifest?.entries) ? manifest.entries : []
+
+  if (!Array.isArray(manifest?.entries)) {
+    failures.push({ category: 'manifest', severity: 'error', message: 'manifest.entries must be an array' })
+  }
+
+  const validEntries = []
+
+  for (const entry of entries) {
+    if (typeof entry?.id !== 'string' || typeof entry?.module !== 'string' ||
+      typeof entry?.viewport?.name !== 'string' || typeof entry?.screenshotPath !== 'string') {
+      const fallbackEntry = {
+        id: entry?.id || 'unknown',
+        module: entryModule(entry),
+        screen: entry?.screen || 'unknown',
+        viewport: { name: entryViewport(entry) },
+        screenshotPath: entry?.screenshotPath || '',
+        designSystemReferences: [],
+        objectiveFindings: normalizeFindings()
+      }
+      failures.push(enrichFinding(fallbackEntry, 'manifest', { message: 'Manifest entry is missing valid string id, module, viewport.name, or screenshotPath' }))
+      validEntries.push(fallbackEntry)
+      continue
+    }
+
+    validEntries.push(entry)
+    validateEntryShape(entry, failures)
+
+    if (!screenshotExists(entry, cwd)) {
+      failures.push(enrichFinding(entry, 'requiredScreenshots', { message: `Missing screenshot: ${entry.screenshotPath}` }))
+    }
+
+    const hasFindings = entry.objectiveFindings !== undefined && entry.objectiveFindings !== null
+    const rawFindings = hasFindings ? entry.objectiveFindings : {}
+    if (typeof rawFindings !== 'object' || Array.isArray(rawFindings)) {
+      failures.push(enrichFinding(entry, 'manifest', { message: 'objectiveFindings must be an object with array buckets' }))
+    }
+    const findingSource = typeof rawFindings === 'object' && !Array.isArray(rawFindings) ? rawFindings : {}
+    for (const bucket of FINDING_BUCKETS) {
+      if (findingSource[bucket] !== undefined && !Array.isArray(findingSource[bucket])) {
+        failures.push(enrichFinding(entry, 'manifest', { message: `objectiveFindings.${bucket} must be an array` }))
+      }
+    }
+    const findings = normalizeFindings(findingSource)
+    entry.objectiveFindings = findings
+    for (const bucket of FINDING_BUCKETS) {
+      findings[bucket] = findings[bucket].map(finding => normalizeFindingObject(finding))
+      for (const finding of findings[bucket]) {
+        const enriched = enrichFinding(entry, bucket, finding)
+        if (enriched.severity !== 'warning') failures.push(enriched)
+      }
+    }
+  }
+
+  return { entries: validEntries, failures }
+}
+
+export function findingCount (entries = []) {
+  return entries.reduce((sum, entry) => {
+    const findings = normalizeFindings(entry.objectiveFindings)
+    return sum + FINDING_BUCKETS.reduce((bucketSum, bucket) => bucketSum + findings[bucket].length, 0)
+  }, 0)
+}
+
+function collectEntryFindings (entry) {
+  const collected = []
+  const findings = normalizeFindings(entry.objectiveFindings)
+  for (const bucket of FINDING_BUCKETS) {
+    for (const finding of findings[bucket]) {
+      collected.push(enrichFinding(entry, bucket, finding))
+    }
+  }
+  return collected
+}
+
+function groupFindingsByModuleViewportSeverity (entries = [], failures = []) {
+  const grouped = {}
+  const add = finding => {
+    const module = finding.module || 'unknown'
+    const viewport = finding.viewport || 'unknown'
+    const severity = finding.severity || 'error'
+    if (!grouped[module]) grouped[module] = {}
+    if (!grouped[module][viewport]) grouped[module][viewport] = {}
+    if (!grouped[module][viewport][severity]) grouped[module][viewport][severity] = []
+    grouped[module][viewport][severity].push(finding)
+  }
+
+  for (const entry of entries) {
+    for (const finding of collectEntryFindings(entry)) add(finding)
+  }
+  for (const failure of failures) {
+    if (failure.category === 'manifest' || failure.category === 'requiredScreenshots') add(failure)
+  }
+  return grouped
+}
+
+function groupEntriesByModule (entries = []) {
+  return entries.reduce((groups, entry) => {
+    const module = entryModule(entry)
+    if (!groups[module]) groups[module] = []
+    groups[module].push(entry)
+    return groups
+  }, {})
+}
+
+export function renderAgentMarkdown ({ entries = [], failures = [] }) {
+  const lines = ['# reef-pi UI Audit Report', '']
+  lines.push(`Objective failures: ${failures.length}`)
+  lines.push('')
+
+  for (const [module, moduleEntries] of Object.entries(groupEntriesByModule(entries))) {
+    lines.push(`## ${module}`)
+    for (const entry of moduleEntries) {
+      lines.push(`- ${entryViewport(entry)} ${entry.screen || 'screen'}: ${entry.screenshotPath}`)
+      for (const ref of entry.designSystemReferences || []) {
+        lines.push(`  - Design reference: ${ref}`)
+      }
+    }
+
+    const moduleFailures = failures.filter(finding => finding.module === module)
+    if (moduleFailures.length) {
+      lines.push('')
+      lines.push('Findings:')
+      for (const failure of moduleFailures) {
+        lines.push(`- [${failure.category}] ${failure.message}`)
+      }
+    }
+    lines.push('')
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+export function renderModulePrompt ({ module, entries = [] }) {
+  const lines = [
+    `# UI audit follow-up: ${module}`,
+    '',
+    'Compare these reef-pi screenshots against the existing design-system references.',
+    'Do not invent new design rules, raw hex colors, or fonts.',
+    '',
+    'Design-system references:',
+    '- front-end/design-system/SKILL.md',
+    '- front-end/design-system/colors_and_type.css',
+    '- front-end/design-system/ui_kits/reef-pi-app',
+    '',
+    'Screenshots:'
+  ]
+
+  for (const entry of entries) {
+    lines.push(`- ${entryViewport(entry)}: ${entry.screenshotPath}`)
+  }
+
+  lines.push('', 'Objective findings:')
+  let findingLines = 0
+  for (const entry of entries) {
+    const findings = normalizeFindings(entry.objectiveFindings)
+    for (const bucket of FINDING_BUCKETS) {
+      for (const finding of findings[bucket]) {
+        findingLines += 1
+        lines.push(`- ${entryViewport(entry)} [${bucket}] ${finding.message || JSON.stringify(finding)}`)
+      }
+    }
+  }
+  if (findingLines === 0) lines.push('- None recorded')
+
+  return `${lines.join('\n')}\n`
+}
+
+export function buildUiAuditReport ({ artifactRoot = path.join(process.cwd(), 'test-results', 'ui-audit'), cwd = process.cwd() } = {}) {
+  const manifestPath = path.join(artifactRoot, 'manifest.json')
+  const manifest = loadManifest(manifestPath)
+  const validation = validateManifest(manifest, { cwd })
+  const modules = groupEntriesByModule(validation.entries)
+  const report = {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    entryCount: validation.entries.length,
+    objectiveFindingCount: findingCount(validation.entries),
+    objectiveFailureCount: validation.failures.length,
+    failures: validation.failures,
+    findingsByModule: groupFindingsByModuleViewportSeverity(validation.entries, validation.failures),
+    modules
+  }
+
+  fs.mkdirSync(artifactRoot, { recursive: true })
+  fs.writeFileSync(path.join(artifactRoot, 'agent-report.json'), `${JSON.stringify(report, null, 2)}\n`)
+  fs.writeFileSync(path.join(artifactRoot, 'agent-report.md'), renderAgentMarkdown({ entries: validation.entries, failures: validation.failures }))
+
+  const promptRoot = path.join(artifactRoot, 'prompts')
+  fs.mkdirSync(promptRoot, { recursive: true })
+  for (const [module, entries] of Object.entries(modules)) {
+    fs.writeFileSync(path.join(promptRoot, `${sanitizeFileSlug(module)}.md`), renderModulePrompt({ module, entries }))
+  }
+
+  return { ...report, exitCode: validation.failures.length > 0 ? 1 : 0 }
+}

--- a/front-end/scripts/ui-audit-report-core.test.js
+++ b/front-end/scripts/ui-audit-report-core.test.js
@@ -1,0 +1,380 @@
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const { execFileSync } = require('child_process')
+
+const corePath = path.resolve(__dirname, 'ui-audit-report-core.mjs')
+
+function tmpAuditDir () {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'reef-pi-ui-audit-'))
+}
+
+function writeJson (file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true })
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+function baseEntry (root, overrides = {}) {
+  const screenshotPath = path.join(root, 'screenshots', 'desktop', 'dashboard-landing.png')
+  fs.mkdirSync(path.dirname(screenshotPath), { recursive: true })
+  fs.writeFileSync(screenshotPath, 'png-bytes')
+  return {
+    id: 'desktop-dashboard-landing',
+    screenshotPath,
+    module: 'dashboard',
+    screen: 'landing',
+    viewport: { name: 'desktop', size: { width: 1440, height: 1000 } },
+    theme: 'default',
+    seedProfile: 'full-smoke',
+    route: '/',
+    tab: null,
+    designSystemReferences: [
+      'front-end/design-system/SKILL.md',
+      'front-end/design-system/colors_and_type.css',
+      'front-end/design-system/ui_kits/reef-pi-app'
+    ],
+    objectiveFindings: {
+      requiredScreenshots: [],
+      fatalText: [],
+      consoleErrors: [],
+      failedRequests: [],
+      tapTargets: [],
+      overflow: [],
+      missingAnchors: []
+    },
+    ...overrides
+  }
+}
+
+function runCore (source, input = {}) {
+  const output = execFileSync(process.execPath, ['--input-type=module', '-e', `
+    import * as core from ${JSON.stringify(`file://${corePath}`)};
+    const input = ${JSON.stringify(input)};
+    ${source}
+  `], { encoding: 'utf8' })
+  return JSON.parse(output)
+}
+
+describe('ui-audit-report-core', () => {
+  it('loads and validates a clean manifest', () => {
+    const root = tmpAuditDir()
+    const manifestPath = path.join(root, 'manifest.json')
+    const manifest = { version: 1, generatedAt: '2026-05-24T00:00:00.000Z', entries: [baseEntry(root)] }
+    writeJson(manifestPath, manifest)
+
+    const result = runCore(`
+      const manifest = core.loadManifest(input.manifestPath);
+      const validation = core.validateManifest(manifest, { cwd: process.cwd() });
+      console.log(JSON.stringify({ manifest, failures: validation.failures, entries: validation.entries.length }));
+    `, { manifestPath })
+
+    expect(result.manifest).toEqual(manifest)
+    expect(result.failures).toEqual([])
+    expect(result.entries).toBe(1)
+  })
+
+  it('reports missing screenshots as objective failures', () => {
+    const root = tmpAuditDir()
+    const entry = baseEntry(root, { screenshotPath: path.join(root, 'screenshots', 'desktop', 'missing.png') })
+    fs.rmSync(entry.screenshotPath, { force: true })
+
+    const result = runCore(`
+      const validation = core.validateManifest(input.manifest, { cwd: process.cwd() });
+      console.log(JSON.stringify(validation.failures));
+    `, { manifest: { version: 1, generatedAt: 'now', entries: [entry] } })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ category: 'requiredScreenshots', severity: 'error', module: 'dashboard' })
+  })
+
+
+  it('reports malformed manifest field types as objective failures', () => {
+    const entry = baseEntry(tmpAuditDir(), { screenshotPath: { bad: true } })
+
+    const result = runCore(`
+      const validation = core.validateManifest(input.manifest, { cwd: process.cwd() });
+      console.log(JSON.stringify(validation.failures));
+    `, { manifest: { version: 1, generatedAt: 'now', entries: [entry] } })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ category: 'manifest', severity: 'error', module: 'dashboard' })
+  })
+
+
+
+  it('reports malformed optional manifest field types as objective failures', () => {
+    const entry = baseEntry(tmpAuditDir(), {
+      screen: 42,
+      viewport: { name: 'desktop', size: { width: 'wide', height: 1000 } },
+      theme: false,
+      seedProfile: [],
+      route: 17,
+      tab: {},
+      designSystemReferences: ['front-end/design-system/SKILL.md', 123]
+    })
+
+    const result = runCore(`
+      const validation = core.validateManifest(input.manifest, { cwd: process.cwd() });
+      console.log(JSON.stringify(validation.failures));
+    `, { manifest: { version: 1, generatedAt: 'now', entries: [entry] } })
+
+    expect(result.map(finding => finding.message)).toEqual(expect.arrayContaining([
+      'Manifest entry screen must be a string when present',
+      'Manifest entry viewport.size.width must be a number when present',
+      'Manifest entry theme must be a string when present',
+      'Manifest entry seedProfile must be a string when present',
+      'Manifest entry route must be a string when present',
+      'Manifest entry tab must be a string or null when present',
+      'Manifest entry designSystemReferences must be an array of strings when present'
+    ]))
+  })
+
+  it('reports malformed objectiveFindings objects as manifest failures', () => {
+    const entry = baseEntry(tmpAuditDir(), { objectiveFindings: 'not-an-object' })
+
+    const result = runCore(`
+      const validation = core.validateManifest(input.manifest, { cwd: process.cwd() });
+      console.log(JSON.stringify(validation.failures));
+    `, { manifest: { version: 1, generatedAt: 'now', entries: [entry] } })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ category: 'manifest', severity: 'error', module: 'dashboard' })
+    expect(result[0].message).toContain('objectiveFindings must be an object')
+  })
+
+  it('reports malformed objective finding buckets as manifest failures', () => {
+    const entry = baseEntry(tmpAuditDir(), {
+      objectiveFindings: {
+        requiredScreenshots: [],
+        fatalText: 'not-an-array',
+        consoleErrors: [],
+        failedRequests: [],
+        tapTargets: [],
+        overflow: [],
+        missingAnchors: []
+      }
+    })
+
+    const result = runCore(`
+      const validation = core.validateManifest(input.manifest, { cwd: process.cwd() });
+      console.log(JSON.stringify(validation.failures));
+    `, { manifest: { version: 1, generatedAt: 'now', entries: [entry] } })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ category: 'manifest', severity: 'error', module: 'dashboard' })
+    expect(result[0].message).toContain('objectiveFindings.fatalText')
+  })
+
+  it('counts populated objective findings', () => {
+    const entry = baseEntry(tmpAuditDir(), {
+      objectiveFindings: {
+        requiredScreenshots: [],
+        fatalText: [{ severity: 'error', message: 'Something went wrong' }],
+        consoleErrors: [],
+        failedRequests: [],
+        tapTargets: [{ severity: 'error', selector: 'button.btn-sm', width: 32, height: 32 }],
+        overflow: [],
+        missingAnchors: []
+      }
+    })
+
+    const result = runCore(`
+      console.log(JSON.stringify({ count: core.findingCount(input.entries) }));
+    `, { entries: [entry] })
+
+    expect(result.count).toBe(2)
+  })
+
+  it('writes agent json, markdown, and module prompts', () => {
+    const root = tmpAuditDir()
+    const manifestPath = path.join(root, 'manifest.json')
+    writeJson(manifestPath, { version: 1, generatedAt: 'now', entries: [baseEntry(root)] })
+
+    const result = runCore(`
+      const result = core.buildUiAuditReport({ artifactRoot: input.root, cwd: process.cwd() });
+      console.log(JSON.stringify({
+        exitCode: result.exitCode,
+        json: fs.existsSync(path.join(input.root, 'agent-report.json')),
+        markdown: fs.existsSync(path.join(input.root, 'agent-report.md')),
+        prompt: fs.existsSync(path.join(input.root, 'prompts', 'dashboard.md'))
+      }));
+    `, { root })
+
+    expect(result).toEqual({ exitCode: 0, json: true, markdown: true, prompt: true })
+  })
+
+  it('renders markdown with screenshot links and design-system references', () => {
+    const root = tmpAuditDir()
+    const entry = baseEntry(root)
+
+    const result = runCore(`
+      const markdown = core.renderAgentMarkdown({ entries: input.entries, failures: [] });
+      console.log(JSON.stringify({ markdown }));
+    `, { entries: [entry] })
+
+    expect(result.markdown).toContain('dashboard')
+    expect(result.markdown).toContain(entry.screenshotPath)
+    expect(result.markdown).toContain('front-end/design-system/SKILL.md')
+  })
+
+
+  it('reports null manifest entries without throwing', () => {
+    const result = runCore(`
+      const validation = core.validateManifest(input.manifest, { cwd: process.cwd() });
+      console.log(JSON.stringify(validation.failures));
+    `, { manifest: { version: 1, generatedAt: 'now', entries: [null] } })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ category: 'manifest', severity: 'error', module: 'unknown' })
+  })
+
+  it('reports null objective findings without throwing', () => {
+    const entry = baseEntry(tmpAuditDir(), {
+      objectiveFindings: {
+        requiredScreenshots: [],
+        fatalText: [null],
+        consoleErrors: [],
+        failedRequests: [],
+        tapTargets: [],
+        overflow: [],
+        missingAnchors: []
+      }
+    })
+
+    const result = runCore(`
+      const validation = core.validateManifest(input.manifest, { cwd: process.cwd() });
+      console.log(JSON.stringify(validation.failures));
+    `, { manifest: { version: 1, generatedAt: 'now', entries: [entry] } })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ category: 'fatalText', severity: 'error', module: 'dashboard' })
+  })
+
+  it('sanitizes module names before writing prompt files', () => {
+    const root = tmpAuditDir()
+    const manifestPath = path.join(root, 'manifest.json')
+    writeJson(manifestPath, { version: 1, generatedAt: 'now', entries: [baseEntry(root, { module: '../bad module' })] })
+
+    const result = runCore(`
+      core.buildUiAuditReport({ artifactRoot: input.root, cwd: process.cwd() });
+      console.log(JSON.stringify({
+        escaped: fs.existsSync(path.join(input.root, 'bad module.md')),
+        sanitized: fs.existsSync(path.join(input.root, 'prompts', 'bad-module.md'))
+      }));
+    `, { root })
+
+    expect(result).toEqual({ escaped: false, sanitized: true })
+  })
+
+
+  it('writes reports for malformed null manifest entries', () => {
+    const root = tmpAuditDir()
+    const manifestPath = path.join(root, 'manifest.json')
+    writeJson(manifestPath, { version: 1, generatedAt: 'now', entries: [null] })
+
+    const result = runCore(`
+      const result = core.buildUiAuditReport({ artifactRoot: input.root, cwd: process.cwd() });
+      console.log(JSON.stringify({
+        exitCode: result.exitCode,
+        failures: result.objectiveFailureCount,
+        json: fs.existsSync(path.join(input.root, 'agent-report.json')),
+        markdown: fs.existsSync(path.join(input.root, 'agent-report.md')),
+        prompt: fs.existsSync(path.join(input.root, 'prompts', 'unknown.md'))
+      }));
+    `, { root })
+
+    expect(result).toEqual({ exitCode: 1, failures: 1, json: true, markdown: true, prompt: true })
+  })
+
+
+  it('writes reports for null objective finding entries', () => {
+    const root = tmpAuditDir()
+    const manifestPath = path.join(root, 'manifest.json')
+    writeJson(manifestPath, {
+      version: 1,
+      generatedAt: 'now',
+      entries: [baseEntry(root, {
+        objectiveFindings: {
+          requiredScreenshots: [],
+          fatalText: [null],
+          consoleErrors: [],
+          failedRequests: [],
+          tapTargets: [],
+          overflow: [],
+          missingAnchors: []
+        }
+      })]
+    })
+
+    const result = runCore(`
+      const result = core.buildUiAuditReport({ artifactRoot: input.root, cwd: process.cwd() });
+      console.log(JSON.stringify({
+        exitCode: result.exitCode,
+        failures: result.objectiveFailureCount,
+        json: fs.existsSync(path.join(input.root, 'agent-report.json')),
+        prompt: fs.existsSync(path.join(input.root, 'prompts', 'dashboard.md'))
+      }));
+    `, { root })
+
+    expect(result).toEqual({ exitCode: 1, failures: 1, json: true, prompt: true })
+  })
+
+
+  it('normalizes null findings to empty buckets', () => {
+    const result = runCore(`
+      console.log(JSON.stringify(core.normalizeFindings(null)));
+    `)
+
+    expect(result).toMatchObject({
+      requiredScreenshots: [],
+      fatalText: [],
+      consoleErrors: [],
+      failedRequests: [],
+      tapTargets: [],
+      overflow: [],
+      missingAnchors: []
+    })
+  })
+
+  it('groups failures by module, viewport, and severity in agent report json', () => {
+    const root = tmpAuditDir()
+    const manifestPath = path.join(root, 'manifest.json')
+    writeJson(manifestPath, {
+      version: 1,
+      generatedAt: 'now',
+      entries: [baseEntry(root, {
+        objectiveFindings: {
+          requiredScreenshots: [],
+          fatalText: [{ severity: 'error', message: 'Something went wrong' }],
+          consoleErrors: [],
+          failedRequests: [],
+          tapTargets: [{ severity: 'warning', message: 'Small but report-only' }],
+          overflow: [],
+          missingAnchors: []
+        }
+      })]
+    })
+
+    const result = runCore(`
+      core.buildUiAuditReport({ artifactRoot: input.root, cwd: process.cwd() });
+      const report = JSON.parse(fs.readFileSync(path.join(input.root, 'agent-report.json'), 'utf8'));
+      console.log(JSON.stringify(report.findingsByModule));
+    `, { root })
+
+    expect(result.dashboard.desktop.error).toHaveLength(1)
+    expect(result.dashboard.desktop.warning).toHaveLength(1)
+  })
+
+  it('renders module prompts with no-new-rules instruction', () => {
+    const root = tmpAuditDir()
+
+    const result = runCore(`
+      const prompt = core.renderModulePrompt({ module: 'dashboard', entries: input.entries });
+      console.log(JSON.stringify({ prompt }));
+    `, { entries: [baseEntry(root)] })
+
+    expect(result.prompt).toContain('dashboard')
+    expect(result.prompt).toContain('Do not invent new design rules')
+    expect(result.prompt).toContain('front-end/design-system/colors_and_type.css')
+  })
+})

--- a/front-end/scripts/ui-audit-report.mjs
+++ b/front-end/scripts/ui-audit-report.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+import { buildUiAuditReport } from './ui-audit-report-core.mjs'
+
+try {
+  const result = buildUiAuditReport()
+  if (result.objectiveFailureCount > 0) {
+    console.error(`UI audit failed with ${result.objectiveFailureCount} objective finding(s).`)
+  } else {
+    console.log(`UI audit passed with ${result.entryCount} screenshot manifest entr${result.entryCount === 1 ? 'y' : 'ies'}.`)
+  }
+  process.exitCode = result.exitCode
+} catch (error) {
+  console.error(error.stack || error.message)
+  process.exitCode = 1
+}

--- a/package.json
+++ b/package.json
@@ -86,7 +86,10 @@
     "smoke": "playwright test --project=smoke-chromium",
     "pw-smoke": "playwright test --project=smoke-chromium",
     "pw-smoke:headed": "playwright test --project=smoke-chromium --headed",
-    "ui-audit": "node -e \"require('./front-end/e2e/fixtures/uiAudit').resetUiAuditArtifacts()\" && playwright test --project=ui-audit-chromium",
+    "ui-audit:reset": "node -e \"require('./front-end/e2e/fixtures/uiAudit').resetUiAuditArtifacts()\"",
+    "ui-audit:capture": "yarn run ui-audit:reset && playwright test --project=ui-audit-chromium",
+    "ui-audit:report": "node front-end/scripts/ui-audit-report.mjs",
+    "ui-audit": "yarn run ui-audit:capture && yarn run ui-audit:report",
     "integration": "playwright test --project=integration-chromium",
     "integration:headed": "playwright test --project=integration-chromium --headed"
   },

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
       "**/?(*.)+(test).[jt]s?(x)"
     ],
     "testPathIgnorePatterns": [
-      "<rootDir>/front-end/e2e/"
+      "<rootDir>/front-end/e2e/specs/"
     ],
     "coveragePathIgnorePatterns": [
       "<rootDir>/build/translations/",


### PR DESCRIPTION
## Summary
- add UI audit objective report aggregation and CLI
- collect browser/DOM objective findings during audit capture
- generate agent-ready JSON, Markdown, and per-module prompts
- add UI Audit GitHub Actions workflow and local reproduction docs

## Validation
- yarn run token-diff
- make standard
- yarn jest front-end/scripts/ui-audit-report-core.test.js front-end/e2e/fixtures/uiAudit.test.js --runInBand
- yarn run ui-audit
