### PR TITLE
[claude design] Token contrast audit + automated test

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -40,6 +40,8 @@ jobs:
         run: yarn
       - name: token-diff
         run: yarn run token-diff
+      - name: contrast-check
+        run: yarn run contrast-check
       - name: standard
         run: make standard
       - name: jest

--- a/front-end/design-system/contrast-report.md
+++ b/front-end/design-system/contrast-report.md
@@ -1,7 +1,7 @@
 # reef-pi token contrast report
 
-Generated: 2026-05-12T07:34:27.938Z
-Tokens file: /home/ranjib/workspace/reef-pi-BentoOS/front-end/design-system/colors_and_type.css
+Generated: 2026-05-30T08:45:43.124Z
+Tokens file: /home/ranjib/workspace/reef-pi-codex/front-end/design-system/colors_and_type.css
 
 ## Summary
 

--- a/front-end/design-system/github_issues/BACKLOG.md
+++ b/front-end/design-system/github_issues/BACKLOG.md
@@ -5,7 +5,7 @@
 ## E1 · Design tokens v2
 - [x] #1 Extend `--reefpi-*` scale with state tokens — `issue-01-state-tokens.md`
 - [x] #2 Add dark + actinic theme tokens — `issue-02-theme-tokens.md`
-- [ ] #3 Token contrast audit + automated test — `issue-03-contrast-audit.md`
+- [x] #3 Token contrast audit + automated test — `issue-03-contrast-audit.md`
 - [ ] #4 Migrate `preview/` cards to `var()`-only — `issue-04-preview-migrate.md`
 - [ ] #29 Adopt Manrope + JetBrains Mono (retire Questrial) — `issue-29-font-swap.md`
 

--- a/front-end/design-system/github_issues/issue-02-theme-tokens.md
+++ b/front-end/design-system/github_issues/issue-02-theme-tokens.md
@@ -48,4 +48,4 @@ Deep blue surface, cooler text, brand green kept as the only accent.
 Blocks #22, #23, #26.
 
 ## Status
-Implemented in PR #3078.
+Shipped in PR #3078.

--- a/front-end/design-system/github_issues/issue-03-contrast-audit.md
+++ b/front-end/design-system/github_issues/issue-03-contrast-audit.md
@@ -19,6 +19,9 @@ Lock down a11y so future token edits can't silently regress.
   - `focus` on `brand` gradient stops (both)
 
 ## Acceptance
-- [ ] Script runs in CI; exit code drives PR check.
-- [ ] Report output (both pass + fail) written to `contrast-report.md`.
-- [ ] Failing any pair fails the build with a clear line pointing at the offending token.
+- [x] Script runs in CI; exit code drives PR check.
+- [x] Report output (both pass + fail) written to `contrast-report.md`.
+- [x] Failing any pair fails the build with a clear line pointing at the offending token.
+
+## Status
+Implemented in PR #3079.

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "ui": "webpack --mode=production",
     "ui-dev": "webpack --watch --mode=development",
     "token-diff": "node front-end/scripts/token-diff.mjs",
+    "contrast-check": "node front-end/design-system/scripts/contrast-check.mjs",
     "js-lint": "standard \"front-end/src/**/*.{js,jsx}\"",
     "standard": "standard --fix \"front-end/src/**/*.{js,jsx}\"",
     "jest": "cross-env NODE_ENV=testing jest --env=jsdom",


### PR DESCRIPTION
## Summary
- expose the design-system contrast audit as yarn run contrast-check
- run contrast-check in the frontend CI workflow after token-diff
- refresh contrast-report.md from the current token set
- mark issue #2 shipped in PR #3078 and issue #3 implemented in local tracking

## Verification
- yarn run contrast-check
- yarn run token-diff
- intentional failing-token run against /tmp/reef-pi-contrast-fail.css exits 1 and reports the offending token pairs

Parent epic: front-end/design-system/github_issues/STRATEGY.md E1 Design tokens v2.