### PR TITLE
[claude design] Dashboard · Equipment strip (footer)

### DIFF
--- a/front-end/design-system/github_issues/BACKLOG.md
+++ b/front-end/design-system/github_issues/BACKLOG.md
@@ -20,7 +20,7 @@
 - [x] #10 System status strip — `issue-10-system-strip.md`
 - [x] #11 Hero TemperatureTile — `issue-11-hero-temp.md`
 - [x] #12 Secondary PhTile / AtoTile — `issue-12-ph-ato-tiles.md`
-- [ ] #13 Equipment strip (footer) — `issue-13-equipment-strip.md`
+- [x] #13 Equipment strip (footer) — `issue-13-equipment-strip.md`
 - [ ] #14 Wire behind `dashboard_v2` flag — `issue-14-dashboard-flag.md`
 
 ## E4 · Control trust (flags: `pending_states`, `alert_center`)

--- a/front-end/design-system/github_issues/epic-03-dashboard-v2.md
+++ b/front-end/design-system/github_issues/epic-03-dashboard-v2.md
@@ -14,14 +14,14 @@ Rebuild the dashboard around a clear visual hierarchy. Add a single-line system-
 - [x] Above the tile grid, a system-status strip shows: health pill (OK / Warn / Critical), tank name, uptime, count of active alerts.
 - [x] Temperature tile spans `col-md-8` on desktop, showing big numeric + gradient area chart + shaded threshold band (76–80°F).
 - [x] pH and ATO tiles (`col-md-4`) use `Sparkline v2` + `RangeSelector`.
-- [ ] Equipment toggles move into a horizontal strip along the dashboard footer (above `Summary`).
+- [x] Equipment toggles move into a horizontal strip along the dashboard footer (above `Summary`).
 - [ ] Old dashboard still reachable via `dashboard_v2=false` until flag removal.
 
 ## Sub-tasks
 - [x] #10 System status strip
 - [x] #11 Hero TemperatureTile
 - [x] #12 Secondary PhTile / AtoTile with RangeSelector
-- [ ] #13 Equipment strip (horizontal, footer position)
+- [x] #13 Equipment strip (horizontal, footer position)
 - [ ] #14 Wire behind `dashboard_v2` flag
 
 ## Dependencies

--- a/front-end/design-system/github_issues/issue-13-equipment-strip.md
+++ b/front-end/design-system/github_issues/issue-13-equipment-strip.md
@@ -15,6 +15,6 @@ Replace the square equipment tile with a wider horizontal strip at the dashboard
 - Items ordered by last-toggled desc.
 
 ## Acceptance
-- [ ] Reuses `ToggleSwitch` (with pending/error states from #15 once available).
-- [ ] Tapping equipment name deep-links to `/equipment?edit={id}`.
-- [ ] Keyboard: arrow keys step between items; Space/Enter toggles.
+- [x] Reuses `ToggleSwitch` (with pending/error states from #15 once available).
+- [x] Tapping equipment name deep-links to `/equipment?edit={id}`.
+- [x] Keyboard: arrow keys step between items; Space/Enter toggles.

--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/EquipmentStrip.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/EquipmentStrip.jsx
@@ -14,7 +14,7 @@ import ToggleSwitch from '../primitives/ToggleSwitch'
 function formatOnSince (ts) {
   if (!ts) return null
   const s = Math.floor((Date.now() - ts) / 1000)
-  if (s < 60)   return `on ${s}s`
+  if (s < 60) return `on ${s}s`
   if (s < 3600) return `on ${Math.floor(s / 60)}m`
   const h = Math.floor(s / 3600)
   const m = Math.floor((s % 3600) / 60)
@@ -37,17 +37,26 @@ export default function EquipmentStrip ({ items = [], onToggle }) {
   }
 
   const handleKeyDown = e => {
-    if (e.key === 'ArrowRight') { e.preventDefault(); stepFocus(1) }
-    if (e.key === 'ArrowLeft')  { e.preventDefault(); stepFocus(-1) }
+    if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      stepFocus(1)
+    }
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      stepFocus(-1)
+    }
   }
 
   if (sorted.length === 0) {
     return (
       <div style={stripStyle}>
         <span style={{
-          fontSize: '0.8rem', color: 'var(--reefpi-color-text-muted)',
-          fontFamily: 'var(--reefpi-font-app)', padding: '0 1rem'
-        }}>
+          fontSize: '0.8rem',
+          color: 'var(--reefpi-color-text-muted)',
+          fontFamily: 'var(--reefpi-font-app)',
+          padding: '0 1rem'
+        }}
+        >
           No equipment configured
         </span>
       </div>
@@ -79,11 +88,28 @@ function EquipmentItem ({ item, isLast, onToggle }) {
     ? formatOnSince(item.onSince)
     : null
 
+  const requestToggle = () => {
+    if (item.state === 'pending') return
+    if (item.state === 'error') {
+      onToggle?.(item.id, 'on')
+      return
+    }
+    onToggle?.(item.id, item.state === 'on' ? 'off' : 'on')
+  }
+
+  const handleItemKeyDown = e => {
+    if (e.target !== e.currentTarget) return
+    if (e.key !== ' ' && e.key !== 'Enter') return
+    e.preventDefault()
+    requestToggle()
+  }
+
   return (
     <div
       role='listitem'
       tabIndex={0}
       data-equip-item
+      onKeyDown={handleItemKeyDown}
       style={{
         scrollSnapAlign: 'start',
         flexShrink: 0,
@@ -102,7 +128,7 @@ function EquipmentItem ({ item, isLast, onToggle }) {
       <ToggleSwitch
         state={item.state ?? 'off'}
         onRequestChange={next => onToggle?.(item.id, next)}
-        onRetry={() => onToggle?.(item.id, 'on')}
+        onRetry={requestToggle}
         errorMessage={item.errorMessage}
       />
       <a
@@ -129,7 +155,8 @@ function EquipmentItem ({ item, isLast, onToggle }) {
         fontFamily: 'var(--reefpi-font-mono)',
         height: '11px',
         lineHeight: '11px'
-      }}>
+      }}
+      >
         {onSince ?? ''}
       </span>
     </div>

--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/dashboard_tiles.test.js
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/dashboard_tiles.test.js
@@ -163,8 +163,23 @@ describe('design-system dashboard tiles', () => {
 
     const items = Array.from(container.querySelectorAll('[data-equip-item]'))
     expect(items.map(item => item.querySelector('a').textContent)).toEqual(['New Heater', 'Old Pump', 'Bad Light'])
+    expect(items[0].querySelector('a').getAttribute('href')).toBe('/equipment?edit=new')
+    expect(items[0].querySelector('[role="switch"]')).not.toBeNull()
     expect(items[0].textContent).toContain('on 1m')
     expect(items[2].textContent).toContain('failed')
+
+    expect(renderToStaticMarkup(
+      <EquipmentStrip
+        onToggle={onToggle}
+        items={[{ id: 'strip', name: 'Strip Pump', state: 'off', lastToggledAt: 10 }]}
+      />
+    )).toContain('height:96px')
+    expect(renderToStaticMarkup(
+      <EquipmentStrip
+        onToggle={onToggle}
+        items={[{ id: 'strip', name: 'Strip Pump', state: 'off', lastToggledAt: 10 }]}
+      />
+    )).toContain('scroll-snap-type:x mandatory')
 
     act(() => items[0].querySelector('button').click())
     expect(onToggle).toHaveBeenCalledWith('new', 'off')
@@ -177,6 +192,16 @@ describe('design-system dashboard tiles', () => {
       container.querySelector('[role="list"]').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
     })
     expect(scrollIntoView).toHaveBeenCalled()
+
+    act(() => {
+      items[1].dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }))
+    })
+    expect(onToggle).toHaveBeenCalledWith('old', 'on')
+
+    act(() => {
+      items[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+    expect(onToggle).toHaveBeenCalledWith('new', 'off')
 
     act(() => root.unmount())
     container.remove()


### PR DESCRIPTION
## Summary
- Updates the Dashboard v2 equipment strip into a full-width 96px horizontal footer strip.
- Reuses the existing ToggleSwitch primitive, including pending/error state support.
- Adds deep links from equipment names to `/equipment?edit={id}`.
- Adds keyboard handling for arrow navigation and Space/Enter toggles.
- Marks local issue #13 and E3 tracking docs complete.

## Parent Epic
E3 · dashboard-v2 from `front-end/design-system/github_issues/STRATEGY.md`.

## Validation
- `rtk yarn jest front-end/design-system/ui_kits/reef-pi-app/dashboard/dashboard_tiles.test.js front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js --runInBand`
- `rtk ./node_modules/.bin/standard front-end/design-system/ui_kits/reef-pi-app/dashboard/EquipmentStrip.jsx front-end/design-system/ui_kits/reef-pi-app/dashboard/dashboard_tiles.test.js`
- `rtk git diff --check main..HEAD`
- `rtk yarn run preview-card-check`
- `rtk yarn build`

## Notes
Webpack build completed with the existing asset-size and missing-mode warnings.

Closes #3102
