### PR TITLE
[claude design] Dashboard · Secondary PhTile / AtoTile

### DIFF
--- a/front-end/design-system/github_issues/BACKLOG.md
+++ b/front-end/design-system/github_issues/BACKLOG.md
@@ -19,7 +19,7 @@
 ## E3 · Dashboard v2 (flag: `dashboard_v2`)
 - [x] #10 System status strip — `issue-10-system-strip.md`
 - [x] #11 Hero TemperatureTile — `issue-11-hero-temp.md`
-- [ ] #12 Secondary PhTile / AtoTile — `issue-12-ph-ato-tiles.md`
+- [x] #12 Secondary PhTile / AtoTile — `issue-12-ph-ato-tiles.md`
 - [ ] #13 Equipment strip (footer) — `issue-13-equipment-strip.md`
 - [ ] #14 Wire behind `dashboard_v2` flag — `issue-14-dashboard-flag.md`
 

--- a/front-end/design-system/github_issues/epic-03-dashboard-v2.md
+++ b/front-end/design-system/github_issues/epic-03-dashboard-v2.md
@@ -13,14 +13,14 @@ Rebuild the dashboard around a clear visual hierarchy. Add a single-line system-
 ## Success criteria
 - [x] Above the tile grid, a system-status strip shows: health pill (OK / Warn / Critical), tank name, uptime, count of active alerts.
 - [x] Temperature tile spans `col-md-8` on desktop, showing big numeric + gradient area chart + shaded threshold band (76–80°F).
-- [ ] pH and ATO tiles (`col-md-4`) use `Sparkline v2` + `RangeSelector`.
+- [x] pH and ATO tiles (`col-md-4`) use `Sparkline v2` + `RangeSelector`.
 - [ ] Equipment toggles move into a horizontal strip along the dashboard footer (above `Summary`).
 - [ ] Old dashboard still reachable via `dashboard_v2=false` until flag removal.
 
 ## Sub-tasks
 - [x] #10 System status strip
 - [x] #11 Hero TemperatureTile
-- [ ] #12 Secondary PhTile / AtoTile with RangeSelector
+- [x] #12 Secondary PhTile / AtoTile with RangeSelector
 - [ ] #13 Equipment strip (horizontal, footer position)
 - [ ] #14 Wire behind `dashboard_v2` flag
 

--- a/front-end/design-system/github_issues/issue-12-ph-ato-tiles.md
+++ b/front-end/design-system/github_issues/issue-12-ph-ato-tiles.md
@@ -17,6 +17,6 @@ Each tile:
 - pH uses `band={[8.1, 8.4]}`; ATO uses `band` only if configured target set.
 
 ## Acceptance
-- [ ] Both tiles obey the global-scope `RangeSelector` unless user changes locally (then falls back to local scope).
-- [ ] Identical card chrome across both — extract a `MetricTile` wrapper.
-- [ ] Empty / loading / error states.
+- [x] Both tiles obey the global-scope `RangeSelector` unless user changes locally (then falls back to local scope).
+- [x] Identical card chrome across both — extract a `MetricTile` wrapper.
+- [x] Empty / loading / error states.

--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/MetricTile.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/MetricTile.jsx
@@ -6,12 +6,12 @@ import { useTimeSeries } from '../hooks/useTimeSeries'
 
 const ALERT_BORDER_COLOR = {
   critical: 'var(--reefpi-color-error)',
-  warn:     'var(--reefpi-color-warn)'
+  warn: 'var(--reefpi-color-warn)'
 }
 
 function alertRelTime (ts) {
   const s = Math.floor((Date.now() - ts) / 1000)
-  if (s < 60)   return `${s}s`
+  if (s < 60) return `${s}s`
   if (s < 3600) return `${Math.floor(s / 60)}m`
   return `${Math.floor(s / 3600)}h`
 }
@@ -26,7 +26,7 @@ export default function MetricTile ({
   label,
   unit = '',
   band,
-  globalRange,       // lifted range from parent (optional)
+  globalRange, // lifted range from parent (optional)
   defaultRange = '1d',
   formatValue = v => v.toFixed(2),
   trendPrecision = 2,
@@ -57,6 +57,10 @@ export default function MetricTile ({
   const displayValue = hoverValue !== null ? hoverValue : latest
 
   const alertBorderColor = alert ? (ALERT_BORDER_COLOR[alert.severity] ?? ALERT_BORDER_COLOR.warn) : null
+  const hasPoints = points.length > 0
+  const showSkeleton = loading && !hasPoints
+  const showError = !loading && error && !hasPoints
+  const showEmpty = !loading && !error && !hasPoints
 
   return (
     <div
@@ -81,12 +85,16 @@ export default function MetricTile ({
         padding: '0.625rem 0.875rem',
         borderBottom: '1px solid var(--reefpi-color-border)',
         flexShrink: 0
-      }}>
+      }}
+      >
         <span style={{
-          fontSize: '0.75rem', fontWeight: 500,
-          textTransform: 'uppercase', letterSpacing: '0.06em',
+          fontSize: '0.75rem',
+          fontWeight: 500,
+          textTransform: 'uppercase',
+          letterSpacing: '0.06em',
           color: 'var(--reefpi-color-text-muted)'
-        }}>
+        }}
+        >
           {label}
         </span>
         <RangeSelector
@@ -99,23 +107,29 @@ export default function MetricTile ({
 
       {/* Body */}
       <div style={{
-        flex: '1 1 auto', display: 'flex', flexDirection: 'column',
-        padding: '0.75rem 0.875rem', gap: '0.5rem', minHeight: 0
-      }}>
-        {loading && !points.length ? (
-          <TileSkeleton />
-        ) : error && !points.length ? (
-          <TileError message={error} onRetry={refetch} />
-        ) : !points.length ? (
-          <TileEmpty label={label} />
-        ) : (
+        flex: '1 1 auto',
+        display: 'flex',
+        flexDirection: 'column',
+        padding: '0.75rem 0.875rem',
+        gap: '0.5rem',
+        minHeight: 0
+      }}
+      >
+        {showSkeleton && <TileSkeleton />}
+        {showError && <TileError message={error} onRetry={refetch} />}
+        {showEmpty && <TileEmpty label={label} />}
+        {hasPoints && (
           <>
             {/* Value row */}
             <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.35rem' }}>
               <span style={{
-                fontSize: '1.75rem', fontWeight: 500, lineHeight: 1,
-                color: 'var(--reefpi-color-text)', fontVariantNumeric: 'tabular-nums'
-              }}>
+                fontSize: '1.75rem',
+                fontWeight: 500,
+                lineHeight: 1,
+                color: 'var(--reefpi-color-text)',
+                fontVariantNumeric: 'tabular-nums'
+              }}
+              >
                 {displayValue !== null ? formatValue(displayValue) : '—'}
               </span>
               <span style={{ fontSize: '0.8rem', color: 'var(--reefpi-color-text-muted)' }}>
@@ -155,7 +169,6 @@ export default function MetricTile ({
             alignItems: 'center',
             gap: '0.4rem',
             padding: '0.35rem 0.875rem',
-            borderTop: '1px solid var(--reefpi-color-border)',
             background: 'none',
             border: 'none',
             borderTop: '1px solid var(--reefpi-color-border)',
@@ -174,7 +187,8 @@ export default function MetricTile ({
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
             flex: '1 1 auto'
-          }}>
+          }}
+          >
             {alert.message}
           </span>
           {alert.at && (
@@ -183,7 +197,8 @@ export default function MetricTile ({
               color: 'var(--reefpi-color-text-muted)',
               fontFamily: 'var(--reefpi-font-mono)',
               flexShrink: 0
-            }}>
+            }}
+            >
               {alertRelTime(alert.at)}
             </span>
           )}
@@ -210,9 +225,12 @@ function TrendArrow ({ trend, precision }) {
     <span style={{
       fontSize: '0.72rem',
       color: up ? 'var(--reefpi-color-warn)' : 'var(--reefpi-color-brand)',
-      display: 'inline-flex', alignItems: 'center', gap: '1px',
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: '1px',
       fontVariantNumeric: 'tabular-nums'
-    }}>
+    }}
+    >
       {up ? '▲' : '▼'} {Math.abs(trend).toFixed(precision)}
     </span>
   )
@@ -220,13 +238,16 @@ function TrendArrow ({ trend, precision }) {
 
 function TileSkeleton () {
   const bar = (h, w = '100%') => ({
-    height: h, width: w, borderRadius: 'var(--reefpi-radius-sm)',
+    height: h,
+    width: w,
+    borderRadius: 'var(--reefpi-radius-sm)',
     background: 'linear-gradient(90deg,var(--reefpi-color-surface) 25%,var(--reefpi-color-border) 50%,var(--reefpi-color-surface) 75%)',
-    backgroundSize: '200% 100%', animation: 'reefpi-shimmer 1.4s infinite'
+    backgroundSize: '200% 100%',
+    animation: 'reefpi-shimmer 1.4s infinite'
   })
   return (
     <>
-      <style>{`@keyframes reefpi-shimmer{0%{background-position:200% 0}100%{background-position:-200% 0}}`}</style>
+      <style>{'@keyframes reefpi-shimmer{0%{background-position:200% 0}100%{background-position:-200% 0}}'}</style>
       <div style={bar('1.75rem', '50%')} />
       <div style={{ ...bar('80px'), flex: '1 1 auto' }} />
     </>
@@ -236,23 +257,39 @@ function TileSkeleton () {
 function TileError ({ message, onRetry }) {
   return (
     <div style={{
-      flex: '1 1 auto', display: 'flex', flexDirection: 'column',
-      alignItems: 'center', justifyContent: 'center', gap: '0.5rem'
-    }}>
+      flex: '1 1 auto',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: '0.5rem'
+    }}
+    >
       <span style={{
-        fontSize: '0.75rem', color: 'var(--reefpi-color-error)',
+        fontSize: '0.75rem',
+        color: 'var(--reefpi-color-error)',
         background: 'var(--reefpi-color-error-bg)',
         border: '1px solid var(--reefpi-color-error-border)',
         borderRadius: 'var(--reefpi-radius-sm)',
         padding: '0.4rem 0.75rem'
-      }}>{message}</span>
+      }}
+      >{message}
+      </span>
       {onRetry && (
-        <button onClick={onRetry} style={{
-          background: 'none', border: '1px solid var(--reefpi-color-border-strong)',
-          borderRadius: 'var(--reefpi-radius-sm)', color: 'var(--reefpi-color-text)',
-          fontSize: '0.75rem', padding: '0 0.75rem', minHeight: '44px',
-          cursor: 'pointer', fontFamily: 'var(--reefpi-font-app)'
-        }}>Retry</button>
+        <button
+          onClick={onRetry} style={{
+            background: 'none',
+            border: '1px solid var(--reefpi-color-border-strong)',
+            borderRadius: 'var(--reefpi-radius-sm)',
+            color: 'var(--reefpi-color-text)',
+            fontSize: '0.75rem',
+            padding: '0 0.75rem',
+            minHeight: '44px',
+            cursor: 'pointer',
+            fontFamily: 'var(--reefpi-font-app)'
+          }}
+        >Retry
+        </button>
       )}
     </div>
   )
@@ -261,10 +298,14 @@ function TileError ({ message, onRetry }) {
 function TileEmpty ({ label }) {
   return (
     <div style={{
-      flex: '1 1 auto', display: 'flex', alignItems: 'center',
-      justifyContent: 'center', color: 'var(--reefpi-color-text-muted)',
+      flex: '1 1 auto',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      color: 'var(--reefpi-color-text-muted)',
       fontSize: '0.8rem'
-    }}>
+    }}
+    >
       No {label} data yet
     </div>
   )

--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/dashboard_tiles.test.js
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/dashboard_tiles.test.js
@@ -70,6 +70,33 @@ describe('design-system dashboard tiles', () => {
     expect(html).toContain('1m')
   })
 
+  it('inherits global range until a local compact range is selected', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    act(() => {
+      root.render(
+        <MetricTile
+          metric='ph.display'
+          label='pH'
+          globalRange='7d'
+        />
+      )
+    })
+
+    expect(useTimeSeries).toHaveBeenLastCalledWith({ metric: 'ph.display', range: '7d', maxPoints: 80 })
+
+    const hourRange = container.querySelector('input[value="1h"]')
+    act(() => hourRange.click())
+
+    expect(useTimeSeries).toHaveBeenLastCalledWith({ metric: 'ph.display', range: '1h', maxPoints: 80 })
+    expect(container.querySelector('.reefpi-range-selector')).not.toBeNull()
+
+    act(() => root.unmount())
+    container.remove()
+  })
+
   it('renders MetricTile loading, error, and empty states', () => {
     useTimeSeries.mockReturnValueOnce({ points: [], loading: true, error: null, refetch: jest.fn() })
     expect(renderToStaticMarkup(<MetricTile metric='m1' label='Metric' />)).toContain('reefpi-shimmer')
@@ -90,6 +117,25 @@ describe('design-system dashboard tiles', () => {
 
     useTimeSeries.mockReturnValueOnce({ points: [{ t: 1, v: 7.9 }], loading: false, error: null, refetch: jest.fn() })
     expect(renderToStaticMarkup(<PhTile globalRange='1d' />)).toContain('outside safe range')
+  })
+
+  it('renders pH and ATO secondary tiles with shared chrome and configured bands', () => {
+    useTimeSeries.mockReturnValueOnce({ points: [{ t: 1, v: 8.2 }], loading: false, error: null, refetch: jest.fn() })
+    const phHtml = renderToStaticMarkup(<PhTile globalRange='1d' />)
+    expect(phHtml).toContain('reefpi-metric-tile col-md-4')
+    expect(phHtml).toContain('reefpi-range-selector')
+    expect(phHtml).toContain('linearGradient')
+    expect(phHtml).toContain('var(--reefpi-color-band-safe)')
+
+    useTimeSeries.mockReturnValueOnce({ points: [{ t: 1, v: 50 }, { t: 2, v: 52 }], loading: false, error: null, refetch: jest.fn() })
+    const atoWithTargetHtml = renderToStaticMarkup(<AtoTile globalRange='1d' targetLevel={50} />)
+    expect(atoWithTargetHtml).toContain('reefpi-metric-tile col-md-4')
+    expect(atoWithTargetHtml).toContain('reefpi-range-selector')
+    expect(atoWithTargetHtml).toContain('var(--reefpi-color-band-safe)')
+
+    useTimeSeries.mockReturnValueOnce({ points: [{ t: 1, v: 50 }, { t: 2, v: 52 }], loading: false, error: null, refetch: jest.fn() })
+    const atoWithoutTargetHtml = renderToStaticMarkup(<AtoTile globalRange='1d' />)
+    expect(atoWithoutTargetHtml).not.toContain('var(--reefpi-color-band-safe)')
   })
 
   it('renders EquipmentStrip empty, sorted, toggle, retry, and keyboard flows', () => {


### PR DESCRIPTION
## Summary
- Adds acceptance coverage for the Dashboard v2 secondary pH and ATO tiles.
- Verifies inherited global range behavior, local compact range override, shared MetricTile chrome, pH safe band, and target-gated ATO safe band.
- Cleans up MetricTile lint issues while preserving the existing tile behavior.
- Marks local issue #12 and E3 tracking docs complete.

## Validation
- `rtk yarn jest front-end/design-system/ui_kits/reef-pi-app/dashboard/dashboard_tiles.test.js front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js --runInBand`
- `rtk ./node_modules/.bin/standard front-end/design-system/ui_kits/reef-pi-app/dashboard/MetricTile.jsx front-end/design-system/ui_kits/reef-pi-app/dashboard/PhTile.jsx front-end/design-system/ui_kits/reef-pi-app/dashboard/AtoTile.jsx`
- `rtk git diff --check`
- `rtk yarn run preview-card-check`
- `rtk yarn build`

## Notes
Webpack build completed with the existing asset-size and missing-mode warnings.

Closes #3098
