### PR TITLE
[claude design] Add form primitives

### DIFF
--- a/front-end/design-system/preview/MANIFEST.md
+++ b/front-end/design-system/preview/MANIFEST.md
@@ -80,6 +80,7 @@ All stories live under `preview/primitives/`. Open with `?theme=dark` or `?theme
 | `ThresholdGauge` | safe / warn / critical / outside / no-warn-band / no-safe-band | [primitives/threshold-gauge.html](primitives/threshold-gauge.html) |
 | `Sparkline` | bare / gradient / band / hover / keyboard / back-compat (number[]) | [primitives/sparkline.html](primitives/sparkline.html) |
 | `RangeSelector` | default / compact / keyboard / custom options+scope | [primitives/range-selector.html](primitives/range-selector.html) |
+| `Field` / `Input` / `Select` | label+help / validation / disabled / light+dark+actinic | [primitives/form-controls.html](primitives/form-controls.html) |
 | `useTimeSeries` | loading / loaded (120 pts LTTB) / error / stale-while-revalidate | [primitives/use-time-series.html](primitives/use-time-series.html) |
 
 ## Components (E3 · Dashboard v2)

--- a/front-end/design-system/preview/primitives/form-controls.html
+++ b/front-end/design-system/preview/primitives/form-controls.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>reef-pi - Form primitives</title>
+  <link rel="stylesheet" href="../_card.css">
+  <style>
+    body {
+      padding: var(--reefpi-space-lg);
+      background: var(--reefpi-color-surface);
+    }
+
+    .subtitle {
+      max-width: 720px;
+      margin: 0 0 var(--reefpi-space-lg);
+      color: var(--reefpi-color-text-muted);
+      font-size: 0.875rem;
+    }
+
+    .story-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(220px, 1fr));
+      gap: var(--reefpi-space-md);
+      align-items: start;
+    }
+
+    @media (max-width: 860px) {
+      .story-grid { grid-template-columns: 1fr; }
+    }
+
+    .card {
+      width: auto;
+      min-height: 0;
+      flex-direction: column;
+      border: 1px solid var(--reefpi-color-border);
+      border-radius: var(--reefpi-radius-md);
+      background: var(--reefpi-color-surface-elevated);
+    }
+
+    .card-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--reefpi-space-sm);
+      color: var(--reefpi-color-text);
+      font-weight: 600;
+    }
+
+    .theme-chip {
+      color: var(--reefpi-color-text-muted);
+      font-family: var(--reefpi-font-mono);
+      font-size: 0.7rem;
+      font-weight: 500;
+    }
+
+    .sample {
+      display: grid;
+      gap: var(--reefpi-space-sm);
+      padding: var(--reefpi-space-md);
+      border: 1px solid var(--reefpi-color-border);
+      border-radius: var(--reefpi-radius-md);
+      background: var(--reefpi-color-surface);
+    }
+
+    .field {
+      display: grid;
+      gap: var(--reefpi-space-xxs);
+      min-width: 0;
+    }
+
+    .field label {
+      color: var(--reefpi-color-text);
+      font-size: 0.875rem;
+      font-weight: 600;
+      line-height: 1.35;
+    }
+
+    .required {
+      color: var(--reefpi-color-error);
+      margin-left: 0.25rem;
+    }
+
+    .control {
+      width: 100%;
+      min-height: var(--reefpi-tap-target-min);
+      border: 1px solid var(--reefpi-color-border);
+      border-radius: var(--reefpi-radius-sm);
+      background: var(--reefpi-color-surface-elevated);
+      color: var(--reefpi-color-text);
+      font-family: var(--reefpi-font-app);
+      font-size: 1rem;
+      line-height: 1.4;
+      padding: 0 var(--reefpi-space-sm);
+      box-shadow: none;
+    }
+
+    .control[aria-invalid="true"] {
+      border-color: var(--reefpi-color-error);
+    }
+
+    .control[disabled], .control[readonly] {
+      background: var(--reefpi-color-pending-bg);
+      cursor: not-allowed;
+    }
+
+    .hint, .error {
+      font-size: 0.75rem;
+      line-height: 1.35;
+    }
+
+    .hint { color: var(--reefpi-color-text-muted); }
+    .error { color: var(--reefpi-color-error); font-weight: 500; }
+  </style>
+</head>
+<body>
+  <h1>Field / Input / Select</h1>
+  <p class="subtitle">Tokenized form primitives for replacing Bootstrap form controls route by route.</p>
+
+  <div class="story-grid">
+    <section class="card" data-theme-sample="light">
+      <div class="card-header">Equipment form <span class="theme-chip">light</span></div>
+      <div class="sample">
+        <div class="field">
+          <label for="light-name">Name<span class="required" aria-hidden="true">*</span></label>
+          <input class="control" id="light-name" value="Return pump" aria-describedby="light-name-help" required>
+          <div class="hint" id="light-name-help">Shown on dashboards and control strips.</div>
+        </div>
+        <div class="field">
+          <label for="light-outlet">Outlet</label>
+          <select class="control" id="light-outlet">
+            <option>Outlet 1</option>
+            <option selected>Outlet 2</option>
+            <option>Outlet 3</option>
+          </select>
+        </div>
+      </div>
+    </section>
+
+    <section class="card" data-theme="dark" data-theme-sample="dark">
+      <div class="card-header">Validation <span class="theme-chip">dark</span></div>
+      <div class="sample">
+        <div class="field">
+          <label for="dark-name">Name<span class="required" aria-hidden="true">*</span></label>
+          <input class="control" id="dark-name" value="" aria-invalid="true" aria-describedby="dark-name-error" required>
+          <div class="error" id="dark-name-error" role="alert">Name is required</div>
+        </div>
+        <div class="field">
+          <label for="dark-date">Service date</label>
+          <input class="control" id="dark-date" type="date" value="2026-06-01" readonly>
+        </div>
+      </div>
+    </section>
+
+    <section class="card" data-theme="actinic" data-theme-sample="actinic">
+      <div class="card-header">Disabled states <span class="theme-chip">actinic</span></div>
+      <div class="sample">
+        <div class="field">
+          <label for="actinic-pin">Connector</label>
+          <select class="control" id="actinic-pin" disabled>
+            <option selected>Unavailable</option>
+          </select>
+          <div class="hint">Locked while hardware capabilities load.</div>
+        </div>
+        <div class="field">
+          <label for="actinic-pass">Password</label>
+          <input class="control" id="actinic-pass" type="password" value="reef-pi" disabled>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <script src="../_card.js"></script>
+</body>
+</html>

--- a/front-end/design-system/ui_kits/reef-pi-app/primitives/Form.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/primitives/Form.jsx
@@ -1,0 +1,184 @@
+import React, { cloneElement, isValidElement, useId } from 'react'
+import PropTypes from 'prop-types'
+
+const fieldStyle = {
+  display: 'grid',
+  gap: 'var(--reefpi-space-xxs)',
+  minWidth: 0,
+  fontFamily: 'var(--reefpi-font-app)'
+}
+
+const labelStyle = {
+  color: 'var(--reefpi-color-text)',
+  fontSize: '0.875rem',
+  fontWeight: 600,
+  lineHeight: 1.35
+}
+
+const requiredStyle = {
+  color: 'var(--reefpi-color-error)',
+  marginLeft: '0.25rem'
+}
+
+const hintStyle = {
+  color: 'var(--reefpi-color-text-muted)',
+  fontSize: '0.75rem',
+  lineHeight: 1.35
+}
+
+const errorStyle = {
+  color: 'var(--reefpi-color-error)',
+  fontSize: '0.75rem',
+  lineHeight: 1.35,
+  fontWeight: 500
+}
+
+const controlBaseStyle = {
+  width: '100%',
+  minHeight: 'var(--reefpi-tap-target-min)',
+  border: '1px solid var(--reefpi-color-border)',
+  borderRadius: 'var(--reefpi-radius-sm)',
+  background: 'var(--reefpi-color-surface-elevated)',
+  color: 'var(--reefpi-color-text)',
+  fontFamily: 'var(--reefpi-font-app)',
+  fontSize: '1rem',
+  lineHeight: 1.4,
+  padding: '0 var(--reefpi-space-sm)',
+  transition: 'border-color 0.12s, background-color 0.12s',
+  boxShadow: 'none'
+}
+
+function describedBy (ids) {
+  return ids.filter(Boolean).join(' ') || undefined
+}
+
+function controlStyle ({ invalid, disabled, readOnly, style }) {
+  return Object.assign({}, controlBaseStyle, {
+    borderColor: invalid ? 'var(--reefpi-color-error)' : 'var(--reefpi-color-border)',
+    background: disabled || readOnly ? 'var(--reefpi-color-pending-bg)' : 'var(--reefpi-color-surface-elevated)',
+    cursor: disabled ? 'not-allowed' : 'auto'
+  }, style)
+}
+
+export function Field ({
+  id,
+  label,
+  helpText,
+  error,
+  required = false,
+  children
+}) {
+  const generatedId = useId()
+  const controlId = id || 'reefpi-field-' + generatedId.replace(/:/g, '')
+  const helpId = helpText ? controlId + '-help' : undefined
+  const errorId = error ? controlId + '-error' : undefined
+  const childDescribedBy = describedBy([helpId, errorId])
+  const invalid = Boolean(error)
+
+  const control = isValidElement(children)
+    ? cloneElement(children, {
+      id: children.props.id || controlId,
+      'aria-describedby': describedBy([children.props['aria-describedby'], childDescribedBy]),
+      'aria-invalid': invalid || children.props['aria-invalid'] || undefined,
+      required: required || children.props.required || undefined,
+      invalid: invalid || children.props.invalid || undefined
+    })
+    : children
+
+  return (
+    <div className='reefpi-field' style={fieldStyle}>
+      {label && (
+        <label htmlFor={controlId} style={labelStyle}>
+          {label}
+          {required && <span aria-hidden='true' style={requiredStyle}>*</span>}
+        </label>
+      )}
+      {control}
+      {helpText && <div id={helpId} style={hintStyle}>{helpText}</div>}
+      {error && <div id={errorId} role='alert' style={errorStyle}>{error}</div>}
+    </div>
+  )
+}
+
+export const Input = React.forwardRef(function Input ({
+  invalid = false,
+  disabled = false,
+  readOnly = false,
+  style,
+  type = 'text',
+  ...props
+}, ref) {
+  return (
+    <input
+      ref={ref}
+      type={type}
+      disabled={disabled}
+      readOnly={readOnly}
+      aria-invalid={invalid || undefined}
+      style={controlStyle({ invalid, disabled, readOnly, style })}
+      {...props}
+    />
+  )
+})
+
+export const Select = React.forwardRef(function Select ({
+  invalid = false,
+  disabled = false,
+  readOnly = false,
+  style,
+  options = [],
+  children,
+  ...props
+}, ref) {
+  const renderedOptions = children || options.map(option => {
+    if (typeof option === 'string') {
+      return <option key={option} value={option}>{option}</option>
+    }
+    return <option key={option.value} value={option.value} disabled={option.disabled}>{option.label}</option>
+  })
+
+  return (
+    <select
+      ref={ref}
+      disabled={disabled}
+      aria-invalid={invalid || undefined}
+      style={controlStyle({ invalid, disabled, readOnly, style })}
+      {...props}
+    >
+      {renderedOptions}
+    </select>
+  )
+})
+
+Field.propTypes = {
+  id: PropTypes.string,
+  label: PropTypes.node,
+  helpText: PropTypes.node,
+  error: PropTypes.node,
+  required: PropTypes.bool,
+  children: PropTypes.node
+}
+
+Input.propTypes = {
+  invalid: PropTypes.bool,
+  disabled: PropTypes.bool,
+  readOnly: PropTypes.bool,
+  style: PropTypes.object,
+  type: PropTypes.string
+}
+
+Select.propTypes = {
+  invalid: PropTypes.bool,
+  disabled: PropTypes.bool,
+  readOnly: PropTypes.bool,
+  style: PropTypes.object,
+  options: PropTypes.arrayOf(PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.node.isRequired,
+      disabled: PropTypes.bool
+    })
+  ])),
+  children: PropTypes.node
+}

--- a/front-end/design-system/ui_kits/reef-pi-app/primitives/Form.test.js
+++ b/front-end/design-system/ui_kits/reef-pi-app/primitives/Form.test.js
@@ -1,0 +1,99 @@
+import React, { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { renderToStaticMarkup } from 'react-dom/server'
+import fs from 'fs'
+import path from 'path'
+import { Field, Input, Select } from './Form'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+describe('design-system form primitives', () => {
+  it('wires Field label, help text, error text, required, and aria attributes', () => {
+    const html = renderToStaticMarkup(
+      <Field id='equipment-name' label='Name' helpText='Shown on control panels' error='Name is required' required>
+        <Input name='name' />
+      </Field>
+    )
+
+    expect(html).toContain('for="equipment-name"')
+    expect(html).toContain('id="equipment-name"')
+    expect(html).toContain('required=""')
+    expect(html).toContain('aria-invalid="true"')
+    expect(html).toContain('aria-describedby="equipment-name-help equipment-name-error"')
+    expect(html).toContain('role="alert"')
+    expect(html).toContain('Name is required')
+  })
+
+  it('preserves explicit child ids and described-by references', () => {
+    const html = renderToStaticMarkup(
+      <Field id='field-id' label='Outlet' helpText='Select a connector'>
+        <Select id='custom-outlet' aria-describedby='external-help' options={['Outlet 1']} />
+      </Field>
+    )
+
+    expect(html).toContain('for="field-id"')
+    expect(html).toContain('id="custom-outlet"')
+    expect(html).toContain('aria-describedby="external-help field-id-help"')
+  })
+
+  it('renders Input states without Bootstrap form-control classes', () => {
+    const html = renderToStaticMarkup(
+      <div>
+        <Input type='date' readOnly value='2026-06-01' />
+        <Input type='password' disabled />
+        <Input invalid defaultValue='bad' />
+      </div>
+    )
+
+    expect(html).toContain('type="date"')
+    expect(html).toContain('readOnly=""')
+    expect(html).toContain('disabled=""')
+    expect(html).toContain('aria-invalid="true"')
+    expect(html).not.toContain('form-control')
+  })
+
+  it('renders Select options and emits change events', () => {
+    const onChange = jest.fn()
+    const container = document.createElement('div')
+    const root = createRoot(container)
+
+    act(() => {
+      root.render(
+        <Field id='outlet' label='Outlet'>
+          <Select
+            value='2'
+            onChange={onChange}
+            options={[
+              { value: '1', label: 'Outlet 1' },
+              { value: '2', label: 'Outlet 2' },
+              { value: '3', label: 'Outlet 3', disabled: true }
+            ]}
+          />
+        </Field>
+      )
+    })
+
+    const select = container.querySelector('select')
+    expect(select.value).toBe('2')
+    expect(container.querySelectorAll('option')).toHaveLength(3)
+    expect(container.querySelector("option[value='3']").disabled).toBe(true)
+
+    act(() => {
+      select.value = '1'
+      select.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+
+    expect(onChange).toHaveBeenCalled()
+    act(() => root.unmount())
+  })
+
+  it('documents the preview story across themes without Bootstrap classes', () => {
+    const story = fs.readFileSync(path.join(process.cwd(), 'front-end/design-system/preview/primitives/form-controls.html'), 'utf8')
+
+    expect(story).toContain('data-theme-sample="light"')
+    expect(story).toContain('data-theme-sample="dark"')
+    expect(story).toContain('data-theme-sample="actinic"')
+    expect(story).not.toContain('form-control')
+    expect(story).not.toContain('btn ')
+  })
+})


### PR DESCRIPTION
## Summary
- adds Field, Input, and Select primitives for the Bootstrap form-control exit
- wires label/help/error/required accessibility through Field
- adds a form-controls preview card covering light, dark, and actinic samples
- updates the design-system preview manifest

## Verification
- rtk yarn run bootstrap-class-check
- rtk yarn jest front-end/design-system/ui_kits/reef-pi-app/primitives/Form.test.js --runInBand
- rtk yarn run preview-card-check
- rtk ./node_modules/.bin/standard front-end/design-system/ui_kits/reef-pi-app/primitives/Form.jsx
- rtk git diff --check HEAD^ HEAD

Fixes #3110