### PR TITLE
[claude design] Bootstrap exit tier 1 guard

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -42,6 +42,8 @@ jobs:
         run: yarn run token-diff
       - name: contrast-check
         run: yarn run contrast-check
+      - name: bootstrap-class-check
+        run: yarn run bootstrap-class-check
       - name: standard
         run: make standard
       - name: jest

--- a/front-end/design-system/github_issues/BACKLOG.md
+++ b/front-end/design-system/github_issues/BACKLOG.md
@@ -24,20 +24,20 @@
 - [x] #14 Wire behind `dashboard_v2` flag — `issue-14-dashboard-flag.md`
 
 ## E4 · Control trust (flags: `pending_states`, `alert_center`)
-- [ ] #15 ToggleSwitch pending + error — `issue-15-toggle-states.md`
-- [ ] #16 `useAckMutation` + equipment wire-up — `issue-16-ack-mutation.md`
-- [ ] #17 Alert center slide-over + bell — `issue-17-alert-center.md`
-- [ ] #18 Inline tile alerts — `issue-18-inline-alerts.md`
-- [ ] #19 Retry + backoff UX — `issue-19-retry-backoff.md`
+- [x] #15 ToggleSwitch pending + error — `issue-15-toggle-states.md`
+- [x] #16 `useAckMutation` + equipment wire-up — `issue-16-ack-mutation.md`
+- [x] #17 Alert center slide-over + bell — `issue-17-alert-center.md`
+- [x] #18 Inline tile alerts — `issue-18-inline-alerts.md`
+- [x] #19 Retry + backoff UX — `issue-19-retry-backoff.md`
 
 ## E5 · Shell + theming (flag: `new_shell`)
-- [ ] #20 Collapsible left sidebar (≥992px) — `issue-20-sidebar.md`
-- [ ] #21 Bottom nav + drawer — `issue-21-bottom-nav.md`
-- [ ] #22 Dark theme pass — `issue-22-dark-pass.md`
-- [ ] #23 Actinic theme — `issue-23-actinic.md`
-- [ ] #24 Sign-in confidence card — `issue-24-signin-confidence.md`
-- [ ] #25 Empty states for every list page — `issue-25-empty-states.md`
-- [ ] #26 Theme picker + persistence — `issue-26-theme-picker.md`
+- [x] #20 Collapsible left sidebar (≥992px) — `issue-20-sidebar.md`
+- [x] #21 Bottom nav + drawer — `issue-21-bottom-nav.md`
+- [x] #22 Dark theme pass — `issue-22-dark-pass.md`
+- [x] #23 Actinic theme — `issue-23-actinic.md`
+- [x] #24 Sign-in confidence card — `issue-24-signin-confidence.md`
+- [x] #25 Empty states for every list page — `issue-25-empty-states.md`
+- [x] #26 Theme picker + persistence — `issue-26-theme-picker.md`
 
 ## E6 · Framework exit (no flag — incremental, one route per PR)
 - [ ] #27 Bootstrap 4.6 exit plan — `issue-27-bootstrap-exit.md`

--- a/front-end/design-system/github_issues/epic-04-control-trust.md
+++ b/front-end/design-system/github_issues/epic-04-control-trust.md
@@ -11,18 +11,18 @@ parent: null
 Eliminate the "did that actually work?" anxiety. Every switch, doser command, and setpoint write shows pending → confirmed → error states. Failures funnel into a persistent alert center. Inline alerts appear directly on the affected tile.
 
 ## Success criteria
-- [ ] `ToggleSwitch` has four states: off, on, pending (spinner around thumb), error (red ring + retry).
-- [ ] Every control mutation is wrapped in an optimistic-with-ack helper; ack timeout = 3s before flipping to `error`.
-- [ ] Navbar bell shows count badge + slide-over alert center with Acknowledge/Dismiss.
-- [ ] Any tile whose metric is in an alert state shows a red top-border + single-line description.
-- [ ] Retry uses exponential backoff; max 3 attempts before user-visible error.
+- [x] `ToggleSwitch` has four states: off, on, pending (spinner around thumb), error (red ring + retry).
+- [x] Every control mutation is wrapped in an optimistic-with-ack helper; ack timeout = 3s before flipping to `error`.
+- [x] Navbar bell shows count badge + slide-over alert center with Acknowledge/Dismiss.
+- [x] Any tile whose metric is in an alert state shows a red top-border + single-line description.
+- [x] Retry uses exponential backoff; max 3 attempts before user-visible error.
 
 ## Sub-tasks
-- [ ] #15 ToggleSwitch pending + error states
-- [ ] #16 Optimistic-with-ack pattern + equipment API wire-up
-- [ ] #17 Alert center slide-over + navbar bell
-- [ ] #18 Inline tile alerts
-- [ ] #19 Retry + backoff UX
+- [x] #15 ToggleSwitch pending + error states
+- [x] #16 Optimistic-with-ack pattern + equipment API wire-up
+- [x] #17 Alert center slide-over + navbar bell
+- [x] #18 Inline tile alerts
+- [x] #19 Retry + backoff UX
 
 ## Dependencies
 - #1 (state tokens) for pending/error colors.

--- a/front-end/design-system/github_issues/epic-05-shell-theming.md
+++ b/front-end/design-system/github_issues/epic-05-shell-theming.md
@@ -11,22 +11,22 @@ parent: null
 Replace the top-nav shell with a modern IoT layout: icon-rail sidebar on desktop, bottom-nav on mobile, drawer on tablet. Ship full dark and actinic (night blue) themes. Polish all empty/first-run states and the sign-in confidence card. All changes live behind a `new_shell` flag until complete.
 
 ## Success criteria
-- [ ] `≥992px`: 72px icon-rail sidebar, brand glyph at top, route icons, sign-out pinned at bottom.
-- [ ] `<992px`: bottom nav (5 primary routes) + overflow drawer.
-- [ ] Dark theme usable for every route including modals and alerts.
-- [ ] Actinic theme (deep blue) available as a Settings toggle; auto-switches between 21:00–06:00 if "Follow reef schedule" is on.
-- [ ] All list pages render a real empty state (Lighting without profile, Equipment without items, Dosers without pumps, Timers without schedules).
-- [ ] Sign-in page shows a device confidence card (name · version · IP · uptime) below the form.
-- [ ] Theme picker in `Configuration › Settings` persists to localStorage.
+- [x] `≥992px`: 72px icon-rail sidebar, brand glyph at top, route icons, sign-out pinned at bottom.
+- [x] `<992px`: bottom nav (5 primary routes) + overflow drawer.
+- [x] Dark theme usable for every route including modals and alerts.
+- [x] Actinic theme (deep blue) available as a Settings toggle; auto-switches between 21:00–06:00 if "Follow reef schedule" is on.
+- [x] All list pages render a real empty state (Lighting without profile, Equipment without items, Dosers without pumps, Timers without schedules).
+- [x] Sign-in page shows a device confidence card (name · version · IP · uptime) below the form.
+- [x] Theme picker in `Configuration › Settings` persists to localStorage.
 
 ## Sub-tasks
-- [ ] #20 Collapsible left sidebar (≥992px)
-- [ ] #21 Bottom nav + drawer (mobile/tablet)
-- [ ] #22 Dark theme pass
-- [ ] #23 Actinic theme
-- [ ] #24 Sign-in confidence card
-- [ ] #25 Empty states for every list page
-- [ ] #26 Theme picker + persistence in Settings
+- [x] #20 Collapsible left sidebar (≥992px)
+- [x] #21 Bottom nav + drawer (mobile/tablet)
+- [x] #22 Dark theme pass
+- [x] #23 Actinic theme
+- [x] #24 Sign-in confidence card
+- [x] #25 Empty states for every list page
+- [x] #26 Theme picker + persistence in Settings
 
 ## Dependencies
 - #2 (dark + actinic theme tokens) must land first.

--- a/front-end/scripts/bootstrap-class-check.mjs
+++ b/front-end/scripts/bootstrap-class-check.mjs
@@ -1,0 +1,90 @@
+import { execFileSync } from 'node:child_process'
+
+const scannedPaths = [
+  'front-end/src',
+  'front-end/design-system/ui_kits/reef-pi-app'
+]
+
+const bootstrapClassTokenPattern = /^(container|container-fluid|row|col(?:-[a-z0-9]+)*|d-flex|d-inline|d-inline-flex|justify-content-[a-z-]+|align-items-[a-z-]+|m[trblxy]?-[0-5]|p[trblxy]?-[0-5]|text-(?:center|left|right|muted)|float-(?:left|right)|btn(?:-[a-z0-9-]+)?|form-control|form-group|form-label|list-group(?:-[a-z0-9-]+)?|alert(?:-[a-z0-9-]+)?|custom-(?:select|switch|control))$/
+
+function diffArgs () {
+  if (process.env.BOOTSTRAP_CLASS_CHECK_BASE) {
+    return ['diff', '--unified=0', process.env.BOOTSTRAP_CLASS_CHECK_BASE, 'HEAD', '--', ...scannedPaths]
+  }
+
+  return ['diff', '--unified=0', 'HEAD^', 'HEAD', '--', ...scannedPaths]
+}
+
+function readDiff () {
+  try {
+    return execFileSync('git', diffArgs(), { encoding: 'utf8' })
+  } catch (error) {
+    const message = error.stderr?.toString().trim() || error.message
+    console.warn(`bootstrap-class-check skipped: ${message}`)
+    return ''
+  }
+}
+
+function containsBootstrapClass (source) {
+  const values = []
+  // Regex constructors keep quote handling readable for HTML and JSX class attributes.
+  // eslint-disable-next-line prefer-regex-literals
+  const quoteChars = String.fromCharCode(34, 39, 96)
+  const attrPattern = new RegExp('(?:class|className)\\s*=\\s*([' + quoteChars + '])' +
+    '([^' + quoteChars + ']+)\\1', 'g')
+  // eslint-disable-next-line prefer-regex-literals
+  const stringPattern = new RegExp('([' + quoteChars + '])' +
+    '([^' + quoteChars + ']+)\\1', 'g')
+
+  for (const match of source.matchAll(attrPattern)) {
+    values.push(match[2])
+  }
+
+  if (source.includes('classNames(')) {
+    for (const match of source.matchAll(stringPattern)) {
+      values.push(match[2])
+    }
+  }
+
+  return values.some(value => value.split(/\\s+/).some(token => bootstrapClassTokenPattern.test(token)))
+}
+
+let currentFile = null
+let currentLine = 0
+const findings = []
+
+for (const line of readDiff().split('\n')) {
+  if (line.startsWith('+++ b/')) {
+    currentFile = line.slice('+++ b/'.length)
+    continue
+  }
+
+  const hunk = line.match(/^@@ -\\d+(?:,\\d+)? \\+(\\d+)(?:,\\d+)? @@/)
+  if (hunk) {
+    currentLine = Number(hunk[1]) - 1
+    continue
+  }
+
+  if (line.startsWith('+') && !line.startsWith('+++')) {
+    currentLine += 1
+    const added = line.slice(1)
+    if (containsBootstrapClass(added)) {
+      findings.push(`${currentFile}:${currentLine}: ${added.trim()}`)
+    }
+    continue
+  }
+
+  if (!line.startsWith('-')) {
+    currentLine += 1
+  }
+}
+
+if (findings.length) {
+  console.error('New Bootstrap class usage detected. Use reef-pi tokens, primitives, and plain CSS instead.')
+  for (const finding of findings) {
+    console.error(`- ${finding}`)
+  }
+  process.exit(1)
+}
+
+console.log('bootstrap-class-check passed')

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "ui-dev": "webpack --watch --mode=development",
     "token-diff": "node front-end/scripts/token-diff.mjs",
     "contrast-check": "node front-end/design-system/scripts/contrast-check.mjs",
+    "bootstrap-class-check": "node front-end/scripts/bootstrap-class-check.mjs",
     "js-lint": "standard \"front-end/src/**/*.{js,jsx}\"",
     "standard": "standard --fix \"front-end/src/**/*.{js,jsx}\"",
     "jest": "cross-env NODE_ENV=testing jest --env=jsdom",


### PR DESCRIPTION
## Summary
- adds a Bootstrap class regression check for new JSX/HTML additions under front-end/src and the design-system app kit
- wires the check into Frontend Checks before Standard/Jest
- syncs local E4/E5 tracking docs to the already-closed GitHub issues

## Scope note
This starts E6 with a Tier 1 guard. I did not migrate the next route yet because the default equipment route slice still needs Field/Input/List/Button primitives before a clean Tier 2 migration.

## Verification
- rtk yarn run bootstrap-class-check
- rtk ./node_modules/.bin/standard front-end/scripts/bootstrap-class-check.mjs
- rtk node -e "JSON.parse(require('fs').readFileSync('package.json', 'utf8')); console.log('package.json ok')"
- rtk git diff --check

Fixes #3108