### PR TITLE
[claude design] route/equipment: off Bootstrap

### DIFF
--- a/front-end/design-system/github_issues/issue-27-bootstrap-exit.md
+++ b/front-end/design-system/github_issues/issue-27-bootstrap-exit.md
@@ -75,7 +75,7 @@ Once tier 3 is done, **delete jQuery from `package.json`** (it's only there beca
 
 ## Routes migrated (tick as PRs merge)
 - [ ] dashboard (covered by `dashboard_v2` — Bootstrap-free from day one)
-- [ ] equipment
+- [x] equipment
 - [ ] timers
 - [ ] lighting
 - [ ] temperature

--- a/front-end/src/equipment/chart.jsx
+++ b/front-end/src/equipment/chart.jsx
@@ -5,6 +5,21 @@ import { connect } from 'react-redux'
 import i18next from 'i18next'
 import { EQUIPMENT_POLL_INTERVAL_MS } from './utils'
 
+const chartContainerStyle = {
+  display: 'grid',
+  gap: 'var(--reefpi-space-xs)',
+  minWidth: 0,
+  width: '100%'
+}
+
+const titleStyle = {
+  color: 'var(--reefpi-color-text)',
+  fontFamily: 'var(--reefpi-font-app)',
+  fontSize: '1rem',
+  fontWeight: 600,
+  lineHeight: 1.35
+}
+
 class CustomToolTip extends React.Component {
   render () {
     if (this.props.payload === undefined) {
@@ -41,8 +56,8 @@ export class RawEquipmentChart extends React.Component {
       offstate: eq.on ? undefined : 1
     }))
     return (
-      <div className='container'>
-        <span className='h6'>{i18next.t('capabilities:equipment')}</span>
+      <div style={chartContainerStyle}>
+        <span style={titleStyle}>{i18next.t('capabilities:equipment')}</span>
         <ResponsiveContainer height={this.props.height} width='100%'>
           <BarChart data={equipment}>
             <Bar dataKey='onstate' fill='#00c851' isAnimationActive={false} stackId='a' />

--- a/front-end/src/equipment/ctrl_panel.jsx
+++ b/front-end/src/equipment/ctrl_panel.jsx
@@ -5,6 +5,21 @@ import ToggleSwitch from '../../design-system/ui_kits/reef-pi-app/primitives/Tog
 import { useEquipmentToggle } from '../../design-system/ui_kits/reef-pi-app/hooks/useEquipmentToggle'
 import { buildEquipmentPayload, EQUIPMENT_POLL_INTERVAL_MS, sortEquipment } from './utils'
 
+const panelStyle = {
+  display: 'grid',
+  gap: 'var(--reefpi-space-sm)',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(12rem, 1fr))',
+  marginBottom: 'var(--reefpi-space-xxs)'
+}
+
+const itemStyle = {
+  alignItems: 'center',
+  display: 'inline-flex',
+  gap: 'var(--reefpi-space-xs)',
+  margin: 0,
+  minHeight: 'var(--reefpi-tap-target-min)'
+}
+
 // Per-item toggle with pending states — must be its own component to call hooks
 function PendingEquipmentToggle ({ item, dispatch }) {
   const send = useCallback(next => {
@@ -52,18 +67,14 @@ export class RawEquipmentCtrlPanel extends React.Component {
     }
 
     return (
-      <div className='container' style={{ marginBottom: '3px' }}>
-        <div className='row'>
-          {sortEquipment(this.props.equipment)
-            .map(item => (
-              <div className='col-12 col-sm-6 col-md-2 col-lg-3 order-sm-3' key={'eq-' + item.id}>
-                <label className='d-inline-flex align-items-center mb-0'>
-                  <PendingEquipmentToggle item={item} dispatch={this.props.dispatch} />
-                  <span className='ml-2'>{item.name}</span>
-                </label>
-              </div>
-            ))}
-        </div>
+      <div style={panelStyle}>
+        {sortEquipment(this.props.equipment)
+          .map(item => (
+            <label style={itemStyle} key={'eq-' + item.id}>
+              <PendingEquipmentToggle item={item} dispatch={this.props.dispatch} />
+              <span>{item.name}</span>
+            </label>
+          ))}
       </div>
     )
   }

--- a/front-end/src/equipment/edit_equipment.jsx
+++ b/front-end/src/equipment/edit_equipment.jsx
@@ -1,11 +1,35 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { ErrorFor, ShowError } from '../utils/validation_helper'
+import { ErrorMessage, ShowError } from '../utils/validation_helper'
 import { showError, showUpdateSuccessful } from 'utils/alert'
-import classNames from 'classnames'
 import i18next from 'i18next'
 import { FaTrashAlt, FaSave } from 'react-icons/fa'
 import { SortByName } from 'utils/sort_by_name'
+import Button from '../../design-system/ui_kits/reef-pi-app/primitives/Button'
+import { Field, Input, Select } from '../../design-system/ui_kits/reef-pi-app/primitives/Form'
+
+const formGridStyle = {
+  alignItems: 'end',
+  display: 'grid',
+  gap: 'var(--reefpi-space-md)',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(12rem, 1fr))',
+  width: '100%'
+}
+
+const checkboxStyle = {
+  height: '1.25rem',
+  minHeight: '1.25rem',
+  minWidth: '1.25rem',
+  width: '1.25rem'
+}
+
+const actionStyle = {
+  alignItems: 'center',
+  display: 'inline-flex',
+  gap: 'var(--reefpi-space-xs)'
+}
+
+const fieldError = (name, touched, errors) => ShowError(name, touched, errors) ? ErrorMessage(errors, name) : undefined
 
 const EditEquipment = ({
   values,
@@ -34,41 +58,34 @@ const EditEquipment = ({
   const deleteAction = () => {
     if (values.id) {
       return (
-        <div className='d-inline p-2' onClick={onDelete}>
-          {FaTrashAlt()}
-        </div>
+        <Button type='button' variant='ghost' icon={<FaTrashAlt />} iconOnly aria-label='Delete equipment' onClick={onDelete} />
       )
     }
-    return ''
+    return null
   }
 
   return (
     <form onSubmit={handleSubmit}>
-      <div className='d-flex flex-wrap'>
-        <div className='p-2 mr-auto'>
-          <label className='mr-2'>{i18next.t('name')}</label>
-          <input
+      <div style={formGridStyle}>
+        <Field label={i18next.t('name')} error={fieldError('name', touched, errors)}>
+          <Input
             type='text'
             name='name'
             data-testid='smoke-equipment-name'
             onChange={handleChange}
             onBlur={handleBlur}
-            className={classNames('form-control', { 'is-invalid': ShowError('name', touched, errors) })}
             value={values.name}
           />
-          <ErrorFor errors={errors} touched={touched} name='name' />
-        </div>
-        <div className='p-2 mr-auto'>
-          <label className='mr-2'>{i18next.t('outlet')}</label>
-          <select
+        </Field>
+        <Field label={i18next.t('outlet')} error={fieldError('outlet', touched, errors)}>
+          <Select
             name='outlet'
             data-testid='smoke-equipment-outlet'
             onChange={handleChange}
             onBlur={handleBlur}
-            className={classNames('form-control', { 'is-invalid': ShowError('outlet', touched, errors) })}
             value={values.outlet}
           >
-            <option value='' className='d-none'>-- {i18next.t('select')} --</option>
+            <option value=''>-- {i18next.t('select')} --</option>
             {outlets.slice().sort((a, b) => SortByName(a, b))
               .map((item) => {
                 return (
@@ -80,41 +97,35 @@ const EditEquipment = ({
                   </option>
                 )
               })}
-          </select>
-          <ErrorFor errors={errors} touched={touched} name='outlet' />
-        </div>
-        <div className='p-2 mr-auto'>
-          <label className='mr-2'>{i18next.t('stayoffonboot')}</label>
-          <input
+          </Select>
+        </Field>
+        <Field label={i18next.t('stayoffonboot')} error={fieldError('stay_off_on_boot', touched, errors)}>
+          <Input
             type='checkbox'
             name='stay_off_on_boot'
             checked={values.stay_off_on_boot}
             onChange={handleChange}
             onBlur={handleBlur}
-            className={classNames('form-control', { 'is-invalid': ShowError('stay_off_on_boot', touched, errors) })}
             value={values.stay_off_on_boot}
+            style={checkboxStyle}
           />
-          <ErrorFor errors={errors} touched={touched} name='stay_off_on_boot' />
-        </div>
-        <div className='p-2 mr-auto'>
-          <label className='mr-2'>{i18next.t('equipment:boot_delay')}</label>
-          <input
+        </Field>
+        <Field label={i18next.t('equipment:boot_delay')} error={fieldError('boot_delay', touched, errors)}>
+          <Input
             type='number'
             min='0'
             name='boot_delay'
             value={values.boot_delay}
             onChange={handleChange}
             onBlur={handleBlur}
-            className={classNames('form-control', { 'is-invalid': ShowError('boot_delay', touched, errors) })}
           />
-          <ErrorFor errors={errors} touched={touched} name='boot_delay' />
+        </Field>
+        <div style={actionStyle}>
+          <Button type='submit' id='add_equipment' data-testid='smoke-equipment-submit' icon={<FaSave />}>
+            {actionLabel}
+          </Button>
+          {deleteAction()}
         </div>
-        <div className='p-2 mr-auto'>
-          <button type='submit' id='add_equipment' data-testid='smoke-equipment-submit'>
-            {FaSave()}
-          </button>
-        </div>
-        {deleteAction()}
       </div>
     </form>
   )

--- a/front-end/src/equipment/equipment.jsx
+++ b/front-end/src/equipment/equipment.jsx
@@ -3,6 +3,7 @@ import ViewEquipment from './view_equipment'
 import EquipmentForm from './equipment_form'
 import { confirm } from 'utils/confirm'
 import i18next from 'i18next'
+import { ListItem } from '../../design-system/ui_kits/reef-pi-app/primitives/List'
 
 export default class Equipment extends React.Component {
   constructor (props) {
@@ -68,11 +69,11 @@ export default class Equipment extends React.Component {
 
   render () {
     return (
-      <li className='list-group-item'>
+      <ListItem>
         {this.state.readOnly === true
           ? <ViewEquipment equipment={this.props.equipment} outletName={this.selectedOutlet().name} onEdit={this.handleToggleEdit} onDelete={this.handleDelete} onStateChange={this.handleUpdate} />
           : <EquipmentForm equipment={this.props.equipment} outlets={this.props.outlets} actionLabel={i18next.t('save')} onSubmit={this.handleSubmit} onUpdate={this.handleUpdate} onDelete={this.handleDelete} />}
-      </li>
+      </ListItem>
     )
   }
 }

--- a/front-end/src/equipment/equipment.test.js
+++ b/front-end/src/equipment/equipment.test.js
@@ -2,6 +2,7 @@ import React, { act } from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import Equipment from './equipment'
+import { List } from '../../design-system/ui_kits/reef-pi-app/primitives/List'
 import ViewEquipment from './view_equipment'
 import EditEquipment from './edit_equipment'
 import EquipmentForm from './equipment_form'
@@ -71,7 +72,7 @@ describe('Equipment ui', () => {
 
     expect(props.fetch).toHaveBeenCalled()
     expect(props.fetchOutlets).toHaveBeenCalled()
-    expect(component.render().type).toBe('ul')
+    expect(component.render().type).toBe(List)
   })
 
   it('<Main /> toggles add form and creates equipment payloads', () => {
@@ -358,7 +359,7 @@ describe('Equipment ui', () => {
 
     expect(fetchEquipment).toHaveBeenCalled()
     const rendered = component.render()
-    expect(rendered.props.className).toBe('container')
+    expect(rendered.props.style).toBeTruthy()
     const chart = rendered.props.children[1].props.children
     expect(chart.props.data).toEqual([
       { id: '1', outlet: '1', name: 'Foo', on: true, onstate: 1, offstate: undefined },

--- a/front-end/src/equipment/main.jsx
+++ b/front-end/src/equipment/main.jsx
@@ -7,6 +7,9 @@ import EquipmentForm from './equipment_form'
 import { SORT_NAME_AZ, SORT_NAME_ZA, SORT_ON_FIRST, SORT_OFF_FIRST, sortEquipment } from './utils'
 import i18next from 'i18next'
 import EmptyState, { EquipmentIcon } from '../../design-system/ui_kits/reef-pi-app/shell/EmptyState'
+import Button from '../../design-system/ui_kits/reef-pi-app/primitives/Button'
+import { Field, Select } from '../../design-system/ui_kits/reef-pi-app/primitives/Form'
+import { List, ListItem } from '../../design-system/ui_kits/reef-pi-app/primitives/List'
 
 const sortOptions = [
   { value: SORT_NAME_AZ, label: 'equipment:sort_name_az' },
@@ -14,6 +17,21 @@ const sortOptions = [
   { value: SORT_ON_FIRST, label: 'equipment:sort_on_first' },
   { value: SORT_OFF_FIRST, label: 'equipment:sort_off_first' }
 ]
+
+const sortRowStyle = {
+  alignItems: 'end',
+  display: 'grid',
+  gap: 'var(--reefpi-space-sm)',
+  gridTemplateColumns: 'minmax(12rem, 18rem)',
+  justifyContent: 'start'
+}
+
+const addRowStyle = {
+  alignItems: 'start',
+  display: 'grid',
+  gap: 'var(--reefpi-space-sm)',
+  justifyItems: 'start'
+}
 
 export class RawEquipmentMain extends React.Component {
   constructor (props) {
@@ -58,7 +76,7 @@ export class RawEquipmentMain extends React.Component {
     const sorted = sortEquipment(this.props.equipment, this.state.sortMode)
     const newEquipmentForm = this.state.addEquipment
       ? <EquipmentForm outlets={this.props.outlets} actionLabel={i18next.t('add')} onSubmit={this.handleAddEquipment} />
-      : <div />
+      : null
 
     if (sorted.length === 0 && !this.state.addEquipment) {
       return (
@@ -72,26 +90,17 @@ export class RawEquipmentMain extends React.Component {
     }
 
     return (
-      <ul className='list-group list-group-flush'>
-        <li className='list-group-item'>
-          <div className='row align-items-center'>
-            <div className='col-auto'>
-              <label htmlFor='equipment-sort' className='col-form-label'>{i18next.t('equipment:sort')}</label>
-            </div>
-            <div className='col-auto'>
-              <select
-                id='equipment-sort'
-                className='form-control form-control-sm'
-                value={this.state.sortMode}
-                onChange={this.handleSortChange}
-              >
-                {sortOptions.map(option => (
-                  <option key={option.value} value={option.value}>{i18next.t(option.label)}</option>
-                ))}
-              </select>
-            </div>
-          </div>
-        </li>
+      <List density='roomy'>
+        <ListItem style={sortRowStyle}>
+          <Field id='equipment-sort' label={i18next.t('equipment:sort')}>
+            <Select
+              id='equipment-sort'
+              value={this.state.sortMode}
+              onChange={this.handleSortChange}
+              options={sortOptions.map(option => ({ value: option.value, label: i18next.t(option.label) }))}
+            />
+          </Field>
+        </ListItem>
         {sorted.map(item => {
           return (
             <Equipment
@@ -103,22 +112,21 @@ export class RawEquipmentMain extends React.Component {
             />
           )
         })}
-        <li className='list-group-item add-equipment'>
-          <div className='row'>
-            <div className='col'>
-              <input
-                id='add_equipment'
-                data-testid='smoke-equipment-add-toggle'
-                type='button'
-                value={this.state.addEquipment ? '-' : '+'}
-                onClick={this.handleToggleAddEquipmentDiv}
-                className='btn btn-outline-success'
-              />
-            </div>
-          </div>
+        <ListItem style={addRowStyle}>
+          <Button
+            id='add_equipment'
+            data-testid='smoke-equipment-add-toggle'
+            type='button'
+            variant='secondary'
+            onClick={this.handleToggleAddEquipmentDiv}
+            aria-expanded={this.state.addEquipment}
+            aria-label={this.state.addEquipment ? i18next.t('close') : i18next.t('equipment:add', 'Add equipment')}
+          >
+            {this.state.addEquipment ? '-' : '+'}
+          </Button>
           {newEquipmentForm}
-        </li>
-      </ul>
+        </ListItem>
+      </List>
     )
   }
 }

--- a/front-end/src/equipment/view_equipment.jsx
+++ b/front-end/src/equipment/view_equipment.jsx
@@ -1,8 +1,35 @@
 import React, { useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { FaEdit, FaTrashAlt } from 'react-icons/fa'
+import Button from '../../design-system/ui_kits/reef-pi-app/primitives/Button'
 import ToggleSwitch from '../../design-system/ui_kits/reef-pi-app/primitives/ToggleSwitch'
 import { useEquipmentToggle } from '../../design-system/ui_kits/reef-pi-app/hooks/useEquipmentToggle'
+
+const rowStyle = {
+  alignItems: 'center',
+  display: 'grid',
+  gap: 'var(--reefpi-space-sm)',
+  gridTemplateColumns: 'minmax(0, 1fr) auto auto',
+  width: '100%'
+}
+
+const nameStyle = {
+  display: 'grid',
+  gap: 'var(--reefpi-space-xxs)',
+  minWidth: 0
+}
+
+const outletStyle = {
+  color: 'var(--reefpi-color-text-muted)',
+  fontSize: '0.8125rem',
+  fontStyle: 'italic'
+}
+
+const actionStyle = {
+  alignItems: 'center',
+  display: 'inline-flex',
+  gap: 'var(--reefpi-space-xs)'
+}
 
 function PendingToggle ({ equipment, onStateChange }) {
   const send = useCallback(next => {
@@ -42,23 +69,15 @@ function PendingToggle ({ equipment, onStateChange }) {
 
 const ViewEquipment = ({ equipment, outletName, onStateChange, onDelete, onEdit }) => {
   return (
-    <div className='d-flex'>
-      <div className='p-2'>
-        {equipment.name}
+    <div style={rowStyle}>
+      <div style={nameStyle}>
+        <span>{equipment.name}</span>
+        <small style={outletStyle}>{outletName}</small>
       </div>
-      <div className='p-2 mr-auto font-italic'>
-        <small>{outletName}</small>
-      </div>
-      <div className='p-2'>
-        <PendingToggle equipment={equipment} onStateChange={onStateChange} />
-      </div>
-      <div className='p2'>
-        <div className='d-inline p-2' onClick={onEdit}>
-          {FaEdit()}
-        </div>
-        <div className='d-inline p-2' onClick={onDelete}>
-          {FaTrashAlt()}
-        </div>
+      <PendingToggle equipment={equipment} onStateChange={onStateChange} />
+      <div style={actionStyle}>
+        <Button type='button' variant='ghost' icon={<FaEdit />} iconOnly aria-label='Edit equipment' data-testid='equipment-edit' onClick={onEdit} />
+        <Button type='button' variant='ghost' icon={<FaTrashAlt />} iconOnly aria-label='Delete equipment' data-testid='equipment-delete' onClick={onDelete} />
       </div>
     </div>
   )

--- a/front-end/src/equipment/view_equipment.test.js
+++ b/front-end/src/equipment/view_equipment.test.js
@@ -50,9 +50,8 @@ describe('<ViewEquipment />', () => {
     expect(container.textContent).toContain('Return Pump')
     expect(container.textContent).toContain('Outlet 1')
 
-    const actionButtons = container.querySelectorAll('.d-inline')
-    act(() => actionButtons[0].click())
-    act(() => actionButtons[1].click())
+    act(() => container.querySelector('[data-testid="equipment-edit"]').click())
+    act(() => container.querySelector('[data-testid="equipment-delete"]').click())
     expect(onEdit).toHaveBeenCalled()
     expect(onDelete).toHaveBeenCalled()
 


### PR DESCRIPTION
## Summary
- migrates the Equipment route and dashboard equipment widgets off Bootstrap list/form/button/grid utility classes
- uses reef-pi Button, Field/Input/Select, List/ListItem primitives with tokenized plain CSS layout
- ticks the equipment route in the Bootstrap exit checklist

## Bootstrap proof
```
rtk rg -n "className=['\"][^'\"]*(btn|form-control|form-group|form-label|input-group|custom-switch|custom-control|list-group|container-fluid|row|col-|d-flex|justify-content|align-items|m[tblrxy]?-[0-5]|p[tblrxy]?-[0-5]|text-(center|left|right|muted)|dropdown|modal|nav-tabs|tab-pane|collapse)" front-end/src/equipment
# no matches
```

## Verification
- rtk ./node_modules/.bin/standard front-end/src/equipment/main.jsx front-end/src/equipment/equipment.jsx front-end/src/equipment/view_equipment.jsx front-end/src/equipment/edit_equipment.jsx front-end/src/equipment/ctrl_panel.jsx front-end/src/equipment/chart.jsx
- rtk yarn jest front-end/src/equipment/equipment.test.js front-end/src/equipment/view_equipment.test.js front-end/src/equipment/ctrl_panel.test.js front-end/src/equipment/chart.test.js --runInBand
- rtk yarn run bootstrap-class-check
- rtk git diff --check

Fixes #3120