### PR TITLE
[claude design] Wire Dashboard v2 behind dashboard_v2 flag

### DIFF
--- a/front-end/assets/home.html
+++ b/front-end/assets/home.html
@@ -11,6 +11,6 @@
   </head>
   <body>
     <div id="main-panel"></div>
-    <script>window.FEATURE_FLAGS = Object.assign({ pending_states: true, alert_center: true, dashboard_v2: true, new_shell: true }, window.FEATURE_FLAGS);</script>
+    <script>window.FEATURE_FLAGS = Object.assign({ pending_states: true, alert_center: true, dashboard_v2: false, new_shell: true }, window.FEATURE_FLAGS);</script>
   </body>
 </html>

--- a/front-end/design-system/github_issues/BACKLOG.md
+++ b/front-end/design-system/github_issues/BACKLOG.md
@@ -21,7 +21,7 @@
 - [x] #11 Hero TemperatureTile — `issue-11-hero-temp.md`
 - [x] #12 Secondary PhTile / AtoTile — `issue-12-ph-ato-tiles.md`
 - [x] #13 Equipment strip (footer) — `issue-13-equipment-strip.md`
-- [ ] #14 Wire behind `dashboard_v2` flag — `issue-14-dashboard-flag.md`
+- [x] #14 Wire behind `dashboard_v2` flag — `issue-14-dashboard-flag.md`
 
 ## E4 · Control trust (flags: `pending_states`, `alert_center`)
 - [ ] #15 ToggleSwitch pending + error — `issue-15-toggle-states.md`

--- a/front-end/design-system/github_issues/epic-03-dashboard-v2.md
+++ b/front-end/design-system/github_issues/epic-03-dashboard-v2.md
@@ -15,14 +15,14 @@ Rebuild the dashboard around a clear visual hierarchy. Add a single-line system-
 - [x] Temperature tile spans `col-md-8` on desktop, showing big numeric + gradient area chart + shaded threshold band (76–80°F).
 - [x] pH and ATO tiles (`col-md-4`) use `Sparkline v2` + `RangeSelector`.
 - [x] Equipment toggles move into a horizontal strip along the dashboard footer (above `Summary`).
-- [ ] Old dashboard still reachable via `dashboard_v2=false` until flag removal.
+- [x] Old dashboard still reachable via `dashboard_v2=false` until flag removal.
 
 ## Sub-tasks
 - [x] #10 System status strip
 - [x] #11 Hero TemperatureTile
 - [x] #12 Secondary PhTile / AtoTile with RangeSelector
 - [x] #13 Equipment strip (horizontal, footer position)
-- [ ] #14 Wire behind `dashboard_v2` flag
+- [x] #14 Wire behind `dashboard_v2` flag
 
 ## Dependencies
 - Requires E2 primitives (#5, #6, #7, #8).

--- a/front-end/design-system/github_issues/issue-14-dashboard-flag.md
+++ b/front-end/design-system/github_issues/issue-14-dashboard-flag.md
@@ -9,8 +9,8 @@ parent: "[EPIC] Dashboard v2 — tiered hierarchy + system strip"
 Ship safely.
 
 ## Acceptance
-- [ ] `dashboard_v2` lives in the existing Tweaks object and in server-side feature config.
-- [ ] When `false`, original dashboard renders unchanged.
-- [ ] When `true`, new `<DashboardV2>` renders.
-- [ ] Flag default = `false` until QA sign-off, then flipped to `true`.
-- [ ] Removal ticket filed for 2 releases later.
+- [x] `dashboard_v2` lives in the existing Tweaks object and in server-side feature config.
+- [x] When `false`, original dashboard renders unchanged.
+- [x] When `true`, new `<DashboardV2>` renders.
+- [x] Flag default = `false` until QA sign-off, then flipped to `true`.
+- [x] Removal ticket filed for 2 releases later.

--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js
@@ -1,3 +1,5 @@
+import fs from 'fs'
+import path from 'path'
 import React, { act } from 'react'
 import { createRoot } from 'react-dom/client'
 import { renderToStaticMarkup } from 'react-dom/server'
@@ -38,6 +40,9 @@ import DashboardV2 from './DashboardV2'
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true
 
+const repoRoot = path.resolve(__dirname, '../../../../../')
+
+
 function renderDashboard (props = {}) {
   const container = document.createElement('div')
   document.body.appendChild(container)
@@ -60,6 +65,25 @@ function renderDashboard (props = {}) {
 function dataAlert (container, testId) {
   return JSON.parse(container.querySelector(`[data-testid="${testId}"]`).getAttribute('data-alert'))
 }
+
+describe('dashboard_v2 feature flag wiring', () => {
+  it('keeps dashboard_v2 disabled in the shipped server-rendered feature config', () => {
+    const html = fs.readFileSync(path.join(repoRoot, 'front-end/assets/home.html'), 'utf8')
+
+    expect(html).toContain('window.FEATURE_FLAGS')
+    expect(html).toContain('dashboard_v2: false')
+    expect(html).not.toContain('dashboard_v2: true')
+  })
+
+  it('exposes dashboard_v2 in the design-system Tweaks object and mirrors it to window.FEATURE_FLAGS', () => {
+    const html = fs.readFileSync(path.join(repoRoot, 'front-end/design-system/ui_kits/reef-pi-app/index.html'), 'utf8')
+
+    expect(html).toContain('"dashboardV2": false')
+    expect(html).toContain('window.FEATURE_FLAGS')
+    expect(html).toContain('dashboard_v2: TWEAKS.dashboardV2')
+    expect(html).toContain('Dashboard v2')
+  })
+})
 
 describe('design-system DashboardV2', () => {
   beforeEach(() => {

--- a/front-end/design-system/ui_kits/reef-pi-app/index.html
+++ b/front-end/design-system/ui_kits/reef-pi-app/index.html
@@ -15,7 +15,8 @@
     const TWEAKS = /*EDITMODE-BEGIN*/{
       "startSignedIn": true,
       "startRoute": "dashboard",
-      "devMode": false
+      "devMode": false,
+      "dashboardV2": false
     }/*EDITMODE-END*/;
   </script>
 
@@ -35,6 +36,7 @@
   <script type="text/babel">
     const root = ReactDOM.createRoot(document.getElementById('app'));
     function mount() {
+      window.FEATURE_FLAGS = Object.assign({}, window.FEATURE_FLAGS, { dashboard_v2: TWEAKS.dashboardV2 });
       root.render(
         <App
           initialRoute={TWEAKS.startRoute}
@@ -53,6 +55,7 @@
         <div class="tw-hdr">Tweaks</div>
         <label class="tw-row"><input type="checkbox" ${TWEAKS.startSignedIn ? 'checked' : ''} data-k="startSignedIn"> Start signed in</label>
         <label class="tw-row"><input type="checkbox" ${TWEAKS.devMode ? 'checked' : ''} data-k="devMode"> DevMode (show error footer)</label>
+        <label class="tw-row"><input type="checkbox" ${TWEAKS.dashboardV2 ? 'checked' : ''} data-k="dashboardV2"> Dashboard v2</label>
         <label class="tw-row">Start route
           <select data-k="startRoute">
             ${['dashboard','equipment','lighting','temperature','ato','ph','doser','timers','configuration']

--- a/front-end/e2e/specs/dashboard-and-responsive.spec.js
+++ b/front-end/e2e/specs/dashboard-and-responsive.spec.js
@@ -2,6 +2,12 @@ const { test, expect } = require('@playwright/test')
 const { createSmokeApi, seedDashboard, updateDashboard } = require('../fixtures/apiSeed')
 const { NavBar } = require('../pages/navBar')
 
+async function enableDashboardV2 (page) {
+  await page.addInitScript(() => {
+    window.FEATURE_FLAGS = Object.assign({}, window.FEATURE_FLAGS, { dashboard_v2: true })
+  })
+}
+
 async function expectDashboardReady (page) {
   const dashboardV2 = page.getByTestId('smoke-dashboard-v2')
   if (await dashboardV2.count()) {
@@ -62,6 +68,7 @@ test('prunes orphaned dashboard chart subscriptions from local storage', async (
     await api.dispose()
   }
 
+  await enableDashboardV2(page)
   await page.addInitScript(() => {
     window.localStorage.setItem('dashboard_config', JSON.stringify({
       subscriptions: [


### PR DESCRIPTION
## Summary
- Sets the shipped `dashboard_v2` feature flag default to `false`.
- Adds `dashboardV2` to the design-system Tweaks object and mirrors it into `window.FEATURE_FLAGS.dashboard_v2`.
- Adds tests that lock the shipped default, Tweaks wiring, and true/false DashboardV2 rendering behavior.
- Marks local issue #14 and the E3 Dashboard v2 tracking docs complete.

## Parent Epic
E3 · dashboard-v2 from `front-end/design-system/github_issues/STRATEGY.md`.

## Validation
- `rtk yarn jest front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js front-end/design-system/ui_kits/reef-pi-app/dashboard/dashboard_tiles.test.js --runInBand`
- `rtk ./node_modules/.bin/standard front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js`
- `rtk git diff --check`
- `rtk yarn run preview-card-check`
- `rtk node front-end/design-system/scripts/font-policy-check.mjs`
- `rtk yarn build`

## Notes
Webpack build completed with the existing asset-size and missing-mode warnings.

Closes #3104

Removal ticket: #3105
