### PR TITLE
[claude design] Dashboard · System status strip

### DIFF
--- a/front-end/design-system/github_issues/BACKLOG.md
+++ b/front-end/design-system/github_issues/BACKLOG.md
@@ -17,7 +17,7 @@
 - [x] #9 Storybook entries for primitives — `issue-09-storybook-primitives.md`
 
 ## E3 · Dashboard v2 (flag: `dashboard_v2`)
-- [ ] #10 System status strip — `issue-10-system-strip.md`
+- [x] #10 System status strip — `issue-10-system-strip.md`
 - [ ] #11 Hero TemperatureTile — `issue-11-hero-temp.md`
 - [ ] #12 Secondary PhTile / AtoTile — `issue-12-ph-ato-tiles.md`
 - [ ] #13 Equipment strip (footer) — `issue-13-equipment-strip.md`

--- a/front-end/design-system/github_issues/epic-03-dashboard-v2.md
+++ b/front-end/design-system/github_issues/epic-03-dashboard-v2.md
@@ -11,14 +11,14 @@ parent: null
 Rebuild the dashboard around a clear visual hierarchy. Add a single-line system-status strip up top, promote temperature to a 2-col hero tile with a visible threshold band, demote the equipment panel to a horizontal strip along the bottom. Ship behind a `dashboard_v2` feature flag; flip when stable.
 
 ## Success criteria
-- [ ] Above the tile grid, a system-status strip shows: health pill (OK / Warn / Critical), tank name, uptime, count of active alerts.
+- [x] Above the tile grid, a system-status strip shows: health pill (OK / Warn / Critical), tank name, uptime, count of active alerts.
 - [ ] Temperature tile spans `col-md-8` on desktop, showing big numeric + gradient area chart + shaded threshold band (76–80°F).
 - [ ] pH and ATO tiles (`col-md-4`) use `Sparkline v2` + `RangeSelector`.
 - [ ] Equipment toggles move into a horizontal strip along the dashboard footer (above `Summary`).
 - [ ] Old dashboard still reachable via `dashboard_v2=false` until flag removal.
 
 ## Sub-tasks
-- [ ] #10 System status strip
+- [x] #10 System status strip
 - [ ] #11 Hero TemperatureTile
 - [ ] #12 Secondary PhTile / AtoTile with RangeSelector
 - [ ] #13 Equipment strip (horizontal, footer position)

--- a/front-end/design-system/github_issues/issue-10-system-strip.md
+++ b/front-end/design-system/github_issues/issue-10-system-strip.md
@@ -17,10 +17,10 @@ Single-line strip above the tile grid. Answers "is everything OK?" in one glance
 - Right cluster: alert count (click → opens alert center from #17), kebab (Configure / Sign out).
 
 ## Acceptance
-- [ ] Height 56px; collapses to 48px on narrow viewports.
-- [ ] Health pill derives from alert severity reducer (no independent state).
-- [ ] Clicking alert count opens alert-center slide-over.
-- [ ] Kebab removes the bottom Configure button currently in Dashboard.
+- [x] Height 56px; collapses to 48px on narrow viewports.
+- [x] Health pill derives from alert severity reducer (no independent state).
+- [x] Clicking alert count opens alert-center slide-over.
+- [x] Kebab removes the bottom Configure button currently in Dashboard.
 
 ## Dependencies
 - #17 alert center must exist (or stub) for the alert-count click.

--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import PropTypes from 'prop-types'
 import SystemStrip from './SystemStrip'
+import { AlertCenter } from './AlertCenter'
 import TemperatureTile from './TemperatureTile'
 import PhTile from './PhTile'
 import AtoTile from './AtoTile'
@@ -215,6 +216,7 @@ export default function DashboardV2 ({
 }) {
   const { alerts } = useAlertsStore({ sseEndpoint })
   const [configRevision, setConfigRevision] = useState(0)
+  const [alertCenterOpen, setAlertCenterOpen] = useState(false)
 
   if (!window.FEATURE_FLAGS?.dashboard_v2) {
     return children ?? null
@@ -239,9 +241,11 @@ export default function DashboardV2 ({
     setConfigRevision(v => v + 1)
   }
 
-  const tempAlert = toTileAlert(firstAlertFor(alerts, 'temperature.display'))
-  const phAlert = toTileAlert(firstAlertFor(alerts, 'ph.display'))
-  const atoAlert = toTileAlert(firstAlertFor(alerts, 'ato.reservoir'))
+  const activeAlerts = alerts.filter(alert => !alert.acknowledged)
+
+  const tempAlert = toTileAlert(firstAlertFor(activeAlerts, 'temperature.display'))
+  const phAlert = toTileAlert(firstAlertFor(activeAlerts, 'ph.display'))
+  const atoAlert = toTileAlert(firstAlertFor(activeAlerts, 'ato.reservoir'))
 
   return (
     <div
@@ -257,9 +261,12 @@ export default function DashboardV2 ({
       {/* System strip — full width */}
       <SystemStrip
         sseEndpoint={sseEndpoint}
+        alerts={activeAlerts}
+        onAlertClick={() => setAlertCenterOpen(true)}
         onConfigure={onConfigure}
         onResetDashboardConfig={handleResetDashboardConfig}
       />
+      <AlertCenter open={alertCenterOpen} onClose={() => setAlertCenterOpen(false)} />
 
       {/* Primary metric row */}
       <div className='row' style={{ margin: 0, gap: '1rem', display: 'flex', flexWrap: 'wrap' }}>

--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js
@@ -8,8 +8,19 @@ jest.mock('../hooks/useAlertsStore', () => ({
 }))
 
 jest.mock('./SystemStrip', () => function MockSystemStrip (props) {
-  return <section data-testid='system-strip' data-sse-endpoint={props.sseEndpoint} />
+  return (
+    <section
+      data-testid='system-strip'
+      data-sse-endpoint={props.sseEndpoint}
+      data-alerts={JSON.stringify(props.alerts || [])}
+    >
+      <button data-testid='system-strip-alert-trigger' onClick={props.onAlertClick}>alerts</button>
+    </section>
+  )
 })
+jest.mock('./AlertCenter', () => ({
+  AlertCenter: props => <section data-testid='alert-center' data-open={props.open ? 'yes' : 'no'} />
+}))
 jest.mock('./TemperatureTile', () => function MockTemperatureTile (props) {
   return <section data-testid='temperature-tile' data-global-range={props.globalRange} data-alert={JSON.stringify(props.alert || null)} />
 })
@@ -91,6 +102,31 @@ describe('design-system DashboardV2', () => {
     expect(container.querySelector('[data-testid="ato-tile"]').getAttribute('data-target-level')).toBe('50')
     expect(container.querySelector('[data-testid="equipment-strip"]').getAttribute('data-items')).toBe('1')
     expect(container.querySelector('[data-testid="equipment-strip"]').getAttribute('data-toggle')).toBe('yes')
+
+    cleanup()
+  })
+
+  it('passes active alerts into the system strip and opens the alert center from the strip', () => {
+    window.FEATURE_FLAGS = { dashboard_v2: true }
+    mockAlerts = [
+      { id: '1', title: 'Temperature high', detail: 'Water temperature exceeded limit', severity: 'critical', ts: 101 },
+      { id: '2', title: 'Old alert', detail: 'Already handled', severity: 'warn', ts: 102, acknowledged: true }
+    ]
+
+    const { container, cleanup } = renderDashboard({
+      equipment: [],
+      temperatureControllers: [{ id: '1' }],
+      phProbes: [{ id: '1' }],
+      atos: [{ id: '1' }],
+      sseEndpoint: '/api/alerts'
+    })
+
+    expect(JSON.parse(container.querySelector('[data-testid="system-strip"]').getAttribute('data-alerts'))).toEqual([mockAlerts[0]])
+    expect(container.querySelector('[data-testid="alert-center"]').getAttribute('data-open')).toBe('no')
+
+    act(() => container.querySelector('[data-testid="system-strip-alert-trigger"]').click())
+    expect(container.querySelector('[data-testid="alert-center"]').getAttribute('data-open')).toBe('yes')
+    expect(container.querySelector('#configure-dashboard')).toBeNull()
 
     cleanup()
   })

--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/SystemStrip.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/SystemStrip.jsx
@@ -46,174 +46,176 @@ export default function SystemStrip ({
   }, [menuOpen])
 
   return (
-    <div
-      className='reefpi-system-strip'
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: '0.75rem',
-        height: '56px',
-        padding: '0 1rem',
-        background: 'var(--reefpi-color-surface-elevated)',
-        borderBottom: '1px solid var(--reefpi-color-border)',
-        fontFamily: 'var(--reefpi-font-app)',
-        flexShrink: 0
-      }}
-    >
-      {/* Health pill */}
-      <span
-        aria-label={`System health: ${health}`}
+    <>
+      <style>{'\n        .reefpi-system-strip { height: 56px; }\n        @media (max-width: 480px) { .reefpi-system-strip { height: 48px; } }\n      '}</style>
+      <div
+        className='reefpi-system-strip'
         style={{
-          width: '10px',
-          height: '10px',
-          borderRadius: '50%',
-          background: PILL_COLORS[health],
-          flexShrink: 0,
-          transition: 'background-color 0.2s'
-        }}
-      />
-
-      {/* Tank name */}
-      <span
-        style={{
-          fontSize: '0.9rem',
-          fontWeight: 500,
-          color: 'var(--reefpi-color-text)',
-          whiteSpace: 'nowrap',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          flex: '1 1 auto',
-          minWidth: 0
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.75rem',
+          padding: '0 1rem',
+          background: 'var(--reefpi-color-surface-elevated)',
+          borderBottom: '1px solid var(--reefpi-color-border)',
+          fontFamily: 'var(--reefpi-font-app)',
+          flexShrink: 0
         }}
       >
-        {displayName}
-      </span>
+        {/* Health pill */}
+        <span
+          aria-label={`System health: ${health}`}
+          style={{
+            width: '10px',
+            height: '10px',
+            borderRadius: '50%',
+            background: PILL_COLORS[health],
+            flexShrink: 0,
+            transition: 'background-color 0.2s'
+          }}
+        />
 
-      {/* Uptime + version (hidden on very narrow viewports via flex shrink) */}
-      {(uptimeLabel || version) && (
+        {/* Tank name */}
         <span
           style={{
-            fontSize: '0.72rem',
-            color: 'var(--reefpi-color-text-muted)',
+            fontSize: '0.9rem',
+            fontWeight: 500,
+            color: 'var(--reefpi-color-text)',
             whiteSpace: 'nowrap',
-            flexShrink: 1,
-            overflow: 'hidden'
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            flex: '1 1 auto',
+            minWidth: 0
           }}
         >
-          {[uptimeLabel, version].filter(Boolean).join(' · ')}
+          {displayName}
         </span>
-      )}
 
-      {/* Alert count badge */}
-      {alertCount > 0 && (
-        <button
-          onClick={onAlertClick}
-          aria-label={`${alertCount} alert${alertCount !== 1 ? 's' : ''} — open alert center`}
-          style={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: '0.3rem',
-            background: health === 'critical'
-              ? 'var(--reefpi-color-error-bg)'
-              : 'var(--reefpi-color-warn-bg)',
-            border: `1px solid ${health === 'critical'
-              ? 'var(--reefpi-color-error-border)'
-              : 'var(--reefpi-color-warn)'}`,
-            borderRadius: 'var(--reefpi-radius-sm)',
-            color: health === 'critical'
-              ? 'var(--reefpi-color-error)'
-              : 'var(--reefpi-color-warn)',
-            fontSize: '0.72rem',
-            fontFamily: 'var(--reefpi-font-app)',
-            padding: '2px 8px',
-            cursor: 'pointer',
-            minHeight: '28px',
-            whiteSpace: 'nowrap',
-            flexShrink: 0
-          }}
-        >
+        {/* Uptime + version (hidden on very narrow viewports via flex shrink) */}
+        {(uptimeLabel || version) && (
           <span
             style={{
-              width: '6px',
-              height: '6px',
-              borderRadius: '50%',
-              background: 'currentColor',
-              flexShrink: 0
-            }}
-          />
-          {alertCount} alert{alertCount !== 1 ? 's' : ''}
-        </button>
-      )}
-
-      {/* Kebab menu */}
-      <div ref={menuRef} style={{ position: 'relative', flexShrink: 0 }}>
-        <button
-          aria-label='System menu'
-          aria-expanded={menuOpen}
-          aria-haspopup='true'
-          onClick={() => setMenuOpen(o => !o)}
-          style={{
-            background: 'none',
-            border: 'none',
-            cursor: 'pointer',
-            padding: '6px 8px',
-            minHeight: '44px',
-            minWidth: '44px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            borderRadius: 'var(--reefpi-radius-sm)',
-            color: 'var(--reefpi-color-text-muted)'
-          }}
-        >
-          <svg width='4' height='16' viewBox='0 0 4 16' fill='currentColor' aria-hidden='true'>
-            <circle cx='2' cy='2' r='1.5' />
-            <circle cx='2' cy='8' r='1.5' />
-            <circle cx='2' cy='14' r='1.5' />
-          </svg>
-        </button>
-
-        {menuOpen && (
-          <div
-            role='menu'
-            style={{
-              position: 'absolute',
-              top: '100%',
-              right: 0,
-              zIndex: 100,
-              background: 'var(--reefpi-color-surface-elevated)',
-              border: '1px solid var(--reefpi-color-border)',
-              borderRadius: 'var(--reefpi-radius-md)',
-              boxShadow: '0 4px 12px rgba(0,0,0,0.08)',
-              minWidth: '140px',
+              fontSize: '0.72rem',
+              color: 'var(--reefpi-color-text-muted)',
+              whiteSpace: 'nowrap',
+              flexShrink: 1,
               overflow: 'hidden'
             }}
           >
-            <button
-              role='menuitem'
-              onClick={() => { setMenuOpen(false); onConfigure?.() }}
-              style={menuItemStyle}
-            >
-              Configure
-            </button>
-            <button
-              role='menuitem'
-              onClick={() => { setMenuOpen(false); onResetDashboardConfig?.() }}
-              style={{ ...menuItemStyle, borderTop: '1px solid var(--reefpi-color-border)' }}
-            >
-              Reset dashboard config
-            </button>
-            <button
-              role='menuitem'
-              onClick={() => { setMenuOpen(false); onSignOut?.() }}
-              style={{ ...menuItemStyle, color: 'var(--reefpi-color-error)', borderTop: '1px solid var(--reefpi-color-border)' }}
-            >
-              Sign out
-            </button>
-          </div>
+            {[uptimeLabel, version].filter(Boolean).join(' · ')}
+          </span>
         )}
+
+        {/* Alert count badge */}
+        {alertCount > 0 && (
+          <button
+            onClick={onAlertClick}
+            aria-label={`${alertCount} alert${alertCount !== 1 ? 's' : ''} — open alert center`}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '0.3rem',
+              background: health === 'critical'
+                ? 'var(--reefpi-color-error-bg)'
+                : 'var(--reefpi-color-warn-bg)',
+              border: `1px solid ${health === 'critical'
+              ? 'var(--reefpi-color-error-border)'
+              : 'var(--reefpi-color-warn)'}`,
+              borderRadius: 'var(--reefpi-radius-sm)',
+              color: health === 'critical'
+                ? 'var(--reefpi-color-error)'
+                : 'var(--reefpi-color-warn)',
+              fontSize: '0.72rem',
+              fontFamily: 'var(--reefpi-font-app)',
+              padding: '2px 8px',
+              cursor: 'pointer',
+              minHeight: '28px',
+              whiteSpace: 'nowrap',
+              flexShrink: 0
+            }}
+          >
+            <span
+              style={{
+                width: '6px',
+                height: '6px',
+                borderRadius: '50%',
+                background: 'currentColor',
+                flexShrink: 0
+              }}
+            />
+            {alertCount} alert{alertCount !== 1 ? 's' : ''}
+          </button>
+        )}
+
+        {/* Kebab menu */}
+        <div ref={menuRef} style={{ position: 'relative', flexShrink: 0 }}>
+          <button
+            aria-label='System menu'
+            aria-expanded={menuOpen}
+            aria-haspopup='true'
+            onClick={() => setMenuOpen(o => !o)}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: '6px 8px',
+              minHeight: '44px',
+              minWidth: '44px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRadius: 'var(--reefpi-radius-sm)',
+              color: 'var(--reefpi-color-text-muted)'
+            }}
+          >
+            <svg width='4' height='16' viewBox='0 0 4 16' fill='currentColor' aria-hidden='true'>
+              <circle cx='2' cy='2' r='1.5' />
+              <circle cx='2' cy='8' r='1.5' />
+              <circle cx='2' cy='14' r='1.5' />
+            </svg>
+          </button>
+
+          {menuOpen && (
+            <div
+              role='menu'
+              style={{
+                position: 'absolute',
+                top: '100%',
+                right: 0,
+                zIndex: 100,
+                background: 'var(--reefpi-color-surface-elevated)',
+                border: '1px solid var(--reefpi-color-border)',
+                borderRadius: 'var(--reefpi-radius-md)',
+                boxShadow: '0 4px 12px rgba(0,0,0,0.08)',
+                minWidth: '140px',
+                overflow: 'hidden'
+              }}
+            >
+              <button
+                role='menuitem'
+                onClick={() => { setMenuOpen(false); onConfigure?.() }}
+                style={menuItemStyle}
+              >
+                Configure
+              </button>
+              <button
+                role='menuitem'
+                onClick={() => { setMenuOpen(false); onResetDashboardConfig?.() }}
+                style={{ ...menuItemStyle, borderTop: '1px solid var(--reefpi-color-border)' }}
+              >
+                Reset dashboard config
+              </button>
+              <button
+                role='menuitem'
+                onClick={() => { setMenuOpen(false); onSignOut?.() }}
+                style={{ ...menuItemStyle, color: 'var(--reefpi-color-error)', borderTop: '1px solid var(--reefpi-color-border)' }}
+              >
+                Sign out
+              </button>
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+    </>
   )
 }
 

--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/SystemStrip.test.js
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/SystemStrip.test.js
@@ -27,6 +27,14 @@ describe('design-system SystemStrip', () => {
     )).toContain('System health: critical')
   })
 
+  it('ships the narrow viewport height rule with the component', () => {
+    const html = renderToStaticMarkup(<SystemStrip />)
+
+    expect(html).toContain('height: 56px')
+    expect(html).toContain('@media (max-width: 480px)')
+    expect(html).toContain('height: 48px')
+  })
+
   it('opens menu, invokes actions, and closes on outside pointer down', () => {
     const onAlertClick = jest.fn()
     const onConfigure = jest.fn()


### PR DESCRIPTION
Closes #3094

Parent epic: E3 Dashboard v2

Tracking doc: `front-end/design-system/github_issues/epic-03-dashboard-v2.md`

## What changed

- Wired active alert state from `useAlertsStore` into the Dashboard v2 system strip.
- Opened the controlled alert-center slide-over from the strip alert count.
- Kept Configure in the strip kebab path and covered that Dashboard v2 no longer renders the old bottom Configure button.
- Added coverage for the strip height rule: 56px desktop, 48px narrow viewports.
- Marked design-system issue #10 complete in the local tracking docs.

## Verification

All checks passed locally:

- Dashboard Jest coverage for SystemStrip, DashboardV2, AlertCenter, and dashboard tiles.
- StandardJS for the touched Dashboard v2 and SystemStrip files.
- Preview card check.
- Git whitespace check.
- Production UI build.

<details>
<summary>Commands run</summary>

```sh
rtk yarn jest front-end/design-system/ui_kits/reef-pi-app/dashboard/SystemStrip.test.js front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js front-end/design-system/ui_kits/reef-pi-app/dashboard/AlertCenter.test.js front-end/design-system/ui_kits/reef-pi-app/dashboard/dashboard_tiles.test.js --runInBand
rtk ./node_modules/.bin/standard front-end/design-system/ui_kits/reef-pi-app/dashboard/SystemStrip.jsx front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.jsx front-end/design-system/ui_kits/reef-pi-app/dashboard/SystemStrip.test.js front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js
rtk yarn run preview-card-check
rtk git diff --check
rtk yarn build
```

Note: `rtk yarn build` passed with existing webpack size/mode warnings.
</details>
