### PR TITLE
[claude design] Add list primitives

### DIFF
--- a/front-end/design-system/preview/MANIFEST.md
+++ b/front-end/design-system/preview/MANIFEST.md
@@ -82,6 +82,7 @@ All stories live under `preview/primitives/`. Open with `?theme=dark` or `?theme
 | `RangeSelector` | default / compact / keyboard / custom options+scope | [primitives/range-selector.html](primitives/range-selector.html) |
 | `Field` / `Input` / `Select` | label+help / validation / disabled / light+dark+actinic | [primitives/form-controls.html](primitives/form-controls.html) |
 | `Button` | primary / secondary / danger / ghost / disabled / icon-only | [primitives/button.html](primitives/button.html) |
+| `List` / `ListItem` | list / action list / empty state / dense mobile rows | [primitives/list.html](primitives/list.html) |
 | `useTimeSeries` | loading / loaded (120 pts LTTB) / error / stale-while-revalidate | [primitives/use-time-series.html](primitives/use-time-series.html) |
 
 ## Components (E3 · Dashboard v2)

--- a/front-end/design-system/preview/primitives/list.html
+++ b/front-end/design-system/preview/primitives/list.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>reef-pi - List primitive</title>
+  <link rel="stylesheet" href="../_card.css">
+  <style>
+    body { padding: var(--reefpi-space-lg); background: var(--reefpi-color-surface); }
+    .subtitle { max-width: 720px; margin: 0 0 var(--reefpi-space-lg); color: var(--reefpi-color-text-muted); font-size: 0.875rem; }
+    .story-grid { display: grid; grid-template-columns: repeat(2, minmax(280px, 1fr)); gap: var(--reefpi-space-md); }
+    @media (max-width: 760px) { .story-grid { grid-template-columns: 1fr; } }
+    .card { width: auto; min-height: 0; flex-direction: column; border: 1px solid var(--reefpi-color-border); border-radius: var(--reefpi-radius-md); background: var(--reefpi-color-surface-elevated); }
+    .card-header { color: var(--reefpi-color-text); font-weight: 600; }
+    .rp-list { display: grid; margin: 0; padding: 0; list-style: none; border: 1px solid var(--reefpi-color-border); border-radius: var(--reefpi-radius-md); background: var(--reefpi-color-surface-elevated); overflow: hidden; min-width: 0; }
+    .rp-item { align-items: center; background: var(--reefpi-color-surface-elevated); border-top: 1px solid var(--reefpi-color-border); color: var(--reefpi-color-text); display: grid; gap: var(--reefpi-space-sm); grid-template-columns: minmax(0, 1fr); line-height: 1.4; min-height: var(--reefpi-tap-target-min); min-width: 0; padding: var(--reefpi-space-md); width: 100%; }
+    .rp-item:first-child { border-top: none; }
+    .rp-item[data-density="compact"] { padding: var(--reefpi-space-xs); }
+    .rp-item[data-layout="leading-trailing"] { grid-template-columns: auto minmax(0, 1fr) auto; }
+    .rp-main { min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+    .rp-meta { color: var(--reefpi-color-text-muted); font-size: 0.75rem; }
+    .rp-slot { align-items: center; display: inline-flex; flex-shrink: 0; gap: var(--reefpi-space-xs); }
+    .pill { border: 1px solid var(--reefpi-color-border); border-radius: var(--reefpi-radius-sm); color: var(--reefpi-color-text-muted); font-size: 0.75rem; padding: 0.125rem var(--reefpi-space-xs); }
+    .empty { color: var(--reefpi-color-text-muted); font-size: 0.875rem; line-height: 1.4; padding: var(--reefpi-space-md); text-align: center; }
+  </style>
+</head>
+<body>
+  <h1>List / ListItem</h1>
+  <p class="subtitle">Tokenized list primitive for replacing Bootstrap list surfaces route by route.</p>
+  <div class="story-grid">
+    <section class="card">
+      <div class="card-header">Equipment list</div>
+      <ul class="rp-list" data-density="roomy">
+        <li class="rp-item" data-layout="leading-trailing"><span class="rp-slot">P</span><span class="rp-main">Return pump <span class="rp-meta">Outlet 2</span></span><span class="pill">On</span></li>
+        <li class="rp-item" data-layout="leading-trailing"><span class="rp-slot">H</span><span class="rp-main">Heater</span><span class="pill">Auto</span></li>
+      </ul>
+    </section>
+    <section class="card">
+      <div class="card-header">Action list</div>
+      <ul class="rp-list" data-density="compact">
+        <li class="rp-item" data-density="compact" data-layout="leading-trailing"><span class="rp-main">ATO reservoir sensor with a long label</span><span class="rp-slot"><button class="pill">Edit</button><button class="pill">Delete</button></span></li>
+        <li class="rp-item" data-density="compact" data-layout="leading-trailing"><span class="rp-main">Skimmer delay</span><span class="pill">45s</span></li>
+      </ul>
+    </section>
+    <section class="card">
+      <div class="card-header">Empty state</div>
+      <div class="rp-list empty">No timers configured.</div>
+    </section>
+    <section class="card">
+      <div class="card-header">Dense mobile rows</div>
+      <ul class="rp-list" data-density="compact">
+        <li class="rp-item" data-density="compact"><span class="rp-main">Lighting profile</span></li>
+        <li class="rp-item" data-density="compact"><span class="rp-main">Doser calibration</span></li>
+      </ul>
+    </section>
+  </div>
+  <script src="../_card.js"></script>
+</body>
+</html>

--- a/front-end/design-system/ui_kits/reef-pi-app/primitives/List.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/primitives/List.jsx
@@ -1,0 +1,137 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const densityPadding = {
+  compact: 'var(--reefpi-space-xs)',
+  roomy: 'var(--reefpi-space-md)'
+}
+
+const listStyle = {
+  display: 'grid',
+  margin: 0,
+  padding: 0,
+  listStyle: 'none',
+  border: '1px solid var(--reefpi-color-border)',
+  borderRadius: 'var(--reefpi-radius-md)',
+  background: 'var(--reefpi-color-surface-elevated)',
+  overflow: 'hidden',
+  minWidth: 0
+}
+
+const emptyStyle = {
+  color: 'var(--reefpi-color-text-muted)',
+  fontFamily: 'var(--reefpi-font-app)',
+  fontSize: '0.875rem',
+  lineHeight: 1.4,
+  padding: 'var(--reefpi-space-md)',
+  textAlign: 'center'
+}
+
+function itemStyle ({ density, interactive, style }) {
+  return Object.assign({
+    alignItems: 'center',
+    background: 'var(--reefpi-color-surface-elevated)',
+    borderTop: '1px solid var(--reefpi-color-border)',
+    color: 'var(--reefpi-color-text)',
+    display: 'grid',
+    fontFamily: 'var(--reefpi-font-app)',
+    gap: 'var(--reefpi-space-sm)',
+    gridTemplateColumns: 'minmax(0, 1fr)',
+    lineHeight: 1.4,
+    minHeight: 'var(--reefpi-tap-target-min)',
+    minWidth: 0,
+    padding: densityPadding[density] || densityPadding.roomy,
+    position: 'relative',
+    textAlign: 'left',
+    width: '100%'
+  }, interactive ? { cursor: 'pointer' } : null, style)
+}
+
+function contentStyle ({ hasLeading, hasTrailing }) {
+  if (hasLeading && hasTrailing) return { gridTemplateColumns: 'auto minmax(0, 1fr) auto' }
+  if (hasLeading) return { gridTemplateColumns: 'auto minmax(0, 1fr)' }
+  if (hasTrailing) return { gridTemplateColumns: 'minmax(0, 1fr) auto' }
+  return null
+}
+
+export function List ({
+  children,
+  density = 'roomy',
+  empty,
+  style,
+  ...props
+}) {
+  const items = React.Children.toArray(children).filter(Boolean)
+  const mergedStyle = Object.assign({}, listStyle, style)
+
+  if (!items.length && empty) {
+    return (
+      <div className='reefpi-list-empty' style={Object.assign({}, mergedStyle, emptyStyle)} {...props}>
+        {empty}
+      </div>
+    )
+  }
+
+  return (
+    <ul className='reefpi-list' style={mergedStyle} {...props}>
+      {items.map((child, index) => React.isValidElement(child)
+        ? React.cloneElement(child, {
+          density: child.props.density || density,
+          first: index === 0
+        })
+        : child)}
+    </ul>
+  )
+}
+
+export function ListItem ({
+  action,
+  children,
+  density = 'roomy',
+  first = false,
+  leading,
+  onClick,
+  style,
+  trailing,
+  ...props
+}) {
+  const hasLeading = Boolean(leading)
+  const hasTrailing = Boolean(trailing || action)
+  const mergedStyle = Object.assign(
+    {},
+    itemStyle({ density, interactive: Boolean(onClick), style }),
+    contentStyle({ hasLeading, hasTrailing }),
+    first ? { borderTop: 'none' } : null
+  )
+
+  return (
+    <li className='reefpi-list-item' style={mergedStyle} {...props}>
+      {hasLeading && <span aria-hidden='true' style={{ display: 'inline-flex', flexShrink: 0 }}>{leading}</span>}
+      <div style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}>{children}</div>
+      {hasTrailing && (
+        <div style={{ alignItems: 'center', display: 'inline-flex', flexShrink: 0, gap: 'var(--reefpi-space-xs)' }}>
+          {trailing}
+          {action}
+        </div>
+      )}
+    </li>
+  )
+}
+
+List.propTypes = {
+  children: PropTypes.node,
+  density: PropTypes.oneOf(['compact', 'roomy']),
+  empty: PropTypes.node,
+  style: PropTypes.object
+}
+
+ListItem.propTypes = {
+  action: PropTypes.node,
+  children: PropTypes.node,
+  density: PropTypes.oneOf(['compact', 'roomy']),
+  first: PropTypes.bool,
+  leading: PropTypes.node,
+  onClick: PropTypes.func,
+  style: PropTypes.object,
+  trailing: PropTypes.node
+}

--- a/front-end/design-system/ui_kits/reef-pi-app/primitives/List.test.js
+++ b/front-end/design-system/ui_kits/reef-pi-app/primitives/List.test.js
@@ -1,0 +1,69 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import fs from 'fs'
+import path from 'path'
+import Button from './Button'
+import { List, ListItem } from './List'
+
+describe('design-system List primitives', () => {
+  it('renders semantic list and list item markup without Bootstrap classes', () => {
+    const html = renderToStaticMarkup(
+      <List>
+        <ListItem leading={<span>P</span>} trailing='On'>Return pump</ListItem>
+        <ListItem>Heater</ListItem>
+      </List>
+    )
+
+    expect(html).toContain('<ul')
+    expect(html).toContain('<li')
+    expect(html).toContain('Return pump')
+    expect(html).toContain('Heater')
+    expect(html).not.toContain('list-group')
+  })
+
+  it('supports compact and roomy density while preserving tap target minimums', () => {
+    const compact = renderToStaticMarkup(<List density='compact'><ListItem>Compact</ListItem></List>)
+    const roomy = renderToStaticMarkup(<List density='roomy'><ListItem>Roomy</ListItem></List>)
+
+    expect(compact).toContain('var(--reefpi-space-xs)')
+    expect(roomy).toContain('var(--reefpi-space-md)')
+    expect(compact).toContain('min-height:var(--reefpi-tap-target-min)')
+    expect(roomy).toContain('min-height:var(--reefpi-tap-target-min)')
+  })
+
+  it('supports action rows, leading content, trailing content, and horizontal overflow safety', () => {
+    const html = renderToStaticMarkup(
+      <List>
+        <ListItem
+          leading={<span>ATO</span>}
+          action={<Button variant='secondary'>Edit</Button>}
+          trailing={<span>Enabled</span>}
+        >
+          Auto top off reservoir sensor with a long label
+        </ListItem>
+      </List>
+    )
+
+    expect(html).toContain('grid-template-columns:auto minmax(0, 1fr) auto')
+    expect(html).toContain('min-width:0')
+    expect(html).toContain('Auto top off reservoir sensor')
+    expect(html).toContain('Edit')
+  })
+
+  it('renders empty-state handoff outside list markup', () => {
+    const html = renderToStaticMarkup(<List empty='No equipment configured.' />)
+
+    expect(html).toContain('No equipment configured.')
+    expect(html).toContain('reefpi-list-empty')
+    expect(html).not.toContain('<ul')
+  })
+
+  it('documents the preview story without Bootstrap list classes', () => {
+    const story = fs.readFileSync(path.join(process.cwd(), 'front-end/design-system/preview/primitives/list.html'), 'utf8')
+
+    expect(story).toContain('data-density="roomy"')
+    expect(story).toContain('data-density="compact"')
+    expect(story).toContain('No timers configured.')
+    expect(story).not.toContain('list-group')
+  })
+})


### PR DESCRIPTION
## Summary
- adds List and ListItem primitives for the Bootstrap list-group exit
- supports compact and roomy density, leading/trailing slots, action rows, empty-state handoff, and horizontal overflow safety
- adds a List preview card and manifest entry

## Verification
- rtk yarn run bootstrap-class-check
- rtk yarn jest front-end/design-system/ui_kits/reef-pi-app/primitives/List.test.js --runInBand
- rtk yarn run preview-card-check
- rtk ./node_modules/.bin/standard front-end/design-system/ui_kits/reef-pi-app/primitives/List.jsx
- rtk git diff --check HEAD^ HEAD

Fixes #3112