### PR TITLE
[claude design] Storybook entries for primitives

### DIFF
--- a/front-end/design-system/github_issues/BACKLOG.md
+++ b/front-end/design-system/github_issues/BACKLOG.md
@@ -14,7 +14,7 @@
 - [x] #6 Sparkline v2 (gradient fill, threshold band, hover) — `issue-06-sparkline-v2.md`
 - [x] #7 RangeSelector (1H / 6H / 1D / 7D / 30D) — `issue-07-range-selector.md`
 - [x] #8 `useTimeSeries` hook — `issue-08-use-time-series.md`
-- [ ] #9 Storybook entries for primitives — `issue-09-storybook-primitives.md`
+- [x] #9 Storybook entries for primitives — `issue-09-storybook-primitives.md`
 
 ## E3 · Dashboard v2 (flag: `dashboard_v2`)
 - [ ] #10 System status strip — `issue-10-system-strip.md`

--- a/front-end/design-system/github_issues/epic-02-monitoring-primitives.md
+++ b/front-end/design-system/github_issues/epic-02-monitoring-primitives.md
@@ -15,14 +15,14 @@ Introduce the atomic monitoring components every telemetry tile needs: a thresho
 - [x] `Sparkline v2` supports `fill=gradient`, `band=[min, max]`, hover crosshair.
 - [x] `RangeSelector` emits `{ '1h' | '6h' | '1d' | '7d' | '30d' }` and persists to `localStorage` globally.
 - [x] `useTimeSeries(metric, range)` hook returns downsampled points appropriate for the selected range.
-- [ ] Storybook has interactive examples for each.
+- [x] Storybook has interactive examples for each.
 
 ## Sub-tasks
 - [x] #5 ThresholdGauge component
 - [x] #6 Sparkline v2 (gradient fill, threshold band, hover)
 - [x] #7 RangeSelector (1H / 6H / 1D / 7D / 30D)
 - [x] #8 `useTimeSeries` hook with range + downsample
-- [ ] #9 Storybook entries for all primitives
+- [x] #9 Storybook entries for all primitives
 
 ## Dependencies
 - Requires #1 (state tokens) for gauge colors.

--- a/front-end/design-system/github_issues/issue-09-storybook-primitives.md
+++ b/front-end/design-system/github_issues/issue-09-storybook-primitives.md
@@ -15,5 +15,5 @@ Add isolated design-system entries for everything in E2 so reviewers can click t
 - `useTimeSeries` — loading / loaded / error / stale-while-revalidate (mocked)
 
 ## Acceptance
-- [ ] Each story is a self-contained HTML file under `preview/primitives/` registered in the asset review manifest under **Components**.
-- [ ] No network calls in stories — use fixtures.
+- [x] Each story is a self-contained HTML file under `preview/primitives/` registered in the asset review manifest under **Components**.
+- [x] No network calls in stories — use fixtures.

--- a/front-end/design-system/preview/MANIFEST.md
+++ b/front-end/design-system/preview/MANIFEST.md
@@ -77,8 +77,8 @@ All stories live under `preview/primitives/`. Open with `?theme=dark` or `?theme
 
 | Component | Stories | Preview card |
 |---|---|---|
-| `ThresholdGauge` | within safe / in warn zone / out of bounds / no warn band / no safe band | [primitives/threshold-gauge.html](primitives/threshold-gauge.html) |
-| `Sparkline` | no fill / gradient fill / threshold band / band+hover / back-compat (number[]) | [primitives/sparkline.html](primitives/sparkline.html) |
+| `ThresholdGauge` | safe / warn / critical / outside / no-warn-band / no-safe-band | [primitives/threshold-gauge.html](primitives/threshold-gauge.html) |
+| `Sparkline` | bare / gradient / band / hover / keyboard / back-compat (number[]) | [primitives/sparkline.html](primitives/sparkline.html) |
 | `RangeSelector` | default / compact / keyboard / custom options+scope | [primitives/range-selector.html](primitives/range-selector.html) |
 | `useTimeSeries` | loading / loaded (120 pts LTTB) / error / stale-while-revalidate | [primitives/use-time-series.html](primitives/use-time-series.html) |
 

--- a/front-end/design-system/preview/primitives/threshold-gauge.html
+++ b/front-end/design-system/preview/primitives/threshold-gauge.html
@@ -245,7 +245,42 @@
       </div>
     </div>
 
-    <!-- Story 4: No warn band -->
+    <!-- Story 4: Critical zone -->
+    <div class="card">
+      <div class="card-header">Critical zone — 72.0 °F</div>
+      <div class="card-body">
+        <div class="gauge-host"
+          role="meter"
+          aria-label="Frag tank temperature"
+          aria-valuemin="70" aria-valuemax="86"
+          aria-valuenow="72"
+          aria-valuetext="72°F, critical low">
+
+          <div class="gauge-value-row">
+            <span class="gauge-value out-of-bounds">72.0°F</span>
+            <span class="gauge-label">Frag Tank</span>
+          </div>
+
+          <div class="gauge-track-wrap">
+            <div class="gauge-zones">
+              <div class="zone zone-critical" style="width:25%"></div>
+              <div class="zone zone-warn"     style="width:12.5%"></div>
+              <div class="zone zone-safe"     style="width:25%"></div>
+              <div class="zone zone-warn"     style="width:12.5%"></div>
+              <div class="zone zone-critical" style="width:25%"></div>
+            </div>
+            <div class="gauge-needle" style="left:12.5%; background:var(--reefpi-color-band-critical)"></div>
+            <div class="gauge-indicator out-of-bounds" style="left:12.5%"></div>
+          </div>
+
+          <div class="gauge-minmax">
+            <span>70°F</span><span>86°F</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Story 5: No warn band -->
     <div class="card">
       <div class="card-header">No warn band — safe + critical only</div>
       <div class="card-body">
@@ -287,7 +322,7 @@
       </div>
     </div>
 
-    <!-- Story 5: No safe band — target band only -->
+    <!-- Story 6: No safe band — target band only -->
     <div class="card" style="grid-column: 1 / -1;">
       <div class="card-header">No safe band — target band only (Salinity)</div>
       <div class="card-body">

--- a/front-end/design-system/scripts/preview-card-check.mjs
+++ b/front-end/design-system/scripts/preview-card-check.mjs
@@ -4,9 +4,19 @@ import { fileURLToPath } from 'url'
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url))
 const previewDir = path.resolve(scriptDir, '../preview')
+const manifestPath = path.join(previewDir, 'MANIFEST.md')
 const hexPattern = /#[0-9a-fA-F]{3,6}\b/g
 
 const issues = []
+
+const requiredPrimitiveStories = {
+  'threshold-gauge.html': ['Within safe range', 'In warn zone', 'Critical zone', 'Out of bounds', 'No warn band'],
+  'sparkline.html': ['No fill', 'Gradient fill', 'Threshold band', 'Band + hover', 'keyboard'],
+  'range-selector.html': ['Default', 'Compact', 'Keyboard'],
+  'use-time-series.html': ['Loading', 'Loaded', 'Error', 'Stale-while-revalidate']
+}
+
+const networkNeedles = ['fetch(', 'new XMLHttpRequest', 'new WebSocket', 'new EventSource', 'navigator.sendBeacon(', '"/api/', '\'/api/']
 
 const walk = (dir) => {
   const entries = fs.readdirSync(dir, { withFileTypes: true })
@@ -24,15 +34,16 @@ const checkCssBlock = (filePath, block, baseLine) => {
   let match
   while ((match = hexPattern.exec(block)) !== null) {
     const lineNumber = lineNumberForIndex(block, match.index)
-    const line = block.split("\n")[lineNumber - 1] || ""
-    if (line.includes("literal: brand swatch")) continue
+    const line = block.split('\n')[lineNumber - 1] || ''
+    if (line.includes('literal: brand swatch')) continue
     issues.push(`${path.relative(previewDir, filePath)}:${baseLine + lineNumber - 1} raw hex ${match[0]} in CSS`)
   }
 }
 
 const checkHtml = (filePath, source) => {
+  const relative = path.relative(previewDir, filePath)
   if (source.includes('_card.css') && !source.includes('_card.js')) {
-    issues.push(`${path.relative(previewDir, filePath)}: missing _card.js theme handler`)
+    issues.push(relative + ': missing _card.js theme handler')
   }
 
   const styleBlockPattern = /<style[^>]*>([\s\S]*?)<\/style>/gi
@@ -47,11 +58,43 @@ const checkHtml = (filePath, source) => {
   }
 }
 
+const checkPrimitiveStories = () => {
+  const manifest = fs.readFileSync(manifestPath, 'utf8')
+  const componentsSection = manifest.split('## Components (E2)')[1]?.split('## Components (E3')[0] || ''
+
+  for (const [fileName, stories] of Object.entries(requiredPrimitiveStories)) {
+    const relative = 'primitives/' + fileName
+    const filePath = path.join(previewDir, relative)
+
+    if (!fs.existsSync(filePath)) {
+      issues.push(relative + ': missing primitive story file')
+      continue
+    }
+
+    if (!componentsSection.includes(relative)) {
+      issues.push(relative + ': missing from MANIFEST.md Components (E2) section')
+    }
+
+    const source = fs.readFileSync(filePath, 'utf8')
+    if (networkNeedles.some((needle) => source.includes(needle))) {
+      issues.push(relative + ': primitive stories must use fixtures, not network calls')
+    }
+
+    for (const story of stories) {
+      if (!source.toLowerCase().includes(story.toLowerCase())) {
+        issues.push(relative + ': missing story state ' + story)
+      }
+    }
+  }
+}
+
 for (const filePath of walk(previewDir)) {
   const source = fs.readFileSync(filePath, 'utf8')
   if (filePath.endsWith('.css')) checkCssBlock(filePath, source, 1)
   if (filePath.endsWith('.html')) checkHtml(filePath, source)
 }
+
+checkPrimitiveStories()
 
 if (issues.length > 0) {
   console.error('Preview card token check failed:')


### PR DESCRIPTION
Closes #3092\n\nParent epic: E2 Monitoring primitives, tracked in front-end/design-system/github_issues/epic-02-monitoring-primitives.md\n\n## Summary\n- add the missing ThresholdGauge critical-state primitive story\n- align the primitive manifest story labels with the E2 story requirements\n- extend preview-card-check to enforce primitive manifest registration, required story states, and fixture-only previews\n- mark design-system issue #9 complete in the local tracking docs\n\n## Verification\n- rtk yarn run preview-card-check\n- rtk ./node_modules/.bin/standard front-end/design-system/scripts/preview-card-check.mjs\n- rtk git diff --check\n- rtk yarn build