### PR TITLE
[claude design] Add interaction primitives

### DIFF
--- a/front-end/design-system/preview/MANIFEST.md
+++ b/front-end/design-system/preview/MANIFEST.md
@@ -83,6 +83,7 @@ All stories live under `preview/primitives/`. Open with `?theme=dark` or `?theme
 | `Field` / `Input` / `Select` | label+help / validation / disabled / light+dark+actinic | [primitives/form-controls.html](primitives/form-controls.html) |
 | `Button` | primary / secondary / danger / ghost / disabled / icon-only | [primitives/button.html](primitives/button.html) |
 | `List` / `ListItem` | list / action list / empty state / dense mobile rows | [primitives/list.html](primitives/list.html) |
+| `Dialog` / `Menu` / `Tooltip` / `Tabs` | modal / menu / tooltip / tablist desktop+mobile samples | [primitives/interactions.html](primitives/interactions.html) |
 | `useTimeSeries` | loading / loaded (120 pts LTTB) / error / stale-while-revalidate | [primitives/use-time-series.html](primitives/use-time-series.html) |
 
 ## Components (E3 · Dashboard v2)

--- a/front-end/design-system/preview/primitives/interactions.html
+++ b/front-end/design-system/preview/primitives/interactions.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>reef-pi - Interaction primitives</title>
+  <link rel="stylesheet" href="../_card.css">
+  <style>
+    body { padding: var(--reefpi-space-lg); background: var(--reefpi-color-surface); }
+    .subtitle { max-width: 760px; margin: 0 0 var(--reefpi-space-lg); color: var(--reefpi-color-text-muted); font-size: 0.875rem; }
+    .story-grid { display: grid; grid-template-columns: repeat(2, minmax(280px, 1fr)); gap: var(--reefpi-space-md); }
+    @media (max-width: 760px) { .story-grid { grid-template-columns: 1fr; } }
+    .card { width: auto; min-height: 0; flex-direction: column; border: 1px solid var(--reefpi-color-border); border-radius: var(--reefpi-radius-md); background: var(--reefpi-color-surface-elevated); }
+    .card-header { color: var(--reefpi-color-text); font-weight: 600; }
+    .action { align-items: center; background: var(--reefpi-color-surface-elevated); border: 1px solid var(--reefpi-color-border); border-radius: var(--reefpi-radius-sm); color: var(--reefpi-color-text); cursor: pointer; display: inline-flex; font-family: var(--reefpi-font-app); font-weight: 600; justify-content: center; min-height: var(--reefpi-tap-target-min); min-width: var(--reefpi-tap-target-min); padding: 0 var(--reefpi-space-md); }
+    .panel { border: 1px solid var(--reefpi-color-border); border-radius: var(--reefpi-radius-md); background: var(--reefpi-color-surface-elevated); color: var(--reefpi-color-text); padding: var(--reefpi-space-md); }
+    .row { display: flex; flex-wrap: wrap; gap: var(--reefpi-space-sm); align-items: center; }
+    .dialog-preview { max-width: 24rem; display: grid; gap: var(--reefpi-space-md); }
+    .menu-preview { display: grid; gap: var(--reefpi-space-xxs); max-width: 13rem; }
+    .menu-preview [role="menuitem"] { justify-content: flex-start; width: 100%; }
+    .tooltip-wrap { display: inline-flex; position: relative; }
+    .tooltip { bottom: calc(100% + var(--reefpi-space-xxs)); font-size: 0.75rem; max-width: 14rem; position: absolute; right: 0; white-space: nowrap; }
+    .tabs { display: grid; gap: var(--reefpi-space-sm); }
+    [role="tablist"] { display: flex; gap: var(--reefpi-space-xs); overflow-x: auto; }
+    [aria-selected="true"] { background: var(--reefpi-color-brand); border-color: var(--reefpi-color-brand); color: var(--reefpi-color-nav-text-strong); }
+  </style>
+</head>
+<body>
+  <h1>Dialog / Menu / Tooltip / Tabs</h1>
+  <p class="subtitle">Interaction primitives for removing modal, dropdown, tooltip, and tab script dependencies.</p>
+  <div class="story-grid">
+    <section class="card">
+      <div class="card-header">Dialog</div>
+      <div class="panel dialog-preview" role="dialog" aria-modal="true" aria-labelledby="dialog-title">
+        <h2 id="dialog-title" style="font-size:1.25rem;margin:0">Delete Skimmer ?</h2>
+        <div>This action will delete equipment Skimmer.</div>
+        <div class="row" style="justify-content:flex-end"><button class="action">Cancel</button><button class="action">Confirm</button></div>
+      </div>
+    </section>
+    <section class="card">
+      <div class="card-header">Menu</div>
+      <button class="action" aria-haspopup="menu" aria-expanded="true">More</button>
+      <div class="panel menu-preview" role="menu">
+        <button class="action" role="menuitem">Edit</button>
+        <button class="action" role="menuitem">Delete</button>
+      </div>
+    </section>
+    <section class="card">
+      <div class="card-header">Tooltip</div>
+      <span class="tooltip-wrap"><button class="action" aria-describedby="tip-retry">Retry</button><span class="panel tooltip" id="tip-retry" role="tooltip">Retry command</span></span>
+    </section>
+    <section class="card">
+      <div class="card-header">Tabs</div>
+      <div class="tabs">
+        <div role="tablist" aria-label="Configuration tabs"><button class="action" role="tab" aria-selected="true" aria-controls="settings-panel">Settings</button><button class="action" role="tab" aria-selected="false" aria-controls="connectors-panel">Connectors</button></div>
+        <section class="panel" id="settings-panel" role="tabpanel">Settings panel</section>
+      </div>
+    </section>
+  </div>
+  <script src="../_card.js"></script>
+</body>
+</html>

--- a/front-end/design-system/ui_kits/reef-pi-app/primitives/Interaction.jsx
+++ b/front-end/design-system/ui_kits/reef-pi-app/primitives/Interaction.jsx
@@ -1,0 +1,367 @@
+import React, { useEffect, useId, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import PropTypes from 'prop-types'
+
+const surfaceStyle = {
+  background: 'var(--reefpi-color-surface-elevated)',
+  border: '1px solid var(--reefpi-color-border)',
+  borderRadius: 'var(--reefpi-radius-md)',
+  color: 'var(--reefpi-color-text)',
+  fontFamily: 'var(--reefpi-font-app)'
+}
+
+const actionButtonStyle = {
+  alignItems: 'center',
+  background: 'var(--reefpi-color-surface-elevated)',
+  border: '1px solid var(--reefpi-color-border)',
+  borderRadius: 'var(--reefpi-radius-sm)',
+  color: 'var(--reefpi-color-text)',
+  cursor: 'pointer',
+  display: 'inline-flex',
+  fontFamily: 'var(--reefpi-font-app)',
+  fontSize: '0.9375rem',
+  fontWeight: 600,
+  gap: 'var(--reefpi-space-xs)',
+  justifyContent: 'center',
+  minHeight: 'var(--reefpi-tap-target-min)',
+  minWidth: 'var(--reefpi-tap-target-min)',
+  padding: '0 var(--reefpi-space-md)'
+}
+
+function focusableElements (node) {
+  if (!node) return []
+  return Array.from(node.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'))
+    .filter(el => !el.disabled && !el.getAttribute('aria-hidden'))
+}
+
+export function Dialog ({
+  actions,
+  children,
+  labelledBy,
+  onClose,
+  open = false,
+  title
+}) {
+  const generatedId = useId()
+  const titleId = labelledBy || 'reefpi-dialog-' + generatedId.replace(/:/g, '')
+  const panelRef = useRef(null)
+  const previousFocusRef = useRef(null)
+
+  useEffect(() => {
+    if (!open) return undefined
+    previousFocusRef.current = document.activeElement
+    const focusables = focusableElements(panelRef.current)
+    ;(focusables[0] || panelRef.current)?.focus()
+
+    return () => {
+      previousFocusRef.current?.focus?.()
+    }
+  }, [open])
+
+  if (!open || typeof document === 'undefined') return null
+
+  const handleKeyDown = event => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      onClose?.()
+      return
+    }
+
+    if (event.key !== 'Tab') return
+    const focusables = focusableElements(panelRef.current)
+    if (!focusables.length) return
+    const first = focusables[0]
+    const last = focusables[focusables.length - 1]
+
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault()
+      first.focus()
+    }
+  }
+
+  return createPortal(
+    <div
+      className='reefpi-dialog-backdrop'
+      role='presentation'
+      style={{
+        alignItems: 'center',
+        background: 'rgba(31, 42, 31, 0.36)',
+        display: 'flex',
+        inset: 0,
+        justifyContent: 'center',
+        padding: 'var(--reefpi-space-md)',
+        position: 'fixed',
+        zIndex: 1000
+      }}
+      onMouseDown={event => {
+        if (event.target === event.currentTarget) onClose?.()
+      }}
+    >
+      <section
+        aria-labelledby={titleId}
+        aria-modal='true'
+        className='reefpi-dialog'
+        onKeyDown={handleKeyDown}
+        ref={panelRef}
+        role='dialog'
+        tabIndex='-1'
+        style={Object.assign({}, surfaceStyle, {
+          display: 'grid',
+          gap: 'var(--reefpi-space-md)',
+          maxHeight: 'calc(100vh - 2rem)',
+          maxWidth: '32rem',
+          overflow: 'auto',
+          padding: 'var(--reefpi-space-lg)',
+          width: '100%'
+        })}
+      >
+        {title && <h2 id={titleId} style={{ fontSize: '1.25rem', margin: 0 }}>{title}</h2>}
+        <div>{children}</div>
+        {actions && <div style={{ display: 'flex', gap: 'var(--reefpi-space-sm)', justifyContent: 'flex-end' }}>{actions}</div>}
+      </section>
+    </div>,
+    document.body
+  )
+}
+
+function MenuItemButton ({ item }) {
+  const handleSelect = event => {
+    item.onSelect?.(event)
+  }
+
+  return (
+    <button
+      onClick={handleSelect}
+      role='menuitem'
+      style={Object.assign({}, actionButtonStyle, {
+        borderColor: 'transparent',
+        justifyContent: 'flex-start',
+        width: '100%'
+      })}
+      type='button'
+    >
+      {item.label}
+    </button>
+  )
+}
+
+export function Menu ({
+  buttonLabel,
+  children,
+  items = []
+}) {
+  const [open, setOpen] = useState(false)
+  const buttonRef = useRef(null)
+  const menuRef = useRef(null)
+
+  useEffect(() => {
+    if (!open) return undefined
+    const handleMouseDown = event => {
+      if (!menuRef.current?.contains(event.target) && !buttonRef.current?.contains(event.target)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handleMouseDown)
+    return () => document.removeEventListener('mousedown', handleMouseDown)
+  }, [open])
+
+  const focusItem = index => {
+    const buttons = focusableElements(menuRef.current)
+    buttons[index]?.focus()
+  }
+
+  const handleMenuKeyDown = event => {
+    const buttons = focusableElements(menuRef.current)
+    const current = buttons.indexOf(document.activeElement)
+    if (event.key === 'Escape') {
+      setOpen(false)
+      buttonRef.current?.focus()
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      focusItem((current + 1 + buttons.length) % buttons.length)
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      focusItem((current - 1 + buttons.length) % buttons.length)
+    }
+  }
+
+  return (
+    <div className='reefpi-menu' style={{ display: 'inline-flex', position: 'relative' }}>
+      <button
+        aria-expanded={open}
+        aria-haspopup='menu'
+        onClick={() => setOpen(value => !value)}
+        ref={buttonRef}
+        style={actionButtonStyle}
+        type='button'
+      >
+        {buttonLabel}
+      </button>
+      {open && (
+        <div
+          className='reefpi-menu-panel'
+          onKeyDown={handleMenuKeyDown}
+          ref={menuRef}
+          role='menu'
+          style={Object.assign({}, surfaceStyle, {
+            display: 'grid',
+            minWidth: '12rem',
+            padding: 'var(--reefpi-space-xxs)',
+            position: 'absolute',
+            right: 0,
+            top: 'calc(100% + var(--reefpi-space-xxs))',
+            zIndex: 20
+          })}
+        >
+          {children || items.map(item => <MenuItemButton item={item} key={item.label} />)}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function Tooltip ({ children, id, text }) {
+  const generatedId = useId()
+  const tooltipId = id || 'reefpi-tooltip-' + generatedId.replace(/:/g, '')
+  const [open, setOpen] = useState(false)
+
+  return (
+    <span className='reefpi-tooltip' style={{ display: 'inline-flex', position: 'relative' }}>
+      {React.isValidElement(children)
+        ? React.cloneElement(children, {
+          'aria-describedby': tooltipId,
+          onBlur: event => { children.props.onBlur?.(event); setOpen(false) },
+          onFocus: event => { children.props.onFocus?.(event); setOpen(true) },
+          onMouseEnter: event => { children.props.onMouseEnter?.(event); setOpen(true) },
+          onMouseLeave: event => { children.props.onMouseLeave?.(event); setOpen(false) }
+        })
+        : children}
+      {open && (
+        <span
+          id={tooltipId}
+          role='tooltip'
+          style={Object.assign({}, surfaceStyle, {
+            bottom: 'calc(100% + var(--reefpi-space-xxs))',
+            fontSize: '0.75rem',
+            maxWidth: '16rem',
+            padding: 'var(--reefpi-space-xs)',
+            position: 'absolute',
+            right: 0,
+            zIndex: 30
+          })}
+        >
+          {text}
+        </span>
+      )}
+    </span>
+  )
+}
+
+export function Tabs ({ tabs = [], value, onChange }) {
+  const [internalValue, setInternalValue] = useState(value || tabs[0]?.id)
+  const activeValue = value || internalValue
+  const activeIndex = Math.max(0, tabs.findIndex(tab => tab.id === activeValue))
+  const activeTab = tabs[activeIndex]
+  const tabRefs = useRef([])
+
+  const select = next => {
+    if (value === undefined) setInternalValue(next)
+    onChange?.(next)
+  }
+
+  const handleKeyDown = event => {
+    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return
+    event.preventDefault()
+    let nextIndex = activeIndex
+    if (event.key === 'ArrowLeft') nextIndex = (activeIndex - 1 + tabs.length) % tabs.length
+    if (event.key === 'ArrowRight') nextIndex = (activeIndex + 1) % tabs.length
+    if (event.key === 'Home') nextIndex = 0
+    if (event.key === 'End') nextIndex = tabs.length - 1
+    select(tabs[nextIndex].id)
+    tabRefs.current[nextIndex]?.focus()
+  }
+
+  return (
+    <div className='reefpi-tabs'>
+      <div aria-label='Tabs' onKeyDown={handleKeyDown} role='tablist' style={{ display: 'flex', gap: 'var(--reefpi-space-xs)', overflowX: 'auto' }}>
+        {tabs.map((tab, index) => {
+          const selected = tab.id === activeValue
+          return (
+            <button
+              aria-controls={'panel-' + tab.id}
+              aria-selected={selected}
+              id={'tab-' + tab.id}
+              key={tab.id}
+              onClick={() => select(tab.id)}
+              ref={node => { tabRefs.current[index] = node }}
+              role='tab'
+              style={Object.assign({}, actionButtonStyle, selected
+                ? {
+                    background: 'var(--reefpi-color-brand)',
+                    border: '1px solid var(--reefpi-color-brand)',
+                    color: 'var(--reefpi-color-nav-text-strong)'
+                  }
+                : null)}
+              tabIndex={selected ? 0 : -1}
+              type='button'
+            >
+              {tab.label}
+            </button>
+          )
+        })}
+      </div>
+      {activeTab && (
+        <section
+          aria-labelledby={'tab-' + activeTab.id}
+          id={'panel-' + activeTab.id}
+          role='tabpanel'
+          style={Object.assign({}, surfaceStyle, { marginTop: 'var(--reefpi-space-sm)', padding: 'var(--reefpi-space-md)' })}
+        >
+          {activeTab.panel}
+        </section>
+      )}
+    </div>
+  )
+}
+
+Dialog.propTypes = {
+  actions: PropTypes.node,
+  children: PropTypes.node,
+  labelledBy: PropTypes.string,
+  onClose: PropTypes.func,
+  open: PropTypes.bool,
+  title: PropTypes.node
+}
+
+MenuItemButton.propTypes = {
+  item: PropTypes.shape({
+    label: PropTypes.node.isRequired,
+    onSelect: PropTypes.func
+  }).isRequired
+}
+
+Menu.propTypes = {
+  buttonLabel: PropTypes.node.isRequired,
+  children: PropTypes.node,
+  items: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.node.isRequired,
+    onSelect: PropTypes.func
+  }))
+}
+
+Tooltip.propTypes = {
+  children: PropTypes.node,
+  id: PropTypes.string,
+  text: PropTypes.node.isRequired
+}
+
+Tabs.propTypes = {
+  tabs: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    label: PropTypes.node.isRequired,
+    panel: PropTypes.node
+  })),
+  value: PropTypes.string,
+  onChange: PropTypes.func
+}

--- a/front-end/design-system/ui_kits/reef-pi-app/primitives/Interaction.test.js
+++ b/front-end/design-system/ui_kits/reef-pi-app/primitives/Interaction.test.js
@@ -1,0 +1,106 @@
+import React, { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import fs from 'fs'
+import path from 'path'
+import { Dialog, Menu, Tabs, Tooltip } from './Interaction'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+function render (component) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => root.render(component))
+  return { container, root, cleanup: () => act(() => { root.unmount(); container.remove() }) }
+}
+
+describe('design-system interaction primitives', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('renders Dialog as a labelled modal and closes on Escape and backdrop click', () => {
+    const onClose = jest.fn()
+    render(<Dialog open title='Delete equipment' onClose={onClose} actions={<button>Confirm</button>}>This action will delete equipment Skimmer.</Dialog>)
+
+    const dialog = document.querySelector('[role="dialog"]')
+    expect(dialog).toBeTruthy()
+    expect(dialog.getAttribute('aria-modal')).toBe('true')
+    expect(dialog.getAttribute('aria-labelledby')).toBeTruthy()
+
+    act(() => dialog.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })))
+    expect(onClose).toHaveBeenCalledTimes(1)
+
+    act(() => document.querySelector('.reefpi-dialog-backdrop').dispatchEvent(new MouseEvent('mousedown', { bubbles: true })))
+    expect(onClose).toHaveBeenCalledTimes(2)
+  })
+
+  it('cycles Dialog focus inside the modal', () => {
+    render(<Dialog open title='Focus test'><button>First</button><button>Second</button></Dialog>)
+    const dialog = document.querySelector('[role="dialog"]')
+    const buttons = document.querySelectorAll('button')
+
+    buttons[1].focus()
+    act(() => dialog.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true })))
+    expect(document.activeElement).toBe(buttons[0])
+  })
+
+  it('opens Menu, moves with arrow keys, closes on outside click, and runs item actions', () => {
+    const select = jest.fn()
+    render(<Menu buttonLabel='More' items={[{ label: 'Edit', onSelect: select }, { label: 'Delete' }]} />)
+
+    act(() => document.querySelector('button').click())
+    expect(document.querySelector('[role="menu"]')).toBeTruthy()
+
+    const items = document.querySelectorAll('[role="menuitem"]')
+    items[0].focus()
+    act(() => document.querySelector('[role="menu"]').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true })))
+    expect(document.activeElement).toBe(items[1])
+
+    act(() => items[0].click())
+    expect(select).toHaveBeenCalled()
+
+    act(() => document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })))
+    expect(document.querySelector('[role="menu"]')).toBeNull()
+  })
+
+  it('shows Tooltip on focus and hover with described-by wiring', () => {
+    render(<Tooltip text='Retry command'><button>Retry</button></Tooltip>)
+    const button = document.querySelector('button')
+
+    act(() => button.focus())
+    const tooltip = document.querySelector('[role="tooltip"]')
+    expect(tooltip.textContent).toBe('Retry command')
+    expect(button.getAttribute('aria-describedby')).toBe(tooltip.id)
+
+    act(() => button.blur())
+    expect(document.querySelector('[role="tooltip"]')).toBeNull()
+  })
+
+  it('renders keyboardable Tabs and calls onChange when stepping tabs', () => {
+    const onChange = jest.fn()
+    const { container } = render(<Tabs onChange={onChange} tabs={[
+      { id: 'settings', label: 'Settings', panel: 'Settings panel' },
+      { id: 'connectors', label: 'Connectors', panel: 'Connectors panel' }
+    ]} />)
+
+    const tablist = container.querySelector('[role="tablist"]')
+    expect(container.querySelector('[role="tabpanel"]').textContent).toBe('Settings panel')
+
+    act(() => tablist.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true })))
+    expect(onChange).toHaveBeenCalledWith('connectors')
+    expect(container.querySelector('[role="tabpanel"]').textContent).toBe('Connectors panel')
+  })
+
+  it('documents the preview story without Bootstrap JS or jQuery hooks', () => {
+    const story = fs.readFileSync(path.join(process.cwd(), 'front-end/design-system/preview/primitives/interactions.html'), 'utf8')
+
+    expect(story).toContain('role="dialog"')
+    expect(story).toContain('role="menu"')
+    expect(story).toContain('role="tooltip"')
+    expect(story).toContain('role="tablist"')
+    expect(story).not.toContain('data-toggle')
+    expect(story).not.toContain('jquery')
+    expect(story).not.toContain('bootstrap')
+  })
+})


### PR DESCRIPTION
## Summary
- adds Dialog, Menu, Tooltip, and Tabs primitives for Bootstrap JS exit
- covers modal Escape/backdrop/focus behavior, menu outside/keyboard behavior, tooltip focus/hover, and tabs keyboarding
- adds interactions preview card and manifest entry

## Verification
- rtk ./node_modules/.bin/standard --fix front-end/design-system/ui_kits/reef-pi-app/primitives/Interaction.jsx
- rtk yarn jest front-end/design-system/ui_kits/reef-pi-app/primitives/Interaction.test.js --runInBand
- rtk yarn run preview-card-check
- rtk yarn run bootstrap-class-check
- rtk git diff --check

Fixes #3113