### PR TITLE
[claude design] flip dashboard_v2 ON — enable DashboardV2 for all users

### DIFF
--- a/front-end/assets/home.html
+++ b/front-end/assets/home.html
@@ -11,6 +11,6 @@
   </head>
   <body>
     <div id="main-panel"></div>
-    <script>window.FEATURE_FLAGS = Object.assign({ pending_states: true, alert_center: true, dashboard_v2: false, new_shell: true }, window.FEATURE_FLAGS);</script>
+    <script>window.FEATURE_FLAGS = Object.assign({ pending_states: true, alert_center: true, dashboard_v2: true, new_shell: true }, window.FEATURE_FLAGS);</script>
   </body>
 </html>

--- a/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js
+++ b/front-end/design-system/ui_kits/reef-pi-app/dashboard/DashboardV2.test.js
@@ -67,12 +67,12 @@ function dataAlert (container, testId) {
 }
 
 describe('dashboard_v2 feature flag wiring', () => {
-  it('keeps dashboard_v2 disabled in the shipped server-rendered feature config', () => {
+  it('has dashboard_v2 enabled in the shipped server-rendered feature config', () => {
     const html = fs.readFileSync(path.join(repoRoot, 'front-end/assets/home.html'), 'utf8')
 
     expect(html).toContain('window.FEATURE_FLAGS')
-    expect(html).toContain('dashboard_v2: false')
-    expect(html).not.toContain('dashboard_v2: true')
+    expect(html).toContain('dashboard_v2: true')
+    expect(html).not.toContain('dashboard_v2: false')
   })
 
   it('exposes dashboard_v2 in the design-system Tweaks object and mirrors it to window.FEATURE_FLAGS', () => {


### PR DESCRIPTION
## Summary

- Flips `dashboard_v2: false` → `dashboard_v2: true` in `front-end/assets/home.html`
- All other flags (`pending_states`, `alert_center`, `new_shell`) were already `true`
- Updates the flag-guard test to assert the new expected value

## What this enables

The E3 Dashboard v2 tiles ship to all users:
- System status strip (health pill + uptime + alert count)
- Hero TemperatureTile (2-col, threshold band)
- Secondary PhTile / AtoTile with RangeSelector
- Equipment strip (horizontal layout)

## Test Plan

- [x] All 1190 Jest tests passing locally
- [x] `dashboard_v2: true` present in `home.html`
- [x] DashboardV2 flag-guard test updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)