### PR TITLE
[claude design] Dashboard · Hero TemperatureTile

### DIFF
--- a/front-end/design-system/github_issues/BACKLOG.md
+++ b/front-end/design-system/github_issues/BACKLOG.md
@@ -18,7 +18,7 @@
 
 ## E3 · Dashboard v2 (flag: `dashboard_v2`)
 - [x] #10 System status strip — `issue-10-system-strip.md`
-- [ ] #11 Hero TemperatureTile — `issue-11-hero-temp.md`
+- [x] #11 Hero TemperatureTile — `issue-11-hero-temp.md`
 - [ ] #12 Secondary PhTile / AtoTile — `issue-12-ph-ato-tiles.md`
 - [ ] #13 Equipment strip (footer) — `issue-13-equipment-strip.md`
 - [ ] #14 Wire behind `dashboard_v2` flag — `issue-14-dashboard-flag.md`

--- a/front-end/design-system/github_issues/epic-03-dashboard-v2.md
+++ b/front-end/design-system/github_issues/epic-03-dashboard-v2.md
@@ -12,14 +12,14 @@ Rebuild the dashboard around a clear visual hierarchy. Add a single-line system-
 
 ## Success criteria
 - [x] Above the tile grid, a system-status strip shows: health pill (OK / Warn / Critical), tank name, uptime, count of active alerts.
-- [ ] Temperature tile spans `col-md-8` on desktop, showing big numeric + gradient area chart + shaded threshold band (76–80°F).
+- [x] Temperature tile spans `col-md-8` on desktop, showing big numeric + gradient area chart + shaded threshold band (76–80°F).
 - [ ] pH and ATO tiles (`col-md-4`) use `Sparkline v2` + `RangeSelector`.
 - [ ] Equipment toggles move into a horizontal strip along the dashboard footer (above `Summary`).
 - [ ] Old dashboard still reachable via `dashboard_v2=false` until flag removal.
 
 ## Sub-tasks
 - [x] #10 System status strip
-- [ ] #11 Hero TemperatureTile
+- [x] #11 Hero TemperatureTile
 - [ ] #12 Secondary PhTile / AtoTile with RangeSelector
 - [ ] #13 Equipment strip (horizontal, footer position)
 - [ ] #14 Wire behind `dashboard_v2` flag

--- a/front-end/design-system/github_issues/issue-11-hero-temp.md
+++ b/front-end/design-system/github_issues/issue-11-hero-temp.md
@@ -16,7 +16,7 @@ Promote temperature to a 2-col tile that doubles as the dashboard's anchor.
 - Header-right: `<RangeSelector scope="dashboard" />`.
 
 ## Acceptance
-- [ ] Uses `useTimeSeries('temperature.display', range)`.
-- [ ] Crosshair-hover updates the numeric readout so user can scrub history.
-- [ ] Meets min-height 320px on desktop, 260px on mobile.
-- [ ] Empty / loading / error states match tile conventions.
+- [x] Uses `useTimeSeries('temperature.display', range)`.
+- [x] Crosshair-hover updates the numeric readout so user can scrub history.
+- [x] Meets min-height 320px on desktop, 260px on mobile.
+- [x] Empty / loading / error states match tile conventions.

--- a/front-end/design-system/preview/dashboard/temperature-tile.html
+++ b/front-end/design-system/preview/dashboard/temperature-tile.html
@@ -30,7 +30,7 @@
       font-family: var(--reefpi-font-app);
     }
 
-    @media (max-width: 600px) { .temp-tile { min-height: 260px; } }
+    @media (max-width: 480px) { .temp-tile { min-height: 260px; } }
 
     .tile-header {
       display: flex;
@@ -99,6 +99,9 @@
     /* ── Error state ───────────────────────────── */
     .error-state { flex:1 1 auto; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:.75rem; }
     .error-banner { padding:.5rem .75rem; background:var(--reefpi-color-error-bg); border:1px solid var(--reefpi-color-error-border); border-radius:var(--reefpi-radius-sm); color:var(--reefpi-color-error); font-size:.8rem; }
+    .empty-state { flex:1 1 auto; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:.5rem; color:var(--reefpi-color-text-muted); text-align:center; }
+    .empty-title { font-size:.9rem; font-weight:500; color:var(--reefpi-color-text); }
+    .empty-copy { font-size:.75rem; max-width:18rem; }
 
     /* ── RangeSelector ─────────────────────────── */
     .rs { display:inline-flex; border:1px solid var(--reefpi-color-border); border-radius:var(--reefpi-radius-sm); overflow:hidden; background:var(--reefpi-color-surface-elevated); }
@@ -181,7 +184,25 @@
     </div>
   </div>
 
-  <!-- Story 3: Error -->
+  <!-- Story 3: Empty -->
+  <div class="card" style="margin-bottom:1.5rem;">
+    <div class="card-header">Empty state</div>
+    <div class="card-body" style="padding:0;">
+      <div class="temp-tile">
+        <div class="tile-header">
+          <span class="tile-header-label">Temperature</span>
+        </div>
+        <div class="tile-body">
+          <div class="empty-state">
+            <div class="empty-title">No temperature data yet</div>
+            <div class="empty-copy">Telemetry will appear here after the next successful reading.</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Story 4: Error -->
   <div class="card">
     <div class="card-header">Error state</div>
     <div class="card-body" style="padding:0;">

--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/TemperatureTile.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/TemperatureTile.jsx
@@ -41,130 +41,151 @@ export default function TemperatureTile ({ metric = 'temperature.display', unit 
   const alertBorder = alert ? (ALERT_BORDER[alert.severity] ?? ALERT_BORDER.warn) : null
 
   return (
-    <div
-      className='reefpi-temperature-tile col-md-8'
-      style={{
-        background: 'var(--reefpi-color-surface-elevated)',
-        border: '1px solid var(--reefpi-color-border)',
-        borderTop: alertBorder ? `3px solid ${alertBorder}` : '1px solid var(--reefpi-color-border)',
-        borderRadius: 'var(--reefpi-radius-md)',
-        display: 'flex',
-        flexDirection: 'column',
-        minHeight: '320px',
-        overflow: 'hidden',
-        fontFamily: 'var(--reefpi-font-app)'
-      }}
-    >
-      {/* ── Header ── */}
-      <div style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        padding: '0.75rem 1rem',
-        borderBottom: '1px solid var(--reefpi-color-border)',
-        flexShrink: 0
-      }}
+    <>
+      <style>{'\n        .reefpi-temperature-tile { min-height: 320px; }\n        @media (max-width: 480px) { .reefpi-temperature-tile { min-height: 260px; } }\n      '}</style>
+      <div
+        className='reefpi-temperature-tile col-md-8'
+        style={{
+          background: 'var(--reefpi-color-surface-elevated)',
+          border: '1px solid var(--reefpi-color-border)',
+          borderTop: alertBorder ? `3px solid ${alertBorder}` : '1px solid var(--reefpi-color-border)',
+          borderRadius: 'var(--reefpi-radius-md)',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+          fontFamily: 'var(--reefpi-font-app)'
+        }}
       >
-        <span style={{ fontSize: '0.75rem', fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--reefpi-color-text-muted)' }}>
-          Temperature
-        </span>
-        <RangeSelector value={range} onChange={setRange} scope='dashboard' compact />
-      </div>
+        {/* ── Header ── */}
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '0.75rem 1rem',
+          borderBottom: '1px solid var(--reefpi-color-border)',
+          flexShrink: 0
+        }}
+        >
+          <span style={{ fontSize: '0.75rem', fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--reefpi-color-text-muted)' }}>
+            Temperature
+          </span>
+          <RangeSelector value={range} onChange={setRange} scope='dashboard' compact />
+        </div>
 
-      {/* ── Body ── */}
-      <div style={{ flex: '1 1 auto', display: 'flex', flexDirection: 'column', padding: '1rem', gap: '0.75rem', minHeight: 0 }}>
+        {/* ── Body ── */}
+        <div style={{ flex: '1 1 auto', display: 'flex', flexDirection: 'column', padding: '1rem', gap: '0.75rem', minHeight: 0 }}>
 
-        {loading && !points.length ? (
-          <LoadingSkeleton />
-        ) : error && !points.length ? (
-          <ErrorState message={error} onRetry={refetch} />
-        ) : (
-          <>
-            {/* ThresholdGauge */}
-            <ThresholdGauge
-              value={display ?? 78}
-              safe={SAFE}
-              warn={WARN}
-              critical={CRIT}
-              unit={unit}
-              label='Display Tank'
-            />
+          {loading && !points.length && <LoadingSkeleton />}
+          {!loading && error && !points.length && <ErrorState message={error} onRetry={refetch} />}
+          {!loading && !error && !points.length && <EmptyState />}
+          {points.length > 0 && (
+            <>
+              {/* ThresholdGauge */}
+              <ThresholdGauge
+                value={display ?? 78}
+                safe={SAFE}
+                warn={WARN}
+                critical={CRIT}
+                unit={unit}
+                label='Display Tank'
+              />
 
-            {/* Numeric readout */}
-            <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.5rem' }}>
-              <span style={{
-                fontSize: '3rem',
-                fontWeight: 500,
-                lineHeight: 1,
-                color: 'var(--reefpi-color-text)',
-                fontVariantNumeric: 'tabular-nums'
-              }}
-              >
-                {display !== null ? display.toFixed(1) : '—'}
-              </span>
-              <span style={{ fontSize: '1rem', color: 'var(--reefpi-color-text-muted)' }}>{unit}</span>
-              {diff !== null && hoverValue === null && (
+              {/* Numeric readout */}
+              <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.5rem' }}>
                 <span style={{
-                  fontSize: '0.8rem',
-                  color: parseFloat(diff) >= 0 ? 'var(--reefpi-color-warn)' : 'var(--reefpi-color-brand)',
+                  fontSize: '3rem',
+                  fontWeight: 500,
+                  lineHeight: 1,
+                  color: 'var(--reefpi-color-text)',
                   fontVariantNumeric: 'tabular-nums'
                 }}
                 >
-                  {parseFloat(diff) >= 0 ? '+' : ''}{diff} vs 1h ago
+                  {display !== null ? display.toFixed(1) : '—'}
                 </span>
-              )}
-              {hoverValue !== null && (
-                <span style={{ fontSize: '0.8rem', color: 'var(--reefpi-color-text-muted)' }}>
-                  scrubbing history
-                </span>
-              )}
-            </div>
+                <span style={{ fontSize: '1rem', color: 'var(--reefpi-color-text-muted)' }}>{unit}</span>
+                {diff !== null && hoverValue === null && (
+                  <span style={{
+                    fontSize: '0.8rem',
+                    color: parseFloat(diff) >= 0 ? 'var(--reefpi-color-warn)' : 'var(--reefpi-color-brand)',
+                    fontVariantNumeric: 'tabular-nums'
+                  }}
+                  >
+                    {parseFloat(diff) >= 0 ? '+' : ''}{diff} vs 1h ago
+                  </span>
+                )}
+                {hoverValue !== null && (
+                  <span style={{ fontSize: '0.8rem', color: 'var(--reefpi-color-text-muted)' }}>
+                    scrubbing history
+                  </span>
+                )}
+              </div>
 
-            {/* Sparkline — fills remaining height */}
-            <div style={{ flex: '1 1 auto', minHeight: '80px' }}>
-              <Sparkline
-                points={points}
-                fill='gradient'
-                band={SAFE}
-                bandColor='var(--reefpi-color-band-safe)'
-                hover
-                onHover={pt => setHoverValue(pt ? pt.v : null)}
-                height={120}
-              />
-            </div>
-          </>
+              {/* Sparkline — fills remaining height */}
+              <div style={{ flex: '1 1 auto', minHeight: '80px' }}>
+                <Sparkline
+                  points={points}
+                  fill='gradient'
+                  band={SAFE}
+                  bandColor='var(--reefpi-color-band-safe)'
+                  hover
+                  onHover={pt => setHoverValue(pt ? pt.v : null)}
+                  height={120}
+                />
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Inline alert footer */}
+        {alert && (
+          <button
+            onClick={onAlertClick}
+            aria-live='polite'
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.375rem',
+              padding: '0.375rem 0.875rem',
+              background: 'transparent',
+              border: 'none',
+              borderTop: `1px solid ${alertBorder}`,
+              width: '100%',
+              cursor: onAlertClick ? 'pointer' : 'default',
+              fontFamily: 'var(--reefpi-font-app)',
+              flexShrink: 0
+            }}
+          >
+            <span style={{ fontSize: '0.72rem', color: alertBorder, flex: '1 1 auto', textAlign: 'left', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {alert.message}
+            </span>
+            {alert.at && (
+              <span style={{ fontSize: '0.65rem', color: 'var(--reefpi-color-text-muted)', fontFamily: 'var(--reefpi-font-mono)', flexShrink: 0 }}>
+                {alertRelTime(alert.at)}
+              </span>
+            )}
+          </button>
         )}
       </div>
+    </>
+  )
+}
 
-      {/* Inline alert footer */}
-      {alert && (
-        <button
-          onClick={onAlertClick}
-          aria-live='polite'
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.375rem',
-            padding: '0.375rem 0.875rem',
-            background: 'transparent',
-            border: 'none',
-            borderTop: `1px solid ${alertBorder}`,
-            width: '100%',
-            cursor: onAlertClick ? 'pointer' : 'default',
-            fontFamily: 'var(--reefpi-font-app)',
-            flexShrink: 0
-          }}
-        >
-          <span style={{ fontSize: '0.72rem', color: alertBorder, flex: '1 1 auto', textAlign: 'left', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-            {alert.message}
-          </span>
-          {alert.at && (
-            <span style={{ fontSize: '0.65rem', color: 'var(--reefpi-color-text-muted)', fontFamily: 'var(--reefpi-font-mono)', flexShrink: 0 }}>
-              {alertRelTime(alert.at)}
-            </span>
-          )}
-        </button>
-      )}
+function EmptyState () {
+  return (
+    <div
+      style={{
+        flex: '1 1 auto',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '0.5rem',
+        color: 'var(--reefpi-color-text-muted)',
+        textAlign: 'center'
+      }}
+    >
+      <div style={{ fontSize: '0.9rem', fontWeight: 500, color: 'var(--reefpi-color-text)' }}>No temperature data yet</div>
+      <div style={{ fontSize: '0.75rem', maxWidth: '18rem' }}>Telemetry will appear here after the next successful reading.</div>
     </div>
   )
 }

--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/dashboard_tiles.test.js
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/dashboard_tiles.test.js
@@ -150,9 +150,47 @@ describe('design-system dashboard tiles', () => {
       refetch: jest.fn()
     })
     const html = renderToStaticMarkup(<TemperatureTile metric='temp' unit='F' />)
+    expect(useTimeSeries).toHaveBeenLastCalledWith({ metric: 'temp', range: '1d', maxPoints: 120 })
     expect(html).toContain('Temperature')
     expect(html).toContain('78.3')
     expect(html).toContain('vs 1h ago')
+    expect(html).toContain('col-md-8')
+    expect(html).toContain('min-height: 320px')
+    expect(html).toContain('@media (max-width: 480px)')
+    expect(html).toContain('min-height: 260px')
+  })
+
+  it('renders TemperatureTile empty state and updates readout while scrubbing history', () => {
+    useTimeSeries.mockReturnValueOnce({ points: [], loading: false, error: null, refetch: jest.fn() })
+    expect(renderToStaticMarkup(<TemperatureTile metric='temp' unit='F' />)).toContain('No temperature data yet')
+
+    useTimeSeries.mockReturnValueOnce({
+      points: [{ t: 1, v: 77.1 }, { t: 2, v: 81.5 }],
+      loading: false,
+      error: null,
+      refetch: jest.fn()
+    })
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    act(() => {
+      root.render(<TemperatureTile metric='temp' unit='F' />)
+    })
+
+    expect(container.textContent).toContain('81.5')
+    const svg = container.querySelector('svg[aria-label="Sparkline chart"]')
+    svg.getBoundingClientRect = () => ({ left: 0, width: 300 })
+
+    act(() => {
+      svg.dispatchEvent(new MouseEvent('pointermove', { clientX: 0, bubbles: true }))
+    })
+
+    expect(container.textContent).toContain('77.1')
+    expect(container.textContent).toContain('scrubbing history')
+
+    act(() => root.unmount())
+    container.remove()
   })
 
   it('renders TemperatureTile alert footer and handles alert clicks', () => {


### PR DESCRIPTION
Closes #3096

Parent epic: E3 Dashboard v2

Tracking doc: `front-end/design-system/github_issues/epic-03-dashboard-v2.md`

## What Changed

- Kept `TemperatureTile` as the `col-md-8` Dashboard v2 hero tile.
- Added component-owned min-height rules: 320px desktop, 260px narrow viewport.
- Added an explicit empty state alongside the existing loading and error states.
- Added regression coverage for `useTimeSeries` range wiring, the hero layout contract, and sparkline hover scrubbing updating the numeric readout.
- Updated the TemperatureTile preview with the empty state and matching mobile breakpoint.
- Marked design-system issue #11 complete in the local tracking docs.

## Verification

All checks passed locally:

- Dashboard tile, DashboardV2, Sparkline, and RangeSelector Jest coverage.
- StandardJS for the touched TemperatureTile files.
- Preview card check.
- Git whitespace check.
- Production UI build.

<details>
<summary>Commands run</summary>

```sh
rtk yarn jest front-end/design-system/ui_kits/reef-pi-app/dashboard/dashboard_tiles.test.js front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js front-end/design-system/ui_kits/reef-pi-app/primitives/Sparkline.test.js front-end/design-system/ui_kits/reef-pi-app/primitives/RangeSelector.test.js --runInBand
rtk ./node_modules/.bin/standard front-end/design-system/ui_kits/reef-pi-app/dashboard/TemperatureTile.jsx front-end/design-system/ui_kits/reef-pi-app/dashboard/dashboard_tiles.test.js
rtk yarn run preview-card-check
rtk git diff --check
rtk yarn build
```

Note: `rtk yarn build` passed with existing webpack size/mode warnings.
</details>
