### PR TITLE
[claude design] Add button primitive

### DIFF
--- a/front-end/design-system/preview/MANIFEST.md
+++ b/front-end/design-system/preview/MANIFEST.md
@@ -81,6 +81,7 @@ All stories live under `preview/primitives/`. Open with `?theme=dark` or `?theme
 | `Sparkline` | bare / gradient / band / hover / keyboard / back-compat (number[]) | [primitives/sparkline.html](primitives/sparkline.html) |
 | `RangeSelector` | default / compact / keyboard / custom options+scope | [primitives/range-selector.html](primitives/range-selector.html) |
 | `Field` / `Input` / `Select` | label+help / validation / disabled / light+dark+actinic | [primitives/form-controls.html](primitives/form-controls.html) |
+| `Button` | primary / secondary / danger / ghost / disabled / icon-only | [primitives/button.html](primitives/button.html) |
 | `useTimeSeries` | loading / loaded (120 pts LTTB) / error / stale-while-revalidate | [primitives/use-time-series.html](primitives/use-time-series.html) |
 
 ## Components (E3 · Dashboard v2)

--- a/front-end/design-system/preview/primitives/button.html
+++ b/front-end/design-system/preview/primitives/button.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>reef-pi - Button primitive</title>
+  <link rel="stylesheet" href="../_card.css">
+  <style>
+    body { padding: var(--reefpi-space-lg); background: var(--reefpi-color-surface); }
+    .subtitle { max-width: 720px; margin: 0 0 var(--reefpi-space-lg); color: var(--reefpi-color-text-muted); font-size: 0.875rem; }
+    .story-grid { display: grid; grid-template-columns: repeat(2, minmax(280px, 1fr)); gap: var(--reefpi-space-md); }
+    @media (max-width: 760px) { .story-grid { grid-template-columns: 1fr; } }
+    .card { width: auto; min-height: 0; flex-direction: column; border: 1px solid var(--reefpi-color-border); border-radius: var(--reefpi-radius-md); background: var(--reefpi-color-surface-elevated); }
+    .card-header { color: var(--reefpi-color-text); font-weight: 600; }
+    .sample-row { display: flex; flex-wrap: wrap; gap: var(--reefpi-space-sm); align-items: center; }
+    .action { align-items: center; border: 1px solid transparent; border-radius: var(--reefpi-radius-sm); box-shadow: none; cursor: pointer; display: inline-flex; font-family: var(--reefpi-font-app); font-size: 0.9375rem; font-weight: 600; gap: var(--reefpi-space-xs); justify-content: center; line-height: 1.2; min-height: var(--reefpi-tap-target-min); min-width: var(--reefpi-tap-target-min); padding: 0 var(--reefpi-space-md); text-align: center; text-decoration: none; transition: background-color 0.12s, border-color 0.12s, color 0.12s; user-select: none; }
+    .action[data-variant="primary"] { background: var(--reefpi-color-brand); border-color: var(--reefpi-color-brand); color: var(--reefpi-color-nav-text-strong); }
+    .action[data-variant="secondary"] { background: var(--reefpi-color-surface-elevated); border-color: var(--reefpi-color-border); color: var(--reefpi-color-text); }
+    .action[data-variant="danger"] { background: var(--reefpi-color-error); border-color: var(--reefpi-color-error); color: var(--reefpi-color-nav-text-strong); }
+    .action[data-variant="ghost"] { background: transparent; border-color: transparent; color: var(--reefpi-color-text); }
+    .action[data-state="disabled"] { cursor: not-allowed; opacity: 0.58; }
+    .action.icon-only { padding: 0; }
+  </style>
+</head>
+<body>
+  <h1>Button</h1>
+  <p class="subtitle">Tokenized action primitive for replacing Bootstrap button classes route by route.</p>
+  <div class="story-grid">
+    <section class="card">
+      <div class="card-header">Variants</div>
+      <div class="sample-row">
+        <button class="action" data-variant="primary">Save</button>
+        <button class="action" data-variant="secondary">Cancel</button>
+        <button class="action" data-variant="danger">Delete</button>
+        <button class="action" data-variant="ghost">Edit</button>
+      </div>
+    </section>
+    <section class="card">
+      <div class="card-header">States</div>
+      <div class="sample-row">
+        <button class="action" data-variant="primary" type="submit">Apply</button>
+        <button class="action" data-variant="secondary" data-state="disabled" disabled>Disabled</button>
+        <button class="action icon-only" data-variant="ghost" aria-label="Edit"><span aria-hidden="true">&#9998;</span></button>
+        <button class="action icon-only" data-variant="danger" aria-label="Delete"><span aria-hidden="true">&#10005;</span></button>
+      </div>
+    </section>
+  </div>
+  <script src="../_card.js"></script>
+</body>
+</html>

--- a/front-end/design-system/ui_kits/reef-pi-app/primitives/Button.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/primitives/Button.jsx
@@ -1,0 +1,108 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const baseStyle = {
+  alignItems: 'center',
+  border: '1px solid transparent',
+  borderRadius: 'var(--reefpi-radius-sm)',
+  boxShadow: 'none',
+  cursor: 'pointer',
+  display: 'inline-flex',
+  fontFamily: 'var(--reefpi-font-app)',
+  fontSize: '0.9375rem',
+  fontWeight: 600,
+  gap: 'var(--reefpi-space-xs)',
+  justifyContent: 'center',
+  lineHeight: 1.2,
+  minHeight: 'var(--reefpi-tap-target-min)',
+  minWidth: 'var(--reefpi-tap-target-min)',
+  padding: '0 var(--reefpi-space-md)',
+  textAlign: 'center',
+  textDecoration: 'none',
+  transition: 'background-color 0.12s, border-color 0.12s, color 0.12s',
+  userSelect: 'none'
+}
+
+const variants = {
+  primary: {
+    background: 'var(--reefpi-color-brand)',
+    borderColor: 'var(--reefpi-color-brand)',
+    color: 'var(--reefpi-color-nav-text-strong)'
+  },
+  secondary: {
+    background: 'var(--reefpi-color-surface-elevated)',
+    borderColor: 'var(--reefpi-color-border)',
+    color: 'var(--reefpi-color-text)'
+  },
+  danger: {
+    background: 'var(--reefpi-color-error)',
+    borderColor: 'var(--reefpi-color-error)',
+    color: 'var(--reefpi-color-nav-text-strong)'
+  },
+  ghost: {
+    background: 'transparent',
+    borderColor: 'transparent',
+    color: 'var(--reefpi-color-text)'
+  }
+}
+
+const disabledStyle = {
+  cursor: 'not-allowed',
+  opacity: 0.58
+}
+
+const Button = React.forwardRef(function Button ({
+  as: Component = 'button',
+  children,
+  className,
+  disabled = false,
+  icon,
+  iconOnly = false,
+  style,
+  type = 'button',
+  variant = 'primary',
+  ...props
+}, ref) {
+  const mergedStyle = Object.assign(
+    {},
+    baseStyle,
+    variants[variant] || variants.primary,
+    disabled ? disabledStyle : null,
+    iconOnly ? { padding: 0 } : null,
+    style
+  )
+  const componentProps = Object.assign({}, props, {
+    className,
+    ref,
+    style: mergedStyle
+  })
+
+  if (Component === 'button') {
+    componentProps.type = type
+    componentProps.disabled = disabled
+  } else if (disabled) {
+    componentProps['aria-disabled'] = true
+    componentProps.tabIndex = -1
+  }
+
+  return (
+    <Component {...componentProps}>
+      {icon && <span aria-hidden='true' style={{ display: 'inline-flex', flexShrink: 0 }}>{icon}</span>}
+      {!iconOnly && children}
+    </Component>
+  )
+})
+
+Button.propTypes = {
+  as: PropTypes.elementType,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  icon: PropTypes.node,
+  iconOnly: PropTypes.bool,
+  style: PropTypes.object,
+  type: PropTypes.oneOf(['button', 'submit', 'reset']),
+  variant: PropTypes.oneOf(['primary', 'secondary', 'danger', 'ghost'])
+}
+
+export default Button

--- a/front-end/design-system/ui_kits/reef-pi-app/primitives/Button.test.js
+++ b/front-end/design-system/ui_kits/reef-pi-app/primitives/Button.test.js
@@ -1,0 +1,67 @@
+import React, { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { renderToStaticMarkup } from 'react-dom/server'
+import fs from 'fs'
+import path from 'path'
+import Button from './Button'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+describe('design-system Button primitive', () => {
+  it('renders primary button defaults without Bootstrap classes', () => {
+    const html = renderToStaticMarkup(<Button>Save</Button>)
+
+    expect(html).toContain('type="button"')
+    expect(html).toContain('Save')
+    expect(html).toContain('var(--reefpi-color-brand)')
+    expect(html).not.toContain('btn')
+  })
+
+  it('supports submit and reset button types', () => {
+    expect(renderToStaticMarkup(<Button type='submit'>Apply</Button>)).toContain('type="submit"')
+    expect(renderToStaticMarkup(<Button type='reset'>Reset</Button>)).toContain('type="reset"')
+  })
+
+  it('renders secondary, danger, and ghost variants', () => {
+    expect(renderToStaticMarkup(<Button variant='secondary'>Cancel</Button>)).toContain('var(--reefpi-color-border)')
+    expect(renderToStaticMarkup(<Button variant='danger'>Delete</Button>)).toContain('var(--reefpi-color-error)')
+    expect(renderToStaticMarkup(<Button variant='ghost'>Edit</Button>)).toContain('transparent')
+  })
+
+  it('supports disabled behavior and click handling', () => {
+    const onClick = jest.fn()
+    const container = document.createElement('div')
+    const root = createRoot(container)
+
+    act(() => {
+      root.render(<Button onClick={onClick}>Run</Button>)
+    })
+    act(() => container.querySelector('button').click())
+    expect(onClick).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      root.render(<Button onClick={onClick} disabled>Run</Button>)
+    })
+    expect(container.querySelector('button').disabled).toBe(true)
+
+    act(() => root.unmount())
+  })
+
+  it('supports icon-only buttons with an accessible label', () => {
+    const html = renderToStaticMarkup(<Button variant='ghost' icon={<span>+</span>} iconOnly aria-label='Add equipment' />)
+
+    expect(html).toContain('aria-label="Add equipment"')
+    expect(html).toContain('>+</span>')
+    expect(html).not.toContain('Add equipment</button>')
+  })
+
+  it('documents the preview story without Bootstrap button classes', () => {
+    const story = fs.readFileSync(path.join(process.cwd(), 'front-end/design-system/preview/primitives/button.html'), 'utf8')
+
+    expect(story).toContain('data-variant="primary"')
+    expect(story).toContain('data-state="disabled"')
+    expect(story).toContain('aria-label="Edit"')
+    expect(story).not.toContain('btn ')
+    expect(story).not.toContain('btn-')
+  })
+})


### PR DESCRIPTION
## Summary
- adds the tokenized Button primitive for the Bootstrap button exit
- supports primary, secondary, danger, and ghost variants
- supports button/submit/reset types, disabled state, icon+label, and icon-only actions
- adds a Button preview card and manifest entry

## Verification
- rtk yarn run bootstrap-class-check
- rtk yarn jest front-end/design-system/ui_kits/reef-pi-app/primitives/Button.test.js --runInBand
- rtk yarn run preview-card-check
- rtk ./node_modules/.bin/standard front-end/design-system/ui_kits/reef-pi-app/primitives/Button.jsx
- rtk git diff --check HEAD^ HEAD

Fixes #3111