### PR TITLE
[claude design] F12 + E6 #28 tick + sign_in.jsx Bootstrap migration

### DIFF
--- a/docs/superpowers/plans/2026-06-01-f12-e6-sign-in-bootstrap.md
+++ b/docs/superpowers/plans/2026-06-01-f12-e6-sign-in-bootstrap.md
@@ -1,0 +1,436 @@
+# F12 + E6 sign-in Bootstrap Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire EmptyState to the camera module (F12), tick E6 #28 in BACKLOG.md, and replace all Bootstrap classes in sign_in.jsx with design-system primitives.
+
+**Architecture:** Three independent changes committed separately, shipped in one PR. camera/main.jsx gets a conditional EmptyState render; sign_in.jsx drops all Bootstrap in favour of Button/Field/Input from the design-system primitives and inline token CSS; BACKLOG.md gets a checkbox tick.
+
+**Tech Stack:** React 19, Jest/jsdom, design-system Button/Field/Input/EmptyState primitives, `var(--reefpi-*)` CSS tokens, `eslint.config.mjs` Bootstrap ban (lint:no-bootstrap)
+
+---
+
+## File Map
+
+| Action | File | Change |
+|--------|------|--------|
+| Modify | `front-end/src/camera/main.jsx` | Import EmptyState; conditional render when images empty |
+| Modify | `front-end/src/camera/camera.test.js` | Add EmptyState render test |
+| Modify | `front-end/design-system/github_issues/BACKLOG.md` | Tick E6 #28 checkbox |
+| Modify | `front-end/src/sign_in.jsx` | Replace all Bootstrap classes with primitives + inline tokens |
+
+---
+
+## Task 1: Camera EmptyState (F12)
+
+**Files:**
+- Modify: `front-end/src/camera/main.jsx`
+- Modify: `front-end/src/camera/camera.test.js`
+
+### Background
+
+`camera/main.jsx` renders `<Gallery images={[]} />` silently when no images exist. Wire in `EmptyState` so users see a helpful message. The `EmptyState` component lives at `front-end/design-system/ui_kits/reef-pi-app/shell/EmptyState.jsx` and is imported as default export. No named icon exports exist for camera, so omit the `icon` prop (EmptyState uses a generic placeholder automatically).
+
+Path from `front-end/src/camera/main.jsx` to EmptyState: `../../design-system/ui_kits/reef-pi-app/shell/EmptyState`
+
+The test file uses a `findByType(tree, Component)` helper already defined at the top. Import `EmptyState` in the test file the same way the component will import it.
+
+- [ ] **Step 1: Add a failing test to `camera.test.js`**
+
+Add the following import near the top of `front-end/src/camera/camera.test.js`, after the existing imports:
+
+```js
+import EmptyState from '../../design-system/ui_kits/reef-pi-app/shell/EmptyState'
+```
+
+Then add this test inside the `describe('Camera module', ...)` block, after the existing `'<Main /> mounts with empty state'` test:
+
+```js
+it('<Main /> renders EmptyState when images is empty', () => {
+  const camera = new RawCamera({
+    config: {},
+    images: [],
+    fetchConfig: jest.fn(),
+    listImages: jest.fn(),
+    updateConfig: jest.fn()
+  })
+  const tree = camera.render()
+  expect(findByType(tree, EmptyState)).toBeDefined()
+})
+```
+
+- [ ] **Step 2: Run to confirm FAIL**
+
+```bash
+yarn jest front-end/src/camera/camera.test.js --testNamePattern="renders EmptyState"
+```
+
+Expected: FAIL — EmptyState is not rendered yet.
+
+- [ ] **Step 3: Update `front-end/src/camera/main.jsx`**
+
+Add the EmptyState import after the existing imports (line 8, after `import i18next`):
+
+```js
+import EmptyState from '../../design-system/ui_kits/reef-pi-app/shell/EmptyState'
+```
+
+In the `render()` method, find the gallery row (currently around line 69):
+
+```jsx
+<div className='row'>
+  <Gallery images={images} />
+</div>
+```
+
+Replace it with:
+
+```jsx
+<div className='row'>
+  {images.length > 0
+    ? <Gallery images={images} />
+    : !this.state.showConfig && (
+      <EmptyState
+        title='No images yet'
+        body='Capture an image to get started.'
+      />
+    )}
+</div>
+```
+
+- [ ] **Step 4: Run test to confirm PASS**
+
+```bash
+yarn jest front-end/src/camera/camera.test.js --testNamePattern="renders EmptyState"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run full camera test suite**
+
+```bash
+yarn jest front-end/src/camera/camera.test.js
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add front-end/src/camera/main.jsx front-end/src/camera/camera.test.js
+git commit -m "[claude design] F12: wire EmptyState to camera module"
+```
+
+---
+
+## Task 2: Tick E6 #28 in BACKLOG.md
+
+**Files:**
+- Modify: `front-end/design-system/github_issues/BACKLOG.md`
+
+### Background
+
+`@material-ui` has zero matches in `front-end/src/`. `react-toggle-switch` was removed in PR #3117. Both dependencies the epic targeted are gone. The checkbox is a one-line change.
+
+- [ ] **Step 1: Tick the checkbox**
+
+In `front-end/design-system/github_issues/BACKLOG.md`, find the line:
+
+```markdown
+- [ ] #28 Material-UI v4 exit plan — `issue-28-mui-exit.md`
+```
+
+Change it to:
+
+```markdown
+- [x] #28 Material-UI v4 exit plan — `issue-28-mui-exit.md`
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add front-end/design-system/github_issues/BACKLOG.md
+git commit -m "[claude design] docs: tick E6 #28 — MUI and react-toggle-switch removed"
+```
+
+---
+
+## Task 3: Migrate sign_in.jsx off Bootstrap
+
+**Files:**
+- Modify: `front-end/src/sign_in.jsx`
+
+### Background
+
+`sign_in.jsx` has five Bootstrap patterns. All are replaced with design-system primitives (`Button`, `Field`, `Input`) and inline token CSS. The existing tests in `sign_in.test.js` test business logic only (login handlers, state transitions) — they do not test rendered DOM structure, so they require no changes.
+
+Import paths from `front-end/src/sign_in.jsx`:
+- Button: `'../design-system/ui_kits/reef-pi-app/primitives/Button'`
+- Field, Input: `'../design-system/ui_kits/reef-pi-app/primitives/Form'`
+
+The lint guard (`yarn lint:no-bootstrap`) currently reports 5 errors on `sign_in.jsx`. After migration it must report 0.
+
+- [ ] **Step 1: Run lint to confirm it currently fails**
+
+```bash
+node_modules/.bin/eslint front-end/src/sign_in.jsx 2>&1 | grep error
+```
+
+Expected: 5 errors for Bootstrap classes.
+
+- [ ] **Step 2: Replace the entire `sign_in.jsx` file**
+
+Write `front-end/src/sign_in.jsx` with this content:
+
+```jsx
+import React from 'react'
+import i18n from 'utils/i18n'
+import { isSignedIn, signIn, signOut } from './session_api'
+import SignInConfidenceCard from '../design-system/ui_kits/reef-pi-app/shell/SignInConfidenceCard'
+import Button from '../design-system/ui_kits/reef-pi-app/primitives/Button'
+import { Field, Input } from '../design-system/ui_kits/reef-pi-app/primitives/Form'
+
+export default class SignIn extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      user: '',
+      password: '',
+      invalidCredentials: false
+    }
+    this.handleLogin = this.handleLogin.bind(this)
+    this.handleUserChange = this.handleUserChange.bind(this)
+    this.handlePasswordChange = this.handlePasswordChange.bind(this)
+  }
+
+  static isSignedIn () {
+    return isSignedIn()
+  }
+
+  static logout () {
+    return signOut().then(() => {
+      SignIn.refreshPage()
+    })
+  }
+
+  /* istanbul ignore next */
+  static refreshPage () {
+    window.location.reload(true)
+  }
+
+  handleLogin (e) {
+    this.setState({ invalidCredentials: false })
+    e.preventDefault()
+    const creds = {
+      user: this.state.user,
+      password: this.state.password
+    }
+    const setState = this.setState.bind(this)
+    return signIn(creds).then(response => {
+      switch (response.status) {
+        case 500:
+          console.log('Internal Server Error')
+          console.log(response)
+          break
+        case 200:
+          SignIn.refreshPage()
+          break
+        default:
+          setState({ invalidCredentials: true })
+          break
+      }
+      return response
+    })
+  }
+
+  handleUserChange (e) {
+    this.setState({ user: e.target.value })
+  }
+
+  handlePasswordChange (e) {
+    this.setState({ password: e.target.value })
+  }
+
+  render () {
+    return (
+      <div style={{ display: 'flex', minHeight: '100vh', alignItems: 'center', justifyContent: 'center' }}>
+        <div style={{ width: '100%', maxWidth: '24rem', padding: '0 1rem' }}>
+          <form id='sign-in-form' data-testid='smoke-sign-in-form'>
+            <div style={{ display: 'grid', gap: 'var(--reefpi-space-sm)' }}>
+              <h1
+                className='reef-pi-title'
+                style={{ fontSize: 'var(--reefpi-h3)', fontWeight: 500, marginBottom: 0 }}
+              >
+                reef-pi
+              </h1>
+              {this.state.invalidCredentials && (
+                <div
+                  role='alert'
+                  style={{
+                    background: 'var(--reefpi-color-error-bg)',
+                    border: '1px solid var(--reefpi-color-error-border)',
+                    borderRadius: 'var(--reefpi-radius-sm)',
+                    color: 'var(--reefpi-color-error)',
+                    padding: 'var(--reefpi-space-xs) var(--reefpi-space-sm)'
+                  }}
+                >
+                  <strong>Oops!</strong> {i18n.t('signin:invalidcredentials')}
+                </div>
+              )}
+              <Field label={i18n.t('signin:username')}>
+                <Input
+                  onChange={this.handleUserChange}
+                  type='text'
+                  id='reef-pi-user'
+                  data-testid='smoke-sign-in-user'
+                  name='username'
+                  placeholder={i18n.t('signin:username')}
+                  required
+                  autoFocus
+                />
+              </Field>
+              <Field label={i18n.t('signin:password')}>
+                <Input
+                  onChange={this.handlePasswordChange}
+                  type='password'
+                  id='reef-pi-pass'
+                  data-testid='smoke-sign-in-pass'
+                  name='password'
+                  placeholder={i18n.t('signin:password')}
+                  required
+                />
+              </Field>
+              <Button
+                variant='primary'
+                type='submit'
+                id='btnSaveCreds'
+                data-testid='smoke-sign-in-submit'
+                onClick={this.handleLogin}
+                style={{ width: '100%' }}
+              >
+                {i18n.t('signin:signin')}
+              </Button>
+            </div>
+          </form>
+          <SignInConfidenceCard />
+        </div>
+      </div>
+    )
+  }
+}
+```
+
+- [ ] **Step 3: Run lint to confirm it now passes**
+
+```bash
+node_modules/.bin/eslint front-end/src/sign_in.jsx 2>&1 | grep -v 'ESLintIgnoreWarning\|trace-warnings'
+```
+
+Expected: no output (zero errors).
+
+- [ ] **Step 4: Run sign_in tests**
+
+```bash
+yarn jest front-end/src/sign_in.test.js
+```
+
+Expected: all 2 tests PASS. The tests only exercise `handleLogin`, `handleUserChange`, `handlePasswordChange`, `isSignedIn`, and `logout` — none of which changed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add front-end/src/sign_in.jsx
+git commit -m "[claude design] route/sign_in: off Bootstrap"
+```
+
+---
+
+## Task 4: Create issue, push PR, update issue, clean up
+
+- [ ] **Step 1: Create the GitHub tracking issue**
+
+```bash
+gh issue create \
+  --title "F12 + E6 #28 tick + sign_in.jsx Bootstrap migration" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Three housekeeping changes shipped together:
+
+- **F12**: Wire `EmptyState` to `camera/main.jsx` — shows a helpful message when no images exist (closes Integration Backlog #2924).
+- **E6 #28 tick**: `@material-ui` and `react-toggle-switch` are both gone; tick the BACKLOG.md checkbox.
+- **E6 #27 first route**: `sign_in.jsx` is now Bootstrap-free — all layout, form controls, and submit button replaced with `Button`, `Field`, `Input` design-system primitives and inline `var(--reefpi-*)` token CSS.
+EOF
+)"
+```
+
+Note the issue number printed — you need it for the PR body.
+
+- [ ] **Step 2: Push branch and open PR**
+
+```bash
+git push -u origin feature/f12-e6-sign-in-bootstrap
+```
+
+Then (replace `<ISSUE>` with the number from Step 1):
+
+```bash
+gh pr create \
+  --title "[claude design] F12 + E6 #28 tick + sign_in.jsx Bootstrap migration" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- **F12**: `EmptyState` now renders in camera when image list is empty. Closes #<ISSUE>.
+- **E6 #28**: Tick — `@material-ui` and `react-toggle-switch` fully removed.
+- **E6 #27 route/sign_in**: Zero Bootstrap classes remain in `sign_in.jsx`. Uses `Button`, `Field`, `Input` from design-system primitives.
+
+## Test plan
+
+- [x] `yarn jest front-end/src/camera/camera.test.js` — all pass
+- [x] `yarn jest front-end/src/sign_in.test.js` — all pass
+- [x] `node_modules/.bin/eslint front-end/src/sign_in.jsx` — zero errors
+- [ ] Visual check: sign-in page renders correctly in browser (centered card, labels above inputs, green submit button)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Comment on the issue with the PR link**
+
+```bash
+gh issue comment <ISSUE> --body "PR opened: <PR_URL>"
+```
+
+- [ ] **Step 4: After PR merges — clean up**
+
+```bash
+git checkout main
+git pull origin main
+git branch -d feature/f12-e6-sign-in-bootstrap
+```
+
+---
+
+## Self-Review
+
+1. **Spec coverage:**
+   - F12 camera EmptyState with test → Task 1 ✓
+   - E6 #28 BACKLOG tick → Task 2 ✓
+   - sign_in.jsx layout (container/col/flex) → Task 3 Step 2 ✓
+   - sign_in.jsx form wrapper → Task 3 Step 2 ✓
+   - sign_in.jsx title Bootstrap classes removed → Task 3 Step 2 ✓
+   - sign_in.jsx error alert → Task 3 Step 2 ✓
+   - sign_in.jsx Field+Input for username → Task 3 Step 2 ✓
+   - sign_in.jsx Field+Input for password → Task 3 Step 2 ✓
+   - sign_in.jsx Button submit → Task 3 Step 2 ✓
+   - lint:no-bootstrap passes → Task 3 Step 3 ✓
+   - GitHub issue + PR + cleanup → Task 4 ✓
+
+2. **Placeholder scan:** No TBDs. All code blocks are complete.
+
+3. **Type consistency:**
+   - `EmptyState` imported as default in both test and component — consistent.
+   - `Field`, `Input` named exports from `Form.jsx` — consistent with the actual Form.jsx API.
+   - `Button` default export from `Button.jsx` — consistent.
+   - Import paths verified: `'../../design-system/...'` from `front-end/src/camera/`, `'../design-system/...'` from `front-end/src/sign_in.jsx` ✓

--- a/docs/superpowers/specs/2026-06-01-f12-e6-sign-in-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-06-01-f12-e6-sign-in-bootstrap-design.md
@@ -1,0 +1,230 @@
+# F12 + E6 #28 Tick + sign_in.jsx Bootstrap Migration Design Spec
+
+**Date:** 2026-06-01
+**Branch:** `feature/f12-e6-sign-in-bootstrap`
+**Issues closed:**
+- Integration Backlog F12 #2924 — Wire EmptyState to camera module
+- BACKLOG E6 #28 — MUI v4 exit (already done; tick only)
+- BACKLOG E6 #27 — Bootstrap exit, first route: sign_in.jsx
+
+---
+
+## Change 1: F12 — Camera EmptyState (`front-end/src/camera/main.jsx`)
+
+When `images.length === 0` and the config panel is not visible, render `EmptyState` instead of an empty `Gallery`.
+
+**Import to add:**
+```js
+import EmptyState from '../../design-system/ui_kits/reef-pi-app/shell/EmptyState'
+```
+
+**Logic change in `render()`:** Replace the current unconditional `<Gallery images={images} />` with:
+```jsx
+{images.length > 0
+  ? <Gallery images={images} />
+  : !this.state.showConfig && (
+    <EmptyState
+      title='No images'
+      copy='Capture an image to get started.'
+    />
+  )}
+```
+
+The Configure button row remains unchanged above this. `<Capture />` and `{this.motion()}` remain below.
+
+**Tests:** `front-end/src/camera/camera.test.js` — add a test asserting EmptyState renders when `images` is empty.
+
+---
+
+## Change 2: E6 #28 BACKLOG tick (`front-end/design-system/github_issues/BACKLOG.md`)
+
+`@material-ui` has 0 matches in `front-end/src/`. `react-toggle-switch` was removed in PR #3117. Both dependencies the epic targeted are gone.
+
+Change:
+```markdown
+- [ ] #28 Material-UI v4 exit plan — `issue-28-mui-exit.md`
+```
+to:
+```markdown
+- [x] #28 Material-UI v4 exit plan — `issue-28-mui-exit.md`
+```
+
+---
+
+## Change 3: sign_in.jsx Bootstrap migration (`front-end/src/sign_in.jsx`)
+
+Replace all five Bootstrap patterns. No logic changes — only markup.
+
+### 3a. Outer centering layout
+
+**Before:**
+```jsx
+<div className='container d-flex h-100'>
+  <div className='align-self-center w-100'>
+    <div className='col-md-12 col-lg-6 mx-auto'>
+```
+
+**After:**
+```jsx
+<div style={{ display: 'flex', minHeight: '100vh', alignItems: 'center', justifyContent: 'center' }}>
+  <div style={{ width: '100%', maxWidth: '24rem', padding: '0 1rem' }}>
+```
+(One fewer nesting level — the middle `align-self-center` div is collapsed into the outer flexbox.)
+
+### 3b. Form wrapper
+
+**Before:** `<div className='form'>`
+
+**After:** `<div style={{ display: 'grid', gap: 'var(--reefpi-space-sm)' }}>`
+
+### 3c. Title
+
+**Before:** `<h1 className='h3 mb-3 font-weight-normal reef-pi-title'>reef-pi</h1>`
+
+**After:** `<h1 className='reef-pi-title' style={{ fontSize: 'var(--reefpi-h3)', fontWeight: 500, marginBottom: 0 }}>reef-pi</h1>`
+
+(`reef-pi-title` is a custom class in `style.scss`, not Bootstrap — keep it.)
+
+### 3d. Error alert
+
+**Before:** `<div className='alert alert-danger' role='alert'>`
+
+**After:**
+```jsx
+<div
+  role='alert'
+  style={{
+    background: 'var(--reefpi-color-error-bg)',
+    border: '1px solid var(--reefpi-color-error-border)',
+    borderRadius: 'var(--reefpi-radius-sm)',
+    color: 'var(--reefpi-color-error)',
+    padding: 'var(--reefpi-space-xs) var(--reefpi-space-sm)'
+  }}
+>
+```
+
+### 3e. Username field
+
+**Before:**
+```jsx
+<label htmlFor='reef-pi-user' className='sr-only'>
+  {i18n.t('signin:username')}
+</label>
+<input
+  onChange={this.handleUserChange}
+  type='text'
+  id='reef-pi-user'
+  data-testid='smoke-sign-in-user'
+  className='form-control'
+  name='username'
+  placeholder={i18n.t('signin:username')}
+  required=''
+  autoFocus=''
+/>
+```
+
+**After:**
+```jsx
+<Field label={i18n.t('signin:username')}>
+  <Input
+    onChange={this.handleUserChange}
+    type='text'
+    id='reef-pi-user'
+    data-testid='smoke-sign-in-user'
+    name='username'
+    placeholder={i18n.t('signin:username')}
+    required
+    autoFocus
+  />
+</Field>
+```
+
+### 3f. Password field
+
+**Before:**
+```jsx
+<label htmlFor='reef-pi-pass' className='sr-only'>
+  {i18n.t('signin:password')}
+</label>
+<input
+  onChange={this.handlePasswordChange}
+  type='password'
+  id='reef-pi-pass'
+  data-testid='smoke-sign-in-pass'
+  className='form-control'
+  name='password'
+  placeholder={i18n.t('signin:password')}
+  required=''
+  autoFocus=''
+/>
+```
+
+**After:**
+```jsx
+<Field label={i18n.t('signin:password')}>
+  <Input
+    onChange={this.handlePasswordChange}
+    type='password'
+    id='reef-pi-pass'
+    data-testid='smoke-sign-in-pass'
+    name='password'
+    placeholder={i18n.t('signin:password')}
+    required
+  />
+</Field>
+```
+
+### 3g. Submit button
+
+**Before:** `<button className='btn btn-lg btn-success btn-block mt-3' onClick={this.handleLogin} type='submit' id='btnSaveCreds' data-testid='smoke-sign-in-submit'>`
+
+**After:**
+```jsx
+<Button
+  variant='primary'
+  type='submit'
+  id='btnSaveCreds'
+  data-testid='smoke-sign-in-submit'
+  onClick={this.handleLogin}
+  style={{ width: '100%' }}
+>
+```
+
+### New imports for sign_in.jsx
+
+Add:
+```js
+import Button from '../design-system/ui_kits/reef-pi-app/primitives/Button'
+import { Field, Input } from '../design-system/ui_kits/reef-pi-app/primitives/Form'
+```
+
+The path from `front-end/src/sign_in.jsx` to `front-end/design-system/` is `../design-system/`.
+
+---
+
+## Tests
+
+### camera.test.js
+Add: renders EmptyState when images array is empty.
+
+### sign_in.test.js
+Existing tests use `data-testid` selectors — these are unchanged. The test that checks for `.reef-pi-title` class still works. No test checks for Bootstrap class names. Existing tests should pass without changes; verify by running them.
+
+---
+
+## Out of scope
+
+- `auth.jsx` Bootstrap cleanup — that file is inside configuration settings and will be handled as part of the configuration route migration.
+- Tier 1 Bootstrap cleanup in sign_in.jsx was already done (container was Tier 1; we're removing it here as part of Tier 2 since the whole file is being migrated).
+
+---
+
+## Definition of Done
+
+- [ ] `EmptyState` renders in `camera/main.jsx` when images is empty.
+- [ ] `camera.test.js` has a test for the empty state.
+- [ ] BACKLOG.md `#28` is ticked.
+- [ ] `sign_in.jsx` has zero Bootstrap class names.
+- [ ] `sign_in.test.js` all tests pass.
+- [ ] `yarn lint:no-bootstrap front-end/src/sign_in.jsx` passes.
+- [ ] Commit prefix: `[claude design]`.

--- a/front-end/design-system/github_issues/BACKLOG.md
+++ b/front-end/design-system/github_issues/BACKLOG.md
@@ -41,7 +41,7 @@
 
 ## E6 · Framework exit (no flag — incremental, one route per PR)
 - [ ] #27 Bootstrap 4.6 exit plan — `issue-27-bootstrap-exit.md`
-- [ ] #28 Material-UI v4 exit plan — `issue-28-mui-exit.md`
+- [x] #28 Material-UI v4 exit plan — `issue-28-mui-exit.md`
 
 ## E7 · UI audit screenshot pipeline
 - [x] #30 UI audit artifact foundation — `issue-30-ui-audit-artifact-foundation.md`

--- a/front-end/src/camera/camera.test.js
+++ b/front-end/src/camera/camera.test.js
@@ -4,6 +4,7 @@ import { RawCapture, cameraImageURL } from './capture'
 import Config from './config'
 import Gallery from './gallery'
 import Motion from './motion'
+import EmptyState from '../../design-system/ui_kits/reef-pi-app/shell/EmptyState'
 import fetchMock from 'fetch-mock'
 import 'isomorphic-fetch'
 import * as Alert from '../utils/alert'
@@ -92,6 +93,18 @@ describe('Camera module', () => {
     })
 
     expect(() => camera.render()).not.toThrow()
+  })
+
+  it('<Main /> renders EmptyState when images is empty', () => {
+    const camera = new RawCamera({
+      config: {},
+      images: [],
+      fetchConfig: jest.fn(),
+      listImages: jest.fn(),
+      updateConfig: jest.fn()
+    })
+    const tree = camera.render()
+    expect(findByType(tree, EmptyState)).toBeDefined()
   })
 
   it('<Main /> toggles config form rendering', () => {

--- a/front-end/src/camera/main.jsx
+++ b/front-end/src/camera/main.jsx
@@ -5,6 +5,7 @@ import Capture, { cameraImageURL } from './capture'
 import { fetchConfig, updateConfig, listImages } from 'redux/actions/camera'
 import { connect } from 'react-redux'
 import Motion from './motion'
+import EmptyState from '../../design-system/ui_kits/reef-pi-app/shell/EmptyState'
 import i18next from 'i18next'
 
 export class RawCamera extends React.Component {
@@ -67,7 +68,14 @@ export class RawCamera extends React.Component {
           {config}
         </div>
         <div className='row'>
-          <Gallery images={images} />
+          {images.length > 0
+            ? <Gallery images={images} />
+            : !this.state.showConfig && (
+              <EmptyState
+                title='No images yet'
+                body='Capture an image to get started.'
+              />
+            )}
         </div>
         <div className='row'>
           <Capture />

--- a/front-end/src/sign_in.jsx
+++ b/front-end/src/sign_in.jsx
@@ -2,6 +2,8 @@ import React from 'react'
 import i18n from 'utils/i18n'
 import { isSignedIn, signIn, signOut } from './session_api'
 import SignInConfidenceCard from '../design-system/ui_kits/reef-pi-app/shell/SignInConfidenceCard'
+import Button from '../design-system/ui_kits/reef-pi-app/primitives/Button'
+import { Field, Input } from '../design-system/ui_kits/reef-pi-app/primitives/Form'
 
 export default class SignIn extends React.Component {
   constructor (props) {
@@ -66,62 +68,66 @@ export default class SignIn extends React.Component {
 
   render () {
     return (
-      <div className='container d-flex h-100'>
-        <div className='align-self-center w-100'>
-          <div className='col-md-12 col-lg-6 mx-auto'>
-            <form id='sign-in-form' data-testid='smoke-sign-in-form'>
-              <div className='form'>
-                <h1 className='h3 mb-3 font-weight-normal reef-pi-title'>reef-pi</h1>
-                {this.state.invalidCredentials
-                  ? (
-                    <div className='alert alert-danger' role='alert'>
-                      <strong>Oops!</strong> {i18n.t('signin:invalidcredentials')}
-                    </div>
-                    )
-                  : (
-                    <div />
-                    )}
-                <label htmlFor='reef-pi-user' className='sr-only'>
-                  {i18n.t('signin:username')}
-                </label>
-                <input
+      <div style={{ display: 'flex', minHeight: '100vh', alignItems: 'center', justifyContent: 'center' }}>
+        <div style={{ width: '100%', maxWidth: '24rem', padding: '0 1rem' }}>
+          <form id='sign-in-form' data-testid='smoke-sign-in-form'>
+            <div style={{ display: 'grid', gap: 'var(--reefpi-space-sm)' }}>
+              <h1
+                className='reef-pi-title'
+                style={{ fontSize: 'var(--reefpi-h3)', fontWeight: 500, marginBottom: 0 }}
+              >
+                reef-pi
+              </h1>
+              {this.state.invalidCredentials && (
+                <div
+                  role='alert'
+                  style={{
+                    background: 'var(--reefpi-color-error-bg)',
+                    border: '1px solid var(--reefpi-color-error-border)',
+                    borderRadius: 'var(--reefpi-radius-sm)',
+                    color: 'var(--reefpi-color-error)',
+                    padding: 'var(--reefpi-space-xs) var(--reefpi-space-sm)'
+                  }}
+                >
+                  <strong>Oops!</strong> {i18n.t('signin:invalidcredentials')}
+                </div>
+              )}
+              <Field label={i18n.t('signin:username')}>
+                <Input
                   onChange={this.handleUserChange}
                   type='text'
                   id='reef-pi-user'
                   data-testid='smoke-sign-in-user'
-                  className='form-control'
                   name='username'
                   placeholder={i18n.t('signin:username')}
-                  required=''
-                  autoFocus=''
+                  required
+                  autoFocus
                 />
-                <label htmlFor='reef-pi-pass' className='sr-only'>
-                  {i18n.t('signin:password')}
-                </label>
-                <input
+              </Field>
+              <Field label={i18n.t('signin:password')}>
+                <Input
                   onChange={this.handlePasswordChange}
                   type='password'
                   id='reef-pi-pass'
                   data-testid='smoke-sign-in-pass'
-                  className='form-control'
                   name='password'
                   placeholder={i18n.t('signin:password')}
-                  required=''
-                  autoFocus=''
+                  required
                 />
-                <button
-                  className='btn btn-lg btn-success btn-block mt-3'
-                  onClick={this.handleLogin}
-                  type='submit'
-                  id='btnSaveCreds'
-                  data-testid='smoke-sign-in-submit'
-                >
-                  {i18n.t('signin:signin')}
-                </button>
-              </div>
-            </form>
-            <SignInConfidenceCard />
-          </div>
+              </Field>
+              <Button
+                variant='primary'
+                type='submit'
+                id='btnSaveCreds'
+                data-testid='smoke-sign-in-submit'
+                onClick={this.handleLogin}
+                style={{ width: '100%' }}
+              >
+                {i18n.t('signin:signin')}
+              </Button>
+            </div>
+          </form>
+          <SignInConfidenceCard />
         </div>
       </div>
     )


### PR DESCRIPTION
## Summary

- **F12**: \`EmptyState\` now renders in camera when image list is empty.
- **E6 #28**: Ticked — \`@material-ui\` and \`react-toggle-switch\` fully removed.
- **E6 #27 route/sign_in**: Zero Bootstrap classes remain in \`sign_in.jsx\`. Uses \`Button\`, \`Field\`, \`Input\` from design-system primitives.

Closes #3121.

## Test plan

- [x] \`yarn jest front-end/src/camera/camera.test.js\` — all pass
- [x] \`yarn jest front-end/src/sign_in.test.js\` — all pass
- [x] \`node_modules/.bin/eslint front-end/src/sign_in.jsx\` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)