### PR TITLE
[claude design] RangeSelector (1H / 6H / 1D / 7D / 30D)

### DIFF
--- a/front-end/design-system/github_issues/BACKLOG.md
+++ b/front-end/design-system/github_issues/BACKLOG.md
@@ -12,7 +12,7 @@
 ## E2 · Monitoring primitives
 - [x] #5 ThresholdGauge component — `issue-05-threshold-gauge.md`
 - [x] #6 Sparkline v2 (gradient fill, threshold band, hover) — `issue-06-sparkline-v2.md`
-- [ ] #7 RangeSelector (1H / 6H / 1D / 7D / 30D) — `issue-07-range-selector.md`
+- [x] #7 RangeSelector (1H / 6H / 1D / 7D / 30D) — `issue-07-range-selector.md`
 - [ ] #8 `useTimeSeries` hook — `issue-08-use-time-series.md`
 - [ ] #9 Storybook entries for primitives — `issue-09-storybook-primitives.md`
 

--- a/front-end/design-system/github_issues/epic-02-monitoring-primitives.md
+++ b/front-end/design-system/github_issues/epic-02-monitoring-primitives.md
@@ -13,14 +13,14 @@ Introduce the atomic monitoring components every telemetry tile needs: a thresho
 ## Success criteria
 - [x] `ThresholdGauge` renders current reading relative to a min/max band with out-of-bounds zones.
 - [x] `Sparkline v2` supports `fill=gradient`, `band=[min, max]`, hover crosshair.
-- [ ] `RangeSelector` emits `{ '1h' | '6h' | '1d' | '7d' | '30d' }` and persists to `localStorage` globally.
+- [x] `RangeSelector` emits `{ '1h' | '6h' | '1d' | '7d' | '30d' }` and persists to `localStorage` globally.
 - [ ] `useTimeSeries(metric, range)` hook returns downsampled points appropriate for the selected range.
 - [ ] Storybook has interactive examples for each.
 
 ## Sub-tasks
 - [x] #5 ThresholdGauge component
 - [x] #6 Sparkline v2 (gradient fill, threshold band, hover)
-- [ ] #7 RangeSelector (1H / 6H / 1D / 7D / 30D)
+- [x] #7 RangeSelector (1H / 6H / 1D / 7D / 30D)
 - [ ] #8 `useTimeSeries` hook with range + downsample
 - [ ] #9 Storybook entries for all primitives
 

--- a/front-end/design-system/github_issues/issue-07-range-selector.md
+++ b/front-end/design-system/github_issues/issue-07-range-selector.md
@@ -29,6 +29,6 @@ Segmented control used in every monitoring tile header.
 - Persists to `localStorage` under `reefpi.range.<scope>` where `scope` defaults to `'global'` but tiles can pass `scope="dashboard"` to isolate.
 
 ## Acceptance
-- [ ] Renders as a `<fieldset>` of `<input type=radio>` so it's keyboard + screen-reader navigable.
-- [ ] Compact mode: "1H" → "1".
-- [ ] Storybook covers full + compact + keyboard.
+- [x] Renders as a `<fieldset>` of `<input type=radio>` so it's keyboard + screen-reader navigable.
+- [x] Compact mode: "1H" → "1".
+- [x] Storybook covers full + compact + keyboard.

--- a/front-end/design-system/preview/primitives/range-selector.html
+++ b/front-end/design-system/preview/primitives/range-selector.html
@@ -37,6 +37,7 @@
     }
 
     .rs-btn {
+      position: relative;
       display: inline-flex;
       align-items: center;
       justify-content: center;
@@ -50,6 +51,7 @@
       background: transparent;
       color: var(--reefpi-color-text);
       border: none;
+      user-select: none;
       transition: background-color 0.12s, color 0.12s;
     }
 
@@ -63,7 +65,14 @@
       font-weight: 500;
     }
 
-    .rs-btn:focus-visible {
+    .rs-radio {
+      position: absolute;
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+
+    .rs-btn:focus-within {
       outline: 2px solid var(--reefpi-color-focus);
       outline-offset: -2px;
       z-index: 1;
@@ -95,7 +104,7 @@
     <div class="card">
       <div class="card-header">Default — value="1d"</div>
       <div class="card-body">
-        <fieldset class="rs" id="rs-default" aria-label="Time range">
+        <fieldset class="rs" id="rs-default" role="radiogroup" aria-label="Time range">
           <legend style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0)">Time range</legend>
         </fieldset>
         <p class="story-caption">options=['1h','6h','1d','7d','30d']</p>
@@ -107,7 +116,7 @@
     <div class="card">
       <div class="card-header">Compact — labels trimmed to digits</div>
       <div class="card-body">
-        <fieldset class="rs" id="rs-compact" aria-label="Time range compact">
+        <fieldset class="rs" id="rs-compact" role="radiogroup" aria-label="Time range compact">
           <legend style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0)">Time range</legend>
         </fieldset>
         <p class="story-caption">compact — "1H" → "1"</p>
@@ -119,7 +128,7 @@
     <div class="card">
       <div class="card-header">Keyboard — tab in, arrow keys</div>
       <div class="card-body">
-        <fieldset class="rs" id="rs-keyboard" aria-label="Time range keyboard">
+        <fieldset class="rs" id="rs-keyboard" role="radiogroup" aria-label="Time range keyboard">
           <legend style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0)">Time range</legend>
         </fieldset>
         <p class="story-caption">Tab → focus ring. ←/→ to step. Enter/Space to select.</p>
@@ -131,7 +140,7 @@
     <div class="card">
       <div class="card-header">Custom options — scope="dashboard"</div>
       <div class="card-body">
-        <fieldset class="rs" id="rs-custom" aria-label="Dashboard time range">
+        <fieldset class="rs" id="rs-custom" role="radiogroup" aria-label="Dashboard time range">
           <legend style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0)">Dashboard time range</legend>
         </fieldset>
         <p class="story-caption">options=['1h','6h','1d'] scope="dashboard"</p>
@@ -162,21 +171,29 @@
 
           var label = compact ? opt.replace(/[a-z]/g, '') : opt.toUpperCase()
 
-          var btn = document.createElement('button')
-          btn.type = 'button'
-          btn.className = 'rs-btn' + (opt === current ? ' active' : '')
-          btn.textContent = label
-          btn.setAttribute('aria-pressed', opt === current ? 'true' : 'false')
-          btn.dataset.opt = opt
+          var input = document.createElement('input')
+          input.setAttribute('type', 'radio')
+          input.className = 'rs-radio'
+          input.name = name
+          input.id = name + '-' + opt
+          input.value = opt
+          input.checked = opt === current
 
-          btn.addEventListener('click', function () {
+          var radioLabel = document.createElement('label')
+          radioLabel.className = 'rs-btn' + (opt === current ? ' active' : '')
+          radioLabel.htmlFor = input.id
+          radioLabel.dataset.opt = opt
+          radioLabel.appendChild(input)
+          radioLabel.appendChild(document.createTextNode(label))
+
+          input.addEventListener('change', function () {
             current = opt
             render()
             if (logEl) logEl.textContent = 'onChange("' + opt + '")'
             try { localStorage.setItem('reefpi.range.' + (scope || 'global'), opt) } catch (e) {}
           })
 
-          fieldset.appendChild(btn)
+          fieldset.appendChild(radioLabel)
         })
       }
 

--- a/front-end/design-system/ui_kits/reef-pi-app/primitives/RangeSelector.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/primitives/RangeSelector.jsx
@@ -11,6 +11,14 @@ function compactLabel (opt) {
   return opt.replace(/[a-z]/g, '')
 }
 
+function getStoredRange (scope) {
+  try { return globalThis.localStorage.getItem(storageKey(scope)) } catch { return null }
+}
+
+function setStoredRange (scope, opt) {
+  try { globalThis.localStorage.setItem(storageKey(scope), opt) } catch { /* storage unavailable */ }
+}
+
 export default function RangeSelector ({
   value: valueProp,
   options = DEFAULT_OPTIONS,
@@ -20,7 +28,7 @@ export default function RangeSelector ({
 }) {
   const [value, setValue] = useState(() => {
     if (valueProp !== undefined) return valueProp
-    try { return localStorage.getItem(storageKey(scope)) || options[0] } catch { return options[0] }
+    return getStoredRange(scope) || options[0]
   })
 
   // Sync when controlled prop changes
@@ -35,7 +43,7 @@ export default function RangeSelector ({
     if (onChange) onChange(opt)
     if (debounceRef.current) clearTimeout(debounceRef.current)
     debounceRef.current = setTimeout(() => {
-      try { localStorage.setItem(storageKey(scope), opt) } catch { /* storage unavailable */ }
+      setStoredRange(scope, opt)
     }, 250)
   }, [onChange, scope])
 
@@ -45,7 +53,6 @@ export default function RangeSelector ({
     <fieldset
       className='reefpi-range-selector'
       style={{
-        border: 'none',
         padding: 0,
         margin: 0,
         display: 'inline-flex',
@@ -67,11 +74,14 @@ export default function RangeSelector ({
         return (
           <React.Fragment key={opt}>
             {i > 0 && (
-              <span aria-hidden='true' style={{
-                width: '1px',
-                background: 'var(--reefpi-color-border)',
-                flexShrink: 0
-              }} />
+              <span
+                aria-hidden='true'
+                style={{
+                  width: '1px',
+                  background: 'var(--reefpi-color-border)',
+                  flexShrink: 0
+                }}
+              />
             )}
             <label
               htmlFor={id}

--- a/front-end/design-system/ui_kits/reef-pi-app/primitives/RangeSelector.test.js
+++ b/front-end/design-system/ui_kits/reef-pi-app/primitives/RangeSelector.test.js
@@ -1,6 +1,8 @@
 import React, { act } from 'react'
 import { createRoot } from 'react-dom/client'
 import { renderToStaticMarkup } from 'react-dom/server'
+import fs from 'fs'
+import path from 'path'
 import RangeSelector from './RangeSelector'
 import ToggleSwitch from './ToggleSwitch'
 
@@ -54,6 +56,26 @@ describe('design-system RangeSelector and ToggleSwitch', () => {
     expect(container.querySelector('input[value="6h"]').checked).toBe(true)
 
     act(() => root.unmount())
+  })
+
+
+  it('renders RangeSelector as a radio fieldset and trims compact labels', () => {
+    const html = renderToStaticMarkup(<RangeSelector value='1h' options={['1h', '6h']} compact />)
+
+    expect(html).toContain('<fieldset')
+    expect(html).toContain('type="radio"')
+    expect(html).toContain('name="reefpi-range-global"')
+    expect(html).toContain('>1</label>')
+    expect(html).toContain('>6</label>')
+    expect(html).not.toContain('>1H</label>')
+  })
+
+  it('documents the preview story as radio inputs instead of button-only controls', () => {
+    const story = fs.readFileSync(path.join(process.cwd(), 'front-end/design-system/preview/primitives/range-selector.html'), 'utf8')
+
+    expect(story).toContain("input.setAttribute('type', 'radio')")
+    expect(story).toContain('role="radiogroup"')
+    expect(story).not.toContain("btn.type = 'button'")
   })
 
   it('renders ToggleSwitch states and invokes the correct callbacks', () => {


### PR DESCRIPTION
Closes #3088\n\n## Summary\n- keep RangeSelector lint-clean while preserving fieldset/radio localStorage behavior\n- update the RangeSelector preview story to use generated radio inputs instead of button-only controls\n- add regression coverage for compact labels and preview radio documentation\n- mark RangeSelector complete in the local design-system tracking docs\n\n## Verification\n- rtk yarn jest front-end/design-system/ui_kits/reef-pi-app/primitives/RangeSelector.test.js --runInBand\n- rtk yarn jest front-end/design-system/ui_kits/reef-pi-app/primitives/RangeSelector.test.js front-end/src/temperature/temperature.test.js front-end/src/ph/ph.test.js front-end/src/ato/main.test.js --runInBand\n- rtk ./node_modules/.bin/standard front-end/design-system/ui_kits/reef-pi-app/primitives/RangeSelector.jsx front-end/design-system/ui_kits/reef-pi-app/primitives/RangeSelector.test.js\n- rtk yarn run preview-card-check\n- rtk git diff --check\n- rtk yarn build